### PR TITLE
fix: stop filtering NewMarket/MarketResolved WS events by subscribed assets

### DIFF
--- a/src/clob/ws/subscription.rs
+++ b/src/clob/ws/subscription.rs
@@ -300,12 +300,7 @@ impl SubscriptionManager {
                             WsMessage::LastTradePrice(ltp) => asset_ids_set.contains(&ltp.asset_id),
                             WsMessage::TickSizeChange(tsc) => asset_ids_set.contains(&tsc.asset_id),
                             WsMessage::BestBidAsk(bba) => asset_ids_set.contains(&bba.asset_id),
-                            WsMessage::NewMarket(nm) => {
-                                nm.asset_ids.iter().any(|id| asset_ids_set.contains(id))
-                            },
-                            WsMessage::MarketResolved(mr) => {
-                                mr.asset_ids.iter().any(|id| asset_ids_set.contains(id))
-                            },
+                            WsMessage::NewMarket(_) | WsMessage::MarketResolved(_) => true,
                             _ => false,
                         };
 

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -1498,7 +1498,7 @@ mod custom_features {
     }
 
     #[tokio::test]
-    async fn subscribe_new_markets_receives_updates() {
+    async fn subscribe_new_markets_receives_updates_for_unsubscribed_assets() {
         let mut server = MockWsServer::start().await;
         let endpoint = server.ws_url("/ws/market");
 
@@ -1513,8 +1513,10 @@ mod custom_features {
         let sub_request = server.recv_subscription().await.unwrap();
         assert!(sub_request.contains("\"custom_feature_enabled\":true"));
 
-        // Send new_market message
-        server.send(&new_market().to_string());
+        // Lifecycle announcements are global, not scoped to subscribed assets.
+        let mut message = new_market();
+        message["assets_ids"] = serde_json::json!([payloads::OTHER_ASSET_ID_STR]);
+        server.send(&message.to_string());
 
         let result = timeout(Duration::from_secs(2), stream.next()).await;
         let nm = result.unwrap().unwrap().unwrap();
@@ -1523,12 +1525,12 @@ mod custom_features {
         assert_eq!(nm.question, "Will it rain tomorrow?");
         assert_eq!(nm.market, payloads::MARKET);
         assert_eq!(nm.slug, "will-it-rain-tomorrow");
-        assert_eq!(nm.asset_ids, vec![payloads::asset_id()]);
+        assert_eq!(nm.asset_ids, vec![payloads::other_asset_id()]);
         assert_eq!(nm.outcomes, vec!["Yes", "No"]);
     }
 
     #[tokio::test]
-    async fn subscribe_market_resolutions_receives_updates() {
+    async fn subscribe_market_resolutions_receives_updates_for_unsubscribed_assets() {
         let mut server = MockWsServer::start().await;
         let endpoint = server.ws_url("/ws/market");
 
@@ -1543,8 +1545,10 @@ mod custom_features {
         let sub_request = server.recv_subscription().await.unwrap();
         assert!(sub_request.contains("\"custom_feature_enabled\":true"));
 
-        // Send market_resolved message
-        server.send(&market_resolved().to_string());
+        // Lifecycle announcements are global, not scoped to subscribed assets.
+        let mut message = market_resolved();
+        message["assets_ids"] = serde_json::json!([payloads::OTHER_ASSET_ID_STR]);
+        server.send(&message.to_string());
 
         let result = timeout(Duration::from_secs(2), stream.next()).await;
         let mr = result.unwrap().unwrap().unwrap();
@@ -1553,7 +1557,7 @@ mod custom_features {
         assert_eq!(mr.question, Some("Will it rain tomorrow?".to_owned()));
         assert_eq!(mr.market, payloads::MARKET);
         assert_eq!(mr.slug, Some("will-it-rain-tomorrow".to_owned()));
-        assert_eq!(mr.asset_ids, vec![payloads::asset_id()]);
+        assert_eq!(mr.asset_ids, vec![payloads::other_asset_id()]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
NewMarket and MarketResolved are broadcast events with new/different asset IDs that will never match the subscriber's asset_ids_set, causing them to be silently dropped. These events should always be yielded to consumers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted WebSocket client filtering fix with regression tests; behavior change only affects previously broken lifecycle streams.
> 
> **Overview**
> **`NewMarket` and `MarketResolved` WebSocket events are no longer dropped when their `asset_ids` do not overlap the subscriber’s asset list.** The market-channel stream filter now always yields these two message types, while book, price, and other per-asset events stay scoped to subscribed assets.
> 
> Previously, lifecycle announcements were gated on `asset_ids_set`, so new or resolved markets (whose IDs are not in the subscription) never reached consumers of `subscribe_new_markets` / `subscribe_market_resolutions`. Integration tests were updated to send lifecycle payloads for a different asset ID and assert they are still delivered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e476b9fd4b88c16aee391c65c30832b611aa26a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->