### PR TITLE
fix(clob): add `side` field to `MakerOrder` struct

### DIFF
--- a/src/clob/ws/types/response.rs
+++ b/src/clob/ws/types/response.rs
@@ -297,6 +297,8 @@ pub struct MakerOrder {
     pub owner: ApiKey,
     /// Price of maker order
     pub price: Decimal,
+    /// Side of maker order
+    pub side: Side,
 }
 
 #[non_exhaustive]

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -222,7 +222,8 @@ pub mod payloads {
                     "order_id": "0xff354cd7ca7539dfa9c28d90943ab5779a4eac34b9b37a757d7b32bdfb11790b",
                     "outcome": "YES",
                     "owner": "9180014b-33c8-9240-a14b-bdca11c0a465",
-                    "price": "0.57"
+                    "price": "0.57",
+                    "side": "BUY"
                 }
             ],
             "market": MARKET_STR,


### PR DESCRIPTION
Each trade event contains a list of maker orders. These orders can have different `side` values (BUY/SELL) that aren't just the opposite of the taker order.

The maker orders in the websocket event have a `side` field, but it's been missed in the clob client so it's not deserialized.

If using trade events to calculate changes in your own positions, it's helpful to be able to tell whether your maker order in the trade event was a BUY or SELL order. 

Fixed by adding the field to the `MakerOrder` struct

---

Been using this fix in the v1 sdk for a while now with no issues. I'm assuming it will be the same for the v2 client. Forgot to ever open a PR in the old repo because it's such a tiny fix.

By this point I must have deserialised tens of thousands of trade events, and never had any errors (or `Side::Unknown(_)` variants).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a missing `side` field to WebSocket trade maker-order deserialization and updates the corresponding test fixture; no behavior changes beyond exposing additional parsed data.
> 
> **Overview**
> Trade WebSocket parsing now includes the maker order’s `side` by adding a `side: Side` field to `MakerOrder` in `src/clob/ws/types/response.rs`.
> 
> The WebSocket integration test payload in `tests/websocket.rs` is updated to include `"side": "BUY"` in `maker_orders`, ensuring deserialization coverage for the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 184372ca7b91c1355f5de7100e7f9c32d63fcd4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->