### PR TITLE
hey team, fixed sign chain id panic, empty-body http ok on errors, and silent query string failure

### DIFF
--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -681,7 +681,7 @@ impl<S: State> Client<S> {
     ///
     /// Returns an error if the request fails or the token ID is invalid.
     pub async fn midpoint(&self, request: &MidpointRequest) -> Result<MidpointResponse> {
-        let params = request.query_params(None);
+        let params = request.query_params(None)?;
         let request = self
             .client()
             .request(Method::GET, format!("{}midpoint{params}", self.host()))
@@ -717,7 +717,7 @@ impl<S: State> Client<S> {
     ///
     /// Returns an error if the request fails or the token ID is invalid.
     pub async fn price(&self, request: &PriceRequest) -> Result<PriceResponse> {
-        let params = request.query_params(None);
+        let params = request.query_params(None)?;
         let request = self
             .client()
             .request(Method::GET, format!("{}price{params}", self.host()))
@@ -756,7 +756,7 @@ impl<S: State> Client<S> {
         &self,
         request: &PriceHistoryRequest,
     ) -> Result<PriceHistoryResponse> {
-        let params = request.query_params(None);
+        let params = request.query_params(None)?;
         let req = self.client().request(
             Method::GET,
             format!("{}prices-history{params}", self.host()),
@@ -775,7 +775,7 @@ impl<S: State> Client<S> {
     ///
     /// Returns an error if the request fails or the token ID is invalid.
     pub async fn spread(&self, request: &SpreadRequest) -> Result<SpreadResponse> {
-        let params = request.query_params(None);
+        let params = request.query_params(None)?;
         let request = self
             .client()
             .request(Method::GET, format!("{}spread{params}", self.host()))
@@ -1017,7 +1017,7 @@ impl<S: State> Client<S> {
         &self,
         request: &OrderBookSummaryRequest,
     ) -> Result<OrderBookSummaryResponse> {
-        let params = request.query_params(None);
+        let params = request.query_params(None)?;
         let request = self
             .client()
             .request(Method::GET, format!("{}book{params}", self.host()))
@@ -1068,7 +1068,7 @@ impl<S: State> Client<S> {
         &self,
         request: &LastTradePriceRequest,
     ) -> Result<LastTradePriceResponse> {
-        let params = request.query_params(None);
+        let params = request.query_params(None)?;
         let request = self
             .client()
             .request(
@@ -1673,11 +1673,13 @@ impl<K: Kind> Client<Authenticated<K>> {
     /// The EIP-712 domain and verifying contract are selected from the order's version:
     /// V2 orders sign against `exchange_v2` with domain version `"2"`; V1 orders sign
     /// against the legacy `exchange` (or neg-risk variant) with domain version `"1"`.
-    #[expect(
-        clippy::missing_panics_doc,
-        reason = "No need to publicly document as we are guarded by the typestate pattern. \
-        We cannot call `sign` without first calling `authenticate`"
-    )]
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the signer's chain id is not set. Use
+    /// [`Signer::with_chain_id`](alloy::signers::Signer) (for example
+    /// `LocalSigner::from_str(...)?` then `.with_chain_id(Some(POLYGON))`) so EIP-712
+    /// signing uses the same chain as the CLOB and exchange contracts.
     pub async fn sign<S: Signer>(
         &self,
         signer: &S,
@@ -1688,9 +1690,11 @@ impl<K: Kind> Client<Authenticated<K>> {
             defer_exec,
         }: SignableOrder,
     ) -> Result<SignedOrder> {
-        let chain_id = signer
-            .chain_id()
-            .expect("Validated not none in `authenticate`");
+        let chain_id = signer.chain_id().ok_or_else(|| {
+            Error::validation(
+                "signer has no chain id; set it with with_chain_id before sign (e.g. LocalSigner::with_chain_id(Some(POLYGON)))",
+            )
+        })?;
 
         let token_id = match &payload {
             OrderPayload::V1(p) => p.order.tokenId,
@@ -1825,7 +1829,7 @@ impl<K: Kind> Client<Authenticated<K>> {
         request: &OrdersRequest,
         next_cursor: Option<String>,
     ) -> Result<Page<OpenOrderResponse>> {
-        let params = request.query_params(next_cursor.as_deref());
+        let params = request.query_params(next_cursor.as_deref())?;
         let request = self
             .client()
             .request(Method::GET, format!("{}data/orders{params}", self.host()))
@@ -1926,7 +1930,7 @@ impl<K: Kind> Client<Authenticated<K>> {
         request: &TradesRequest,
         next_cursor: Option<String>,
     ) -> Result<Page<TradeResponse>> {
-        let params = request.query_params(next_cursor.as_deref());
+        let params = request.query_params(next_cursor.as_deref())?;
         let request = self
             .client()
             .request(Method::GET, format!("{}data/trades{params}", self.host()))
@@ -1964,7 +1968,7 @@ impl<K: Kind> Client<Authenticated<K>> {
     ///
     /// Returns an error if the request fails or the notification IDs are invalid.
     pub async fn delete_notifications(&self, request: &DeleteNotificationsRequest) -> Result<()> {
-        let params = request.query_params(None);
+        let params = request.query_params(None)?;
         let mut request = self
             .client()
             .request(
@@ -1975,9 +1979,7 @@ impl<K: Kind> Client<Authenticated<K>> {
         let headers = self.create_headers(&request).await?;
         *request.headers_mut() = headers;
 
-        self.client().execute(request).await?;
-
-        Ok(())
+        crate::request_empty(self.client(), request).await
     }
 
     /// Retrieves the user's USDC balance and token allowances.
@@ -1997,7 +1999,7 @@ impl<K: Kind> Client<Authenticated<K>> {
             request.signature_type = Some(self.inner.signature_type);
         }
 
-        let params = request.query_params(None);
+        let params = request.query_params(None)?;
         let request = self
             .client()
             .request(
@@ -2027,7 +2029,7 @@ impl<K: Kind> Client<Authenticated<K>> {
             request.signature_type = Some(self.inner.signature_type);
         }
 
-        let params = request.query_params(None);
+        let params = request.query_params(None)?;
         let mut request = self
             .client()
             .request(
@@ -2041,9 +2043,7 @@ impl<K: Kind> Client<Authenticated<K>> {
 
         // We have to send the request separately from `self.request` because this endpoint does
         // not return anything in the response body. Otherwise, we would get an EOF error from reqwest
-        self.client().execute(request).await?;
-
-        Ok(())
+        crate::request_empty(self.client(), request).await
     }
 
     /// Checks if an order is eligible for market maker rewards.
@@ -2156,7 +2156,7 @@ impl<K: Kind> Client<Authenticated<K>> {
         request: &UserRewardsEarningRequest,
         next_cursor: Option<String>,
     ) -> Result<Page<UserRewardsEarningResponse>> {
-        let params = request.query_params(next_cursor.as_deref());
+        let params = request.query_params(next_cursor.as_deref())?;
         let request = self
             .client()
             .request(
@@ -2308,20 +2308,10 @@ impl<K: Kind> Client<Authenticated<K>> {
             )
             .json(&serde_json::json!({ "key": key }))
             .build()?;
-        let method = request.method().clone();
-        let path = request.url().path().to_owned();
         let headers = self.create_headers(&request).await?;
 
         request.headers_mut().extend(headers);
-        let response = self.inner.client.execute(request).await?;
-        let status = response.status();
-
-        if !status.is_success() {
-            let message = response.text().await.unwrap_or_default();
-            return Err(Error::status(status, method, path, message));
-        }
-
-        Ok(())
+        crate::request_empty(&self.inner.client, request).await
     }
 
     /// Gets pre-migration orders for the authenticated user.
@@ -2432,9 +2422,7 @@ impl<K: Kind> Client<Authenticated<K>> {
         *request.headers_mut() = headers;
 
         // The server returns no body; calling `crate::request` would EOF while decoding.
-        self.client().execute(request).await?;
-
-        Ok(())
+        crate::request_empty(self.client(), request).await
     }
 
     /// Returns trades attributed to `builder_code`.
@@ -2453,7 +2441,7 @@ impl<K: Kind> Client<Authenticated<K>> {
                 "builder_code is required and cannot be zero",
             ));
         }
-        let params = request.query_params(next_cursor.as_deref());
+        let params = request.query_params(next_cursor.as_deref())?;
         let sep = if params.is_empty() { '?' } else { '&' };
         let url = format!(
             "{}builder/trades{params}{sep}builder_code={builder_code}",
@@ -2643,7 +2631,7 @@ impl<K: Kind> Client<Authenticated<K>> {
         request: &RfqRequestsRequest,
         next_cursor: Option<&str>,
     ) -> Result<Page<RfqRequest>> {
-        let params = request.query_params(next_cursor);
+        let params = request.query_params(next_cursor)?;
         let http_request = self
             .client()
             .request(
@@ -2707,7 +2695,7 @@ impl<K: Kind> Client<Authenticated<K>> {
         request: &RfqQuotesRequest,
         next_cursor: Option<&str>,
     ) -> Result<Page<RfqQuote>> {
-        let params = request.query_params(next_cursor);
+        let params = request.query_params(next_cursor)?;
         let http_request = self
             .client()
             .request(

--- a/src/clob/types/request.rs
+++ b/src/clob/types/request.rs
@@ -439,11 +439,11 @@ mod tests {
             .build();
 
         assert_eq!(
-            request.query_params(None),
+            request.query_params(None).unwrap(),
             "?id=aa-bb&maker=0x0000000000000000000000000000000000000000&market=0x0000000000000000000000000000000000000000000000000000000000010000&asset_id=100"
         );
         assert_eq!(
-            request.query_params(Some("1")),
+            request.query_params(Some("1")).unwrap(),
             "?id=aa-bb&maker=0x0000000000000000000000000000000000000000&market=0x0000000000000000000000000000000000000000000000000000000000010000&asset_id=100&next_cursor=1"
         );
     }
@@ -458,11 +458,11 @@ mod tests {
             .build();
 
         assert_eq!(
-            request.query_params(None),
+            request.query_params(None).unwrap(),
             "?id=aa-bb&market=0x0000000000000000000000000000000000000000000000000000000000010000&asset_id=100"
         );
         assert_eq!(
-            request.query_params(Some("1")),
+            request.query_params(Some("1")).unwrap(),
             "?id=aa-bb&market=0x0000000000000000000000000000000000000000000000000000000000010000&asset_id=100&next_cursor=1"
         );
     }
@@ -474,8 +474,8 @@ mod tests {
             .notification_ids(vec!["1".to_owned(), "2".to_owned()])
             .build();
 
-        assert_eq!(empty_request.query_params(None), "");
-        assert_eq!(request.query_params(None), "?ids=1%2C2");
+        assert_eq!(empty_request.query_params(None).unwrap(), "");
+        assert_eq!(request.query_params(None).unwrap(), "?ids=1%2C2");
     }
 
     #[test]
@@ -487,7 +487,7 @@ mod tests {
             .build();
 
         assert_eq!(
-            request.query_params(None),
+            request.query_params(None).unwrap(),
             "?asset_type=COLLATERAL&token_id=1&signature_type=0"
         );
     }
@@ -499,7 +499,7 @@ mod tests {
             .build();
 
         assert_eq!(
-            request.query_params(Some("1")),
+            request.query_params(Some("1")).unwrap(),
             "?date=-262143-01-01&order_by=&position=&no_competition=false&next_cursor=1"
         );
     }

--- a/src/data/client.rs
+++ b/src/data/client.rs
@@ -112,7 +112,7 @@ impl Client {
         path: &str,
         req: &Req,
     ) -> Result<Res> {
-        let query = req.query_params(None);
+        let query = req.query_params(None)?;
         let request = self
             .client
             .request(Method::GET, format!("{}{path}{query}", self.host))

--- a/src/gamma/client.rs
+++ b/src/gamma/client.rs
@@ -124,7 +124,7 @@ impl Client {
         path: &str,
         req: &Req,
     ) -> Result<Res> {
-        let query = req.query_params(None);
+        let query = req.query_params(None)?;
         let request = self
             .client
             .request(Method::GET, format!("{}{path}{query}", self.host))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ use serde::Serialize;
 ))]
 use serde::de::DeserializeOwned;
 
-use crate::error::Error;
+use crate::error::{Error, Kind};
 use crate::types::{Address, address};
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -212,16 +212,14 @@ pub trait ToQueryParams: Serialize {
     ///
     /// Returns an empty string if no parameters are set, otherwise returns
     /// a string starting with `?` followed by URL-encoded key-value pairs.
-    /// Also uses an optional cursor as a parameter, if provided.
-    fn query_params(&self, next_cursor: Option<&str>) -> String {
-        let mut params = serde_html_form::to_string(self)
-            .inspect_err(|e| {
-                #[cfg(feature = "tracing")]
-                tracing::error!("Unable to convert to URL-encoded string {e:?}");
-                #[cfg(not(feature = "tracing"))]
-                let _: &serde_html_form::ser::Error = e;
-            })
-            .unwrap_or_default();
+    /// An optional `next_cursor` appends a pagination cursor. Fails with
+    /// [`Error`] if the request cannot be URL-encoded.
+    fn query_params(&self, next_cursor: Option<&str>) -> Result<String, Error> {
+        let mut params = serde_html_form::to_string(self).map_err(|e| {
+            #[cfg(feature = "tracing")]
+            tracing::error!("Unable to convert to URL-encoded string {e:?}");
+            Error::with_source(Kind::Internal, e)
+        })?;
 
         if let Some(cursor) = next_cursor {
             if !params.is_empty() {
@@ -231,9 +229,9 @@ pub trait ToQueryParams: Serialize {
         }
 
         if params.is_empty() {
-            String::new()
+            Ok(String::new())
         } else {
-            format!("?{params}")
+            Ok(format!("?{params}"))
         }
     }
 }
@@ -306,6 +304,54 @@ async fn request<Response: DeserializeOwned>(
             "Unable to find requested resource",
         ))
     }
+}
+
+/// Like [`request`], but for responses with no body (e.g. DELETE) where success must still
+/// be determined from HTTP status.
+#[cfg(any(
+    feature = "bridge",
+    feature = "clob",
+    feature = "data",
+    feature = "gamma"
+))]
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        level = "debug",
+        skip(client, request),
+        fields(
+            method = %request.method(),
+            path = request.url().path(),
+            status_code
+        )
+    )
+)]
+async fn request_empty(client: &reqwest::Client, request: Request) -> Result<()> {
+    let method = request.method().clone();
+    let path = request.url().path().to_owned();
+
+    let response = client.execute(request).await?;
+    let status_code = response.status();
+
+    #[cfg(feature = "tracing")]
+    tracing::Span::current().record("status_code", status_code.as_u16());
+
+    if !status_code.is_success() {
+        let message = response.text().await.unwrap_or_default();
+
+        #[cfg(feature = "tracing")]
+        tracing::warn!(
+            status = %status_code,
+            method = %method,
+            path = %path,
+            message = %message,
+            "API request failed"
+        );
+
+        return Err(Error::status(status_code, method, path, message));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/tests/data.rs
+++ b/tests/data.rs
@@ -1078,7 +1078,7 @@ mod types {
             .sort_direction(SortDirection::Desc)
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(qs.contains("user=0x"));
         assert!(qs.contains("limit=50"));
         assert!(qs.contains("sortBy=CASHPNL"));
@@ -1095,7 +1095,7 @@ mod types {
             .filter(MarketFilter::markets([hash1, hash2]))
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(qs.contains("market="));
         assert!(qs.contains("%2C")); // URL-encoded comma
         assert!(!qs.contains("eventId="));
@@ -1108,7 +1108,7 @@ mod types {
             .filter(MarketFilter::event_ids(["1".to_owned(), "2".to_owned()]))
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(qs.contains("eventId=1%2C2")); // URL-encoded "1,2"
         assert!(!qs.contains("market="));
     }
@@ -1126,7 +1126,7 @@ mod types {
             .trade_filter(TradeFilter::cash(dec!(100.0)).unwrap())
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(qs.contains("filterType=CASH"));
         assert!(qs.contains("filterAmount=100"));
     }
@@ -1138,7 +1138,7 @@ mod types {
             .activity_types(vec![ActivityType::Trade, ActivityType::Redeem])
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(qs.contains("type=TRADE%2CREDEEM")); // URL-encoded "TRADE,REDEEM"
     }
 
@@ -1146,7 +1146,7 @@ mod types {
     fn live_volume_request() {
         let req = LiveVolumeRequest::builder().id(123).build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(qs.contains("id=123"));
     }
 
@@ -1156,7 +1156,7 @@ mod types {
             .user(address!("56687bf447db6ffa42ffe2204a05edaa20f55839"))
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(qs.contains("user=0x"));
     }
 
@@ -1170,7 +1170,7 @@ mod types {
             .unwrap()
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(qs.contains("category=POLITICS"));
         assert!(qs.contains("timePeriod=WEEK"));
         assert!(qs.contains("orderBy=PNL"));
@@ -1298,7 +1298,7 @@ mod request_query_string_extended {
             .title("test")
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(qs.contains("sizeThreshold="));
         assert!(qs.contains("mergeable="));
         assert!(qs.contains("sortBy="));
@@ -1316,7 +1316,7 @@ mod request_query_string_extended {
             .side(Side::Buy)
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(qs.contains("user="));
         assert!(qs.contains("market="));
         assert!(qs.contains("limit="));
@@ -1338,7 +1338,7 @@ mod request_query_string_extended {
             .side(Side::Sell)
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(qs.contains("eventId="));
         assert!(qs.contains("start="));
         assert!(qs.contains("end="));
@@ -1355,7 +1355,7 @@ mod request_query_string_extended {
             .unwrap()
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(qs.contains("minBalance="));
     }
 
@@ -1366,7 +1366,7 @@ mod request_query_string_extended {
             .markets(vec![test_hash()])
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(qs.contains("market="));
     }
 
@@ -1382,7 +1382,7 @@ mod request_query_string_extended {
             .sort_direction(SortDirection::Desc)
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(qs.contains("market="));
         assert!(qs.contains("title="));
         assert!(qs.contains("sortBy="));
@@ -1396,7 +1396,7 @@ mod request_query_string_extended {
             .unwrap()
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(qs.contains("offset="));
     }
 
@@ -1407,7 +1407,7 @@ mod request_query_string_extended {
             .user_name("testuser".to_owned())
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(qs.contains("user="));
         assert!(qs.contains("userName="));
     }
@@ -1418,7 +1418,7 @@ mod request_query_string_extended {
             .trade_filter(TradeFilter::tokens(dec!(50.0)).unwrap())
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(qs.contains("filterType=TOKENS"));
     }
 
@@ -1429,7 +1429,7 @@ mod request_query_string_extended {
             .filter(MarketFilter::markets([] as [B256; 0]))
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(!qs.contains("market="));
     }
 
@@ -1440,7 +1440,7 @@ mod request_query_string_extended {
             .filter(MarketFilter::event_ids([]))
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(!qs.contains("eventId="));
     }
 
@@ -1451,7 +1451,7 @@ mod request_query_string_extended {
             .activity_types(vec![])
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(!qs.contains("type="));
     }
 
@@ -1461,7 +1461,7 @@ mod request_query_string_extended {
             .markets(Vec::<B256>::new())
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(!qs.contains("market="));
     }
 
@@ -1472,7 +1472,7 @@ mod request_query_string_extended {
             .markets(Vec::<B256>::new())
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(!qs.contains("market="));
     }
 
@@ -1501,7 +1501,7 @@ mod request_query_string_extended {
     #[test]
     fn empty_request_query_string() {
         let req = TradesRequest::default();
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(qs.is_empty());
     }
 
@@ -1509,7 +1509,7 @@ mod request_query_string_extended {
     fn trades_request_with_offset() {
         let req = TradesRequest::builder().offset(100).unwrap().build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(qs.contains("offset=100"));
     }
 
@@ -1519,7 +1519,7 @@ mod request_query_string_extended {
             .markets(vec![test_hash()])
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(qs.contains("market="));
     }
 
@@ -1529,7 +1529,7 @@ mod request_query_string_extended {
             .markets(Vec::<B256>::new())
             .build();
 
-        let qs = req.query_params(None);
+        let qs = req.query_params(None).unwrap();
         assert!(!qs.contains("market="));
     }
 

--- a/tests/gamma.rs
+++ b/tests/gamma.rs
@@ -1021,7 +1021,7 @@ mod query_string {
             .abbreviation(vec!["LAL".to_owned(), "BOS".to_owned()])
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.contains("limit=10"));
         assert!(qs.contains("offset=5"));
         assert!(qs.contains("order=name"));
@@ -1042,7 +1042,7 @@ mod query_string {
             .abbreviation(vec![])
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(!qs.contains("league="));
         assert!(!qs.contains("name="));
         assert!(!qs.contains("abbreviation="));
@@ -1059,7 +1059,7 @@ mod query_string {
             .is_carousel(true)
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.contains("limit=20"));
         assert!(qs.contains("offset=10"));
         assert!(qs.contains("order=label"));
@@ -1075,7 +1075,7 @@ mod query_string {
             .include_template(true)
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.contains("include_template=true"));
     }
 
@@ -1086,7 +1086,7 @@ mod query_string {
             .include_template(false)
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.contains("include_template=false"));
     }
 
@@ -1098,7 +1098,7 @@ mod query_string {
             .status(RelatedTagsStatus::Active)
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.contains("omit_empty=true"));
         assert!(qs.contains("status=active"));
     }
@@ -1111,7 +1111,7 @@ mod query_string {
             .status(RelatedTagsStatus::Closed)
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.contains("omit_empty=false"));
         assert!(qs.contains("status=closed"));
     }
@@ -1123,7 +1123,7 @@ mod query_string {
             .status(RelatedTagsStatus::All)
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.contains("status=all"));
     }
 
@@ -1161,7 +1161,7 @@ mod query_string {
             .end_date_max(end_date)
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.contains("limit=50"));
         assert!(qs.contains("offset=10"));
         assert!(qs.contains("order=startDate"));
@@ -1203,7 +1203,7 @@ mod query_string {
             .slug(vec![])
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(!qs.contains("id="));
         assert!(!qs.contains("exclude_tag_id="));
         assert!(!qs.contains("slug="));
@@ -1217,7 +1217,7 @@ mod query_string {
             .include_template(false)
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.contains("include_chat=true"));
         assert!(qs.contains("include_template=false"));
     }
@@ -1230,7 +1230,7 @@ mod query_string {
             .include_template(true)
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.contains("include_chat=false"));
         assert!(qs.contains("include_template=true"));
     }
@@ -1238,7 +1238,7 @@ mod query_string {
     #[test]
     fn event_tags_request_empty_params() {
         let request = EventTagsRequest::builder().id("123").build();
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.is_empty());
     }
 
@@ -1282,7 +1282,7 @@ mod query_string {
             .closed(false)
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.contains("limit=100"));
         assert!(qs.contains("offset=50"));
         assert!(qs.contains("order=volume"));
@@ -1338,7 +1338,7 @@ mod query_string {
             .question_ids(vec![])
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(!qs.contains("id="));
         assert!(!qs.contains("slug="));
         assert!(!qs.contains("clob_token_ids="));
@@ -1355,7 +1355,7 @@ mod query_string {
             .include_tag(true)
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.contains("include_tag=true"));
     }
 
@@ -1366,14 +1366,14 @@ mod query_string {
             .include_tag(false)
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.contains("include_tag=false"));
     }
 
     #[test]
     fn market_tags_request_empty_params() {
         let request = MarketTagsRequest::builder().id("456").build();
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.is_empty());
     }
 
@@ -1392,7 +1392,7 @@ mod query_string {
             .recurrence("daily".to_owned())
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.contains("limit=25"));
         assert!(qs.contains("offset=5"));
         assert!(qs.contains("order=title"));
@@ -1418,7 +1418,7 @@ mod query_string {
             .categories_labels(vec![])
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(!qs.contains("slug="));
         assert!(!qs.contains("categories_ids="));
         assert!(!qs.contains("categories_labels="));
@@ -1431,7 +1431,7 @@ mod query_string {
             .include_chat(true)
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.contains("include_chat=true"));
     }
 
@@ -1448,7 +1448,7 @@ mod query_string {
             .holders_only(true)
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.contains("limit=50"));
         assert!(qs.contains("offset=10"));
         assert!(qs.contains("order=createdAt"));
@@ -1466,7 +1466,7 @@ mod query_string {
             .parent_entity_id("series-123")
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.contains("parent_entity_type=Series"));
         assert!(qs.contains("parent_entity_id=series-123"));
     }
@@ -1478,7 +1478,7 @@ mod query_string {
             .parent_entity_id("market-456")
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.contains("parent_entity_type=market"));
         assert!(qs.contains("parent_entity_id=market-456"));
     }
@@ -1490,7 +1490,7 @@ mod query_string {
             .get_positions(true)
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.contains("get_positions=true"));
     }
 
@@ -1504,7 +1504,7 @@ mod query_string {
             .ascending(true)
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.contains("limit=20"));
         assert!(qs.contains("offset=5"));
         assert!(qs.contains("order=createdAt"));
@@ -1517,7 +1517,7 @@ mod query_string {
             .address(address!("0x56687bf447db6ffa42ffe2204a05edaa20f55839"))
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         // Address serializes to lowercase hex via serde
         assert!(qs.contains("address=0x56687bf447db6ffa42ffe2204a05edaa20f55839"));
     }
@@ -1541,7 +1541,7 @@ mod query_string {
             .optimized(true)
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(qs.contains("q=bitcoin"));
         assert!(qs.contains("cache=true"));
         assert!(qs.contains("events_status=active"));
@@ -1569,14 +1569,14 @@ mod query_string {
             .exclude_tag_id(vec![])
             .build();
 
-        let qs = request.query_params(None);
+        let qs = request.query_params(None).unwrap();
         assert!(!qs.contains("events_tag="));
         assert!(!qs.contains("exclude_tag_id="));
     }
 
     #[test]
     fn unit_query_string_returns_empty() {
-        let qs = ().query_params(None);
+        let qs = ().query_params(None).unwrap();
         assert!(qs.is_empty());
     }
 }


### PR DESCRIPTION
hi, mooncitydev here. was going through the sdk and fixed a few things that seemed worth shipping together.

**sign and chain id** \sign()\ used \expect\ on \signer.chain_id()\ as if only the authenticated signer could be passed, but any signer is allowed. if someone passed a signer without \with_chain_id\, it panicked. it now returns a validation error with a hint to set chain id.

**empty response endpoints and http status** \delete_notifications\, \update_balance_allowance\, and \
evoke_builder_api_key\ called \execute\ and returned \Ok(())\ even when the server responded 4xx/5xx. \delete_readonly_api_key\ already did the right thing; i added a shared \
equest_empty\ in \lib.rs\ and routed the no-body endpoints through it (and refactored delete readonly to use the same path).

**query string encoding** \ToQueryParams::query_params\ used \unwrap_or_default()\ when \serde_html_form::to_string\ failed, so you could get an empty query string and the wrong request without an error. it now returns \Result\ with an internal error. downstream call sites that build urls from this trait need to handle the result (small breaking change; the old behavior was misleading).

i could not run \cargo test\ on the machine i used (toolchain/linker issue on this box) so please let ci run.

cheers
