### PR TITLE
handle empty fee_rate_bps in MakerOrder deserialization

### DIFF
--- a/src/clob/types/response.rs
+++ b/src/clob/types/response.rs
@@ -518,6 +518,7 @@ pub struct MakerOrder {
     pub maker_address: Address,
     pub matched_amount: Decimal,
     pub price: Decimal,
+    #[serde(deserialize_with = "empty_string_as_zero")]
     pub fee_rate_bps: Decimal,
     pub asset_id: U256,
     pub outcome: String,
@@ -898,4 +899,25 @@ pub struct RfqQuote {
     pub size_out: Decimal,
     /// Quoted price.
     pub price: Decimal,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maker_order_with_empty_fee_rate_deserializes() {
+        let json = r#"{
+            "order_id": "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "owner": "00000000-0000-0000-0000-000000000001",
+            "maker_address": "0x0000000000000000000000000000000000000001",
+            "matched_amount": "450",
+            "price": "0.997",
+            "fee_rate_bps": "",
+            "asset_id": "1",
+            "outcome": "No",
+            "side": "BUY"
+        }"#;
+        serde_json::from_str::<MakerOrder>(json).expect("deserialization failed");
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/Polymarket/rs-clob-client-v2/issues/23

Possibly there is an interpretation difference between "intentionally absent" and 0, but I suggest breaking the struct definition for the legacy feature is not worth it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrowly changes JSON deserialization for `MakerOrder.fee_rate_bps` to tolerate empty strings, plus a unit test; behavioral change could mask upstream API issues but is limited to one field.
> 
> **Overview**
> Makes `MakerOrder.fee_rate_bps` robust to the API returning an empty string by deserializing it as `0` via `empty_string_as_zero`.
> 
> Adds a regression unit test ensuring `MakerOrder` deserialization succeeds when `fee_rate_bps` is `""`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11715138979211ebd8126ba90d0b5269c22c2ebb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->