### PR TITLE
chore(release): 0.5.1 - fix repository URL

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,10 +5,10 @@ for contributions and help you get set up.
 
 ## Steps to get started
 
-1. Fork `Polymarket/rs-clob-client`
+1. Fork `Polymarket/rs-clob-client-v2`
 1. Clone your fork
 1. Install [pre-commit](https://pre-commit.com/#intro)
-1. Open pull requests with the [wip](https://github.com/Polymarket/rs-clob-client/issues/labels?q=label%3Awip) label
+1. Open pull requests with the [wip](https://github.com/Polymarket/rs-clob-client-v2/issues/labels?q=label%3Awip) label
    against the `main` branch and include a description of the intended change in the PR description.
 
 Before removing the `wip` label and submitting a PR for review, make sure that:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "polymarket_client_sdk_v2"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "polymarket_client_sdk_v2"
 description = "Polymarket CLOB (Central Limit Order Book) API client SDK"
-version = "0.5.0"
+version = "0.5.1"
 authors = [
     "Polymarket Engineering <engineering@polymarket.com>",
     "Chaz Byrnes <chaz@polymarket.com>",
 ]
 readme = "README.md"
-repository = "https://github.com/polymarket/rs-clob-client"
+repository = "https://github.com/Polymarket/rs-clob-client-v2"
 license = "MIT"
 keywords = ["polymarket", "clob", "orderbook", "trading", "prediction-market"]
 categories = [

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 # Polymarket Rust Client
 
 [![Crates.io](https://img.shields.io/crates/v/polymarket_client_sdk_v2.svg)](https://crates.io/crates/polymarket_client_sdk_v2)
-[![CI](https://github.com/Polymarket/rs-clob-client/actions/workflows/ci.yml/badge.svg)](https://github.com/Polymarket/rs-clob-client/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/Polymarket/rs-clob-client/graph/badge.svg?token=FW1BYWWFJ2)](https://codecov.io/gh/Polymarket/rs-clob-client)
+[![CI](https://github.com/Polymarket/rs-clob-client-v2/actions/workflows/ci.yml/badge.svg)](https://github.com/Polymarket/rs-clob-client-v2/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/Polymarket/rs-clob-client-v2/graph/badge.svg?token=FW1BYWWFJ2)](https://codecov.io/gh/Polymarket/rs-clob-client-v2)
 
 An ergonomic Rust client for interacting with Polymarket services, primarily the Central Limit Order Book (CLOB).
 This crate provides strongly typed request builders, authenticated endpoints, `alloy` support and more.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: metadata and documentation URL updates plus a patch version bump, with no runtime logic changes.
> 
> **Overview**
> Releases `0.5.1` by bumping the crate version in `Cargo.toml`/`Cargo.lock`.
> 
> Updates the `repository` URL and documentation links/badges (`README.md`, `.github/CONTRIBUTING.md`) to point to `Polymarket/rs-clob-client-v2` instead of the old repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a07285c1655ccb7f2f4b5c1dd092ac2586ab1b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->