### PR TITLE
ci: fix release-plz action path after repo rename

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -27,6 +27,6 @@ jobs:
           toolchain: '1.88'
 
       - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128
+        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes only the GitHub Actions `uses` reference while keeping the action version pin unchanged.
> 
> **Overview**
> Fixes the `Release-plz` workflow by switching the `uses` target from `MarcoIeni/release-plz-action` to the renamed `release-plz/action`, keeping the same pinned commit (`v0.5.128`) so releases continue to run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 181f1951bfc30fa965b7d66745d3a6224f7581b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->