### PR TITLE
fix: use screaming snake case for activity types

### DIFF
--- a/src/data/types/mod.rs
+++ b/src/data/types/mod.rs
@@ -49,6 +49,8 @@ pub enum ActivityType {
     /// Yield
     Yield,
     /// Maker rebate (fee rebate for providing liquidity).
+    #[serde(rename = "MAKER_REBATE")]
+    #[strum(serialize = "MAKER_REBATE")]
     MakerRebate,
     /// Unknown activity type from the API (captures the raw value for debugging).
     #[serde(untagged)]

--- a/src/data/types/mod.rs
+++ b/src/data/types/mod.rs
@@ -30,8 +30,8 @@ pub enum Side {
 ///
 /// Activities represent various operations that users can perform on the Polymarket protocol.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum_macros::Display)]
-#[serde(rename_all = "UPPERCASE")]
-#[strum(serialize_all = "UPPERCASE")]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 #[non_exhaustive]
 pub enum ActivityType {
     /// A trade (buy or sell) of outcome tokens.
@@ -49,8 +49,6 @@ pub enum ActivityType {
     /// Yield
     Yield,
     /// Maker rebate (fee rebate for providing liquidity).
-    #[serde(rename = "MAKER_REBATE")]
-    #[strum(serialize = "MAKER_REBATE")]
     MakerRebate,
     /// Unknown activity type from the API (captures the raw value for debugging).
     #[serde(untagged)]

--- a/tests/data.rs
+++ b/tests/data.rs
@@ -1196,6 +1196,23 @@ mod types {
         assert_eq!(ActivityType::Redeem.to_string(), "REDEEM");
         assert_eq!(ActivityType::Reward.to_string(), "REWARD");
         assert_eq!(ActivityType::Conversion.to_string(), "CONVERSION");
+        assert_eq!(ActivityType::MakerRebate.to_string(), "MAKER_REBATE");
+        assert_eq!(
+            serde_json::from_str::<ActivityType>("\"MAKER_REBATE\"").unwrap(),
+            ActivityType::MakerRebate
+        );
+        assert_eq!(
+            serde_json::to_string(&ActivityType::MakerRebate).unwrap(),
+            "\"MAKER_REBATE\""
+        );
+        assert_eq!(
+            serde_json::from_str::<ActivityType>("\"TRADE\"").unwrap(),
+            ActivityType::Trade
+        );
+        assert_eq!(
+            serde_json::to_string(&ActivityType::Trade).unwrap(),
+            "\"TRADE\""
+        );
     }
 
     #[test]


### PR DESCRIPTION
MakerRebate was deserializing to Unknown("MAKER_REBATE") because rename_all = "UPPERCASE" produces "MAKERREBATE" not "MAKER_REBATE". Added explicit serde/strum rename attributes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow enum serialization fix aligned with the API; single-word activity types are unchanged on the wire.
> 
> **Overview**
> Fixes **`ActivityType`** JSON/query serialization so values match the data API. **`MakerRebate`** was falling through to **`Unknown("MAKER_REBATE")`** because **`rename_all = "UPPERCASE"`** emitted **`MAKERREBATE`** (no underscore).
> 
> **`ActivityType`** now uses **`SCREAMING_SNAKE_CASE`** for both **serde** and **strum**, so wire values like **`MAKER_REBATE`** map to the proper variant while single-word types (e.g. **`TRADE`**) stay the same. Tests cover **`MakerRebate`** display and serde round-trips for **`MAKER_REBATE`** and **`TRADE`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bb340db87d4c64ebb9fd35df16a6018ecf61f61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->