### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "polymarket_client_sdk_v2"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "polymarket_client_sdk_v2"
 description = "Polymarket CLOB (Central Limit Order Book) API client SDK"
-version = "0.4.4"
+version = "0.5.0"
 authors = [
     "Polymarket Engineering <engineering@polymarket.com>",
     "Chaz Byrnes <chaz@polymarket.com>",

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Add the crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-polymarket_client_sdk_v2 = "0.4"
+polymarket_client_sdk_v2 = "0.5"
 ```
 
 or
@@ -83,7 +83,7 @@ Enable features in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-polymarket_client_sdk_v2 = { version = "0.3", features = ["ws", "data"] }
+polymarket_client_sdk_v2 = { version = "0.5", features = ["ws", "data"] }
 ```
 
 ## Re-exported Types
@@ -226,7 +226,7 @@ The **signature_type** parameter tells the system how to verify your signatures:
 - `signature_type=2`: Browser wallet proxy signatures (when using a proxy contract, not direct wallet connections)
 - `signature_type=3`: EIP-1271 smart contract wallet signatures (**V2 orders only**)
 
-See [SignatureType](src/clob/types/mod.rs#L182) for more information.
+See [`SignatureType`](src/clob/types/mod.rs) for more information.
 
 ##### Place a market order
 
@@ -303,38 +303,54 @@ async fn main() -> anyhow::Result<()> {
 }
 ```
 
-##### V1 and V2 Orders
+##### V1 and V2 protocols
 
-The SDK supports both V1 (legacy) and V2 exchange contracts. **V2 is the default.** V2 orders add `timestamp`,
-`metadata`, and `builder` fields, and remove the V1-only `taker`, `nonce`, and `feeRateBps` fields. The EIP-712
-domain version is `"2"` for V2 orders.
+The SDK supports both V1 (legacy) and V2 exchange contracts. Protocol is **auto-detected** on
+the first order build via `GET /version` and cached for the lifetime of the `Client`. You pick
+the protocol by pointing the client at the corresponding host:
+
+| Protocol | Host                              | Collateral   | EIP-712 domain version |
+|----------|-----------------------------------|--------------|------------------------|
+| V2       | `https://clob-v2.polymarket.com` | pUSD         | `"2"`                  |
+| V1       | `https://clob.polymarket.com`     | USDC.e       | `"1"`                  |
+
+V2 orders add `timestamp`, `metadata`, and `builder` fields. V1 orders use `taker`, `nonce`,
+and `feeRateBps` instead. The order builder exposes both sets of fields — the ones that don't
+apply to the detected protocol are silently ignored at build time, so you can write one
+code-path that works against either server.
+
+V2-specific builder fields (ignored when the server runs V1):
 
 ```rust,ignore
-use alloy::primitives::B256;
-use polymarket_client_sdk_v2::clob::types::OrderVersion;
+use polymarket_client_sdk_v2::types::B256;
 
-// V2 order (default) — with metadata and builder attribution
 let order = client
     .limit_order()
     .token_id("<token-id>")
     .size(Decimal::ONE_HUNDRED)
     .price(dec!(0.5))
     .side(Side::Buy)
-    .metadata(B256::ZERO)           // optional: 32 bytes of custom metadata
-    .builder_code(B256::ZERO)       // optional: builder fee attribution
-    .defer_exec(false)              // optional: defer execution
+    .metadata(B256::ZERO)           // 32 bytes of custom metadata
+    .builder_code(B256::ZERO)       // builder fee attribution
+    .defer_exec(false)              // defer execution
     .build()
     .await?;
+```
 
-// V1 order (legacy) — explicitly opt in
+V1-specific builder fields (ignored when the server runs V2):
+
+```rust,ignore
+use polymarket_client_sdk_v2::types::Address;
+
 let order = client
     .limit_order()
-    .version(OrderVersion::V1)
     .token_id("<token-id>")
     .size(Decimal::ONE_HUNDRED)
     .price(dec!(0.5))
     .side(Side::Buy)
-    .nonce(0)                        // V1-only field
+    .taker(Address::ZERO)           // explicit taker; default zero = public order
+    .nonce(0)                       // on-chain cancel nonce; default 0
+    .fee_rate_bps(0)                // must match the market rate when set
     .build()
     .await?;
 ```
@@ -383,26 +399,31 @@ async fn main() -> anyhow::Result<()> {
 Real-time orderbook and user event streaming. Requires the `ws` feature.
 
 ```toml
-polymarket_client_sdk_v2 = { version = "0.3", features = ["ws"] }
+polymarket_client_sdk_v2 = { version = "0.5", features = ["ws"] }
 ```
 
 ```rust,ignore
+use std::str::FromStr as _;
+
 use futures::StreamExt as _;
 use polymarket_client_sdk_v2::clob::ws::Client;
+use polymarket_client_sdk_v2::types::U256;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let client = Client::default();
 
-    // Subscribe to orderbook updates for specific assets
-    let asset_ids = vec!["<asset-id>".to_owned()];
+    // Subscribe to orderbook updates for specific assets.
+    let asset_ids = vec![U256::from_str("<asset-id>")?];
     let stream = client.subscribe_orderbook(asset_ids)?;
     let mut stream = Box::pin(stream);
 
     while let Some(book_result) = stream.next().await {
         let book = book_result?;
-        println!("Orderbook update for {}: {} bids, {} asks",
-            book.asset_id, book.bids.len(), book.asks.len());
+        println!(
+            "Orderbook update for {}: {} bids, {} asks",
+            book.asset_id, book.bids.len(), book.asks.len()
+        );
     }
     Ok(())
 }

--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -38,13 +38,13 @@ use crate::clob::types::response::{
     ApiKeysResponse, BalanceAllowanceResponse, BanStatusResponse, BuilderApiKeyResponse,
     BuilderFeeRateResponse, BuilderTradeResponse, CancelOrdersResponse, ClobMarketInfoResponse,
     CurrentRewardResponse, FeeInfo, FeeRateResponse, GeoblockResponse, HeartbeatResponse,
-    LastTradePriceResponse, LastTradesPricesResponse, MarketResponse, MarketRewardResponse,
-    MidpointResponse, MidpointsResponse, NegRiskResponse, NotificationResponse, OpenOrderResponse,
-    OrderBookSummaryResponse, OrderScoringResponse, OrdersScoringResponse, Page, PostOrderResponse,
-    PriceHistoryResponse, PriceResponse, PricesResponse, ReadonlyApiKeyResponse,
-    RewardsPercentagesResponse, SimplifiedMarketResponse, SpreadResponse, SpreadsResponse,
-    TickSizeResponse, TotalUserEarningResponse, TradeResponse, UserEarningResponse,
-    UserRewardsEarningResponse,
+    LastTradePriceResponse, LastTradesPricesResponse, MarketByTokenResponse, MarketResponse,
+    MarketRewardResponse, MidpointResponse, MidpointsResponse, NegRiskResponse,
+    NotificationResponse, OpenOrderResponse, OrderBookSummaryResponse, OrderScoringResponse,
+    OrdersScoringResponse, Page, PostOrderResponse, PriceHistoryResponse, PriceResponse,
+    PricesResponse, ReadonlyApiKeyResponse, RewardsPercentagesResponse, SimplifiedMarketResponse,
+    SpreadResponse, SpreadsResponse, TickSizeResponse, TotalUserEarningResponse, TradeResponse,
+    UserEarningResponse, UserRewardsEarningResponse,
 };
 #[cfg(feature = "rfq")]
 use crate::clob::types::{
@@ -744,23 +744,6 @@ impl<S: State> Client<S> {
         crate::request(&self.inner.client, request, None).await
     }
 
-    /// Retrieves prices for all available market outcome tokens.
-    ///
-    /// Returns the current best bid and ask prices for every active token
-    /// in the system. This is useful for getting a complete market overview.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the request fails.
-    pub async fn all_prices(&self) -> Result<PricesResponse> {
-        let request = self
-            .client()
-            .request(Method::GET, format!("{}prices", self.host()))
-            .build()?;
-
-        crate::request(&self.inner.client, request, None).await
-    }
-
     /// Retrieves historical price data for a market outcome token.
     ///
     /// Returns time-series price data over a specified time range or interval.
@@ -1322,11 +1305,10 @@ impl<S: State> Client<S> {
             *cid
         } else {
             let market = self.market_by_token(token_id).await?;
-            let cid = market.condition_id.ok_or_else(|| {
-                Error::validation(format!("market for token {token_id} has no condition_id"))
-            })?;
-            self.inner.token_condition_map.insert(token_id, cid);
-            cid
+            self.inner
+                .token_condition_map
+                .insert(token_id, market.condition_id);
+            market.condition_id
         };
         self.clob_market_info(&condition_id.to_string()).await?;
         Ok(())
@@ -1352,7 +1334,7 @@ impl<S: State> Client<S> {
     /// # Errors
     ///
     /// Returns an error if the request fails or the token ID is invalid.
-    pub async fn market_by_token(&self, token_id: U256) -> Result<MarketResponse> {
+    pub async fn market_by_token(&self, token_id: U256) -> Result<MarketByTokenResponse> {
         let request = self
             .client()
             .request(
@@ -2173,7 +2155,7 @@ impl<K: Kind> Client<Authenticated<K>> {
         &self,
         request: &UserRewardsEarningRequest,
         next_cursor: Option<String>,
-    ) -> Result<Vec<UserRewardsEarningResponse>> {
+    ) -> Result<Page<UserRewardsEarningResponse>> {
         let params = request.query_params(next_cursor.as_deref());
         let request = self
             .client()

--- a/src/clob/types/response.rs
+++ b/src/clob/types/response.rs
@@ -9,8 +9,8 @@ use bon::Builder;
 use chrono::{DateTime, NaiveDate, Utc};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::{
-    DefaultOnError, DefaultOnNull, NoneAsEmptyString, TimestampMilliSeconds, TimestampSeconds,
-    TryFromInto, serde_as,
+    DefaultOnError, DefaultOnNull, DisplayFromStr, NoneAsEmptyString, TimestampMilliSeconds,
+    TimestampSeconds, TryFromInto, serde_as,
 };
 use sha2::{Digest as _, Sha256};
 use uuid::Uuid;
@@ -170,6 +170,21 @@ pub struct LastTradesPricesResponse {
     pub token_id: U256,
     pub price: Decimal,
     pub side: Side,
+}
+
+/// Response from `GET /markets-by-token/{token_id}`. This endpoint returns a minimal
+/// market descriptor — just the condition ID and the two outcome token IDs — not a full
+/// [`MarketResponse`]. Used to resolve `token_id -> condition_id` before fetching the
+/// full clob-market info.
+#[non_exhaustive]
+#[serde_as]
+#[derive(Debug, Clone, Deserialize, Builder, PartialEq)]
+pub struct MarketByTokenResponse {
+    pub condition_id: B256,
+    #[serde_as(as = "DisplayFromStr")]
+    pub primary_token_id: U256,
+    #[serde_as(as = "DisplayFromStr")]
+    pub secondary_token_id: U256,
 }
 
 #[expect(

--- a/tests/clob.rs
+++ b/tests/clob.rs
@@ -212,33 +212,6 @@ mod unauthenticated {
     }
 
     #[tokio::test]
-    async fn all_prices_should_succeed() -> anyhow::Result<()> {
-        let server = MockServer::start();
-        let client = Client::new(&server.base_url(), Config::default())?;
-
-        let mock = server.mock(|when, then| {
-            when.method(httpmock::Method::GET).path("/prices");
-            then.status(StatusCode::OK)
-                .json_body(json!({ token_1().to_string(): { "BUY": 0.5, "SELL": 0.6 } }));
-        });
-
-        let response = client.all_prices().await?;
-
-        let mut price_map = HashMap::new();
-        let mut side_map = HashMap::new();
-        side_map.insert(Side::Buy, dec!(0.5));
-        side_map.insert(Side::Sell, dec!(0.6));
-        price_map.insert(token_1(), side_map);
-
-        let expected = PricesResponse::builder().prices(price_map).build();
-
-        assert_eq!(response, expected);
-        mock.assert();
-
-        Ok(())
-    }
-
-    #[tokio::test]
     async fn price_history_with_interval_should_succeed() -> anyhow::Result<()> {
         let server = MockServer::start();
         let client = Client::new(&server.base_url(), Config::default())?;
@@ -2518,8 +2491,8 @@ mod authenticated {
                 .query_param("position", "")
                 .query_param("no_competition", "false")
                 .query_param("signature_type", (SignatureType::Eoa as u8).to_string());
-            then.status(StatusCode::OK).json_body(json!(
-                [
+            then.status(StatusCode::OK).json_body(json!({
+                "data": [
                     {
                         "condition_id": "0x0000000000000000000000000000000000000000000000000000000c00d00123",
                         "question": "Will BTC be above $50k on December 31, 2025?",
@@ -2574,8 +2547,11 @@ mod authenticated {
                             }
                         ]
                     }
-                ]
-            ));
+                ],
+                "next_cursor": "LTE=",
+                "limit": 500,
+                "count": 1
+            }));
         });
 
         let request = UserRewardsEarningRequest::builder()
@@ -2585,7 +2561,7 @@ mod authenticated {
             .user_earnings_and_markets_config(&request, None)
             .await?;
 
-        let expected = vec![
+        let expected_entries = vec![
             UserRewardsEarningResponse::builder()
                 .condition_id(b256!(
                     "0000000000000000000000000000000000000000000000000000000c00d00123"
@@ -2644,7 +2620,9 @@ mod authenticated {
                 .build(),
         ];
 
-        assert_eq!(response, expected);
+        assert_eq!(response.data, expected_entries);
+        assert_eq!(response.next_cursor, "LTE=");
+        assert_eq!(response.count, 1);
         mock.assert();
 
         Ok(())


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the public API surface (removes `all_prices`, changes return types for `market_by_token` and rewards pagination) which can break downstream consumers and subtly affect caching behavior.
> 
> **Overview**
> Bumps `polymarket_client_sdk_v2` to **v0.5.0** and updates README dependency snippets/examples accordingly.
> 
> Aligns CLOB client endpoints with current API behavior: removes `Client::all_prices()`, changes `market_by_token()` to return a new minimal `MarketByTokenResponse` (with proper token-id string deserialization), and updates `user_earnings_and_markets_config()` to return a paginated `Page<UserRewardsEarningResponse>` instead of a flat `Vec`.
> 
> Updates tests to match the new reward endpoint response envelope (`data` + `next_cursor`/`count`/`limit`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 672ea09a8676248d6a5ddea3efe45aa32a0be687. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->