### PR TITLE
fix(clob): invalidate version and V2 fee caches

### DIFF
--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -524,7 +524,7 @@ impl<S: State> Client<S> {
         &self.inner.host
     }
 
-    /// Invalidates all internal caches (tick sizes, neg risk flags, and fee rates).
+    /// Invalidates all internal caches (tick sizes, neg risk flags, fee rates, and version).
     ///
     /// This method clears the cached market configuration data, forcing subsequent
     /// requests to fetch fresh data from the API. Use this when you suspect
@@ -533,7 +533,10 @@ impl<S: State> Client<S> {
         self.inner.tick_sizes.clear();
         self.inner.fee_rate_bps.clear();
         self.inner.neg_risk.clear();
+        self.inner.fee_infos.clear();
+        self.inner.token_condition_map.clear();
         self.inner.builder_fee_rates.clear();
+        self.inner.cached_version.store(0, Ordering::Relaxed);
     }
 
     /// Pre-populates the tick size cache for a token, avoiding the HTTP call.

--- a/tests/clob.rs
+++ b/tests/clob.rs
@@ -505,6 +505,78 @@ mod unauthenticated {
     }
 
     #[tokio::test]
+    async fn invalidate_caches_should_clear_market_info_and_version() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = Client::new(&server.base_url(), Config::default())?;
+
+        let condition_id_1 =
+            b256!("0000000000000000000000000000000000000000000000000000000000000001");
+        let condition_id_2 =
+            b256!("0000000000000000000000000000000000000000000000000000000000000002");
+
+        let version_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/version");
+            then.status(StatusCode::OK)
+                .json_body(json!({ "version": 2 }));
+        });
+
+        assert_eq!(client.version().await?, 2);
+
+        let market_1 = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path(format!("/clob-markets/{condition_id_1}"));
+            then.status(StatusCode::OK).json_body(json!({
+                "c": condition_id_1.to_string(),
+                "t": [
+                    { "t": token_1().to_string(), "o": "YES" },
+                    { "t": token_2().to_string(), "o": "NO" }
+                ],
+                "mts": 0.01,
+                "fd": { "r": 0.03, "e": 1, "to": true }
+            }));
+        });
+
+        client.clob_market_info(&condition_id_1.to_string()).await?;
+        assert_eq!(client.fee_exponent(token_1()).await?, 1);
+        market_1.assert_calls(1);
+
+        client.invalidate_internal_caches();
+
+        assert_eq!(client.version().await?, 2);
+        version_mock.assert_calls(2);
+
+        let market_by_token = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path(format!("/markets-by-token/{}", token_1()));
+            then.status(StatusCode::OK).json_body(json!({
+                "condition_id": condition_id_2.to_string(),
+                "primary_token_id": token_1().to_string(),
+                "secondary_token_id": token_2().to_string()
+            }));
+        });
+
+        let market_2 = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path(format!("/clob-markets/{condition_id_2}"));
+            then.status(StatusCode::OK).json_body(json!({
+                "c": condition_id_2.to_string(),
+                "t": [
+                    { "t": token_1().to_string(), "o": "YES" },
+                    { "t": token_2().to_string(), "o": "NO" }
+                ],
+                "mts": 0.001,
+                "fd": { "r": 0.05, "e": 3, "to": true }
+            }));
+        });
+
+        assert_eq!(client.fee_exponent(token_1()).await?, 3);
+        market_by_token.assert();
+        market_2.assert();
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn order_book_should_succeed() -> anyhow::Result<()> {
         let server = MockServer::start();
         let client = Client::new(&server.base_url(), Config::default())?;


### PR DESCRIPTION
Fixes `invalidate_internal_caches()` so it also clears V2 fee metadata, token-to-condition mapping, and cached protocol version.

This prevents order creation from reusing stale V2 fee parameters or an outdated CLOB version after explicit cache invalidation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes cache invalidation semantics for fee/version resolution, which can alter when extra HTTP calls occur and what fee parameters are used for order sizing.
> 
> **Overview**
> Ensures `Client::invalidate_internal_caches()` fully resets **all** CLOB market configuration state by additionally clearing V2 fee metadata (`fee_infos`), token→condition mappings, and the cached `/version` result (reset to `0`).
> 
> Adds a regression test asserting that after invalidation the client re-fetches `version` and re-primes market info via `/markets-by-token` + `/clob-markets`, preventing reuse of stale V2 fee parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c62013113ca8862f4a06d5a4485e2b0cb5de4e6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->