### PR TITLE
chore: release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/Polymarket/rs-clob-client-v2/compare/v0.5.1...v0.5.2) - 2026-04-24
+
+### Other
+
+- fix release-plz action path after repo rename
+
 ## [0.4.4](https://github.com/Polymarket/rs-clob-client/compare/v0.4.3...v0.4.4) - 2026-03-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "polymarket_client_sdk_v2"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "polymarket_client_sdk_v2"
 description = "Polymarket CLOB (Central Limit Order Book) API client SDK"
-version = "0.5.1"
+version = "0.5.2"
 authors = [
     "Polymarket Engineering <engineering@polymarket.com>",
     "Chaz Byrnes <chaz@polymarket.com>",


### PR DESCRIPTION



## 🤖 New release

* `polymarket_client_sdk_v2`: 0.5.1 -> 0.5.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.2](https://github.com/Polymarket/rs-clob-client-v2/compare/v0.5.1...v0.5.2) - 2026-04-24

### Other

- fix release-plz action path after repo rename
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a version/changelog-only release bump with no functional code changes, aside from updating release metadata.
> 
> **Overview**
> Bumps the crate version from `0.5.1` to `0.5.2` in `Cargo.toml` and `Cargo.lock`.
> 
> Updates `CHANGELOG.md` with the `v0.5.2` release entry noting a fix to the release-plz GitHub Action path after the repo rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c05c010a7c4ea4b2deeec371943a059524e8a12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->