### PR TITLE
fix: use CLOB_HOST constant in examples (#27)

### DIFF
--- a/examples/clob/account/get_balance_allowance.rs
+++ b/examples/clob/account/get_balance_allowance.rs
@@ -13,11 +13,12 @@ use polymarket_client_sdk_v2::clob::types::AssetType;
 use polymarket_client_sdk_v2::clob::types::request::BalanceAllowanceRequest;
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| CLOB_HOST.into());
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));
 

--- a/examples/clob/account/get_notifications.rs
+++ b/examples/clob/account/get_notifications.rs
@@ -11,11 +11,12 @@ use alloy::signers::Signer as _;
 use alloy::signers::local::LocalSigner;
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| CLOB_HOST.into());
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));
 

--- a/examples/clob/account/get_open_orders.rs
+++ b/examples/clob/account/get_open_orders.rs
@@ -13,11 +13,12 @@ use polymarket_client_sdk_v2::clob::types::request::OrdersRequest;
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::types::U256;
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| CLOB_HOST.into());
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));
 

--- a/examples/clob/account/get_trades.rs
+++ b/examples/clob/account/get_trades.rs
@@ -13,11 +13,12 @@ use polymarket_client_sdk_v2::clob::types::request::TradesRequest;
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::types::U256;
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| CLOB_HOST.into());
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));
 

--- a/examples/clob/account/update_balance_allowance.rs
+++ b/examples/clob/account/update_balance_allowance.rs
@@ -13,11 +13,12 @@ use polymarket_client_sdk_v2::clob::types::AssetType;
 use polymarket_client_sdk_v2::clob::types::request::UpdateBalanceAllowanceRequest;
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| CLOB_HOST.into());
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));
 

--- a/examples/clob/async.rs
+++ b/examples/clob/async.rs
@@ -25,6 +25,7 @@ use alloy::signers::local::LocalSigner;
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::types::U256;
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 use tokio::join;
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
@@ -53,7 +54,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn unauthenticated() -> anyhow::Result<()> {
-    let client = Client::new("https://clob-v2.polymarket.com", Config::default())?;
+    let client = Client::new(CLOB_HOST, Config::default())?;
     let client_clone = client.clone();
 
     let token_id = U256::from_str(
@@ -115,7 +116,7 @@ async fn authenticated() -> anyhow::Result<()> {
     };
     let signer = LocalSigner::from_str(&private_key)?.with_chain_id(Some(POLYGON));
 
-    let client = Client::new("https://clob-v2.polymarket.com", Config::default())?
+    let client = Client::new(CLOB_HOST, Config::default())?
         .authentication_builder(&signer)
         .authenticate()
         .await?;

--- a/examples/clob/authenticated.rs
+++ b/examples/clob/authenticated.rs
@@ -33,6 +33,7 @@ use polymarket_client_sdk_v2::clob::types::{Amount, OrderType, Side};
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::types::{Decimal, U256};
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 use rust_decimal_macros::dec;
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
@@ -63,7 +64,7 @@ async fn main() -> anyhow::Result<()> {
     let signer = LocalSigner::from_str(&private_key)?.with_chain_id(Some(POLYGON));
 
     let config = Config::builder().use_server_time(true).build();
-    let client = Client::new("https://clob-v2.polymarket.com", config)?
+    let client = Client::new(CLOB_HOST, config)?
         .authentication_builder(&signer)
         .authenticate()
         .await?;

--- a/examples/clob/aws_authenticated.rs
+++ b/examples/clob/aws_authenticated.rs
@@ -24,6 +24,7 @@ use alloy::signers::aws::AwsSigner;
 use aws_config::BehaviorVersion;
 use polymarket_client_sdk_v2::POLYGON;
 use polymarket_client_sdk_v2::clob::{Client, Config};
+use polymarket_client_sdk_v2::CLOB_HOST;
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::layer::SubscriberExt as _;
@@ -55,7 +56,7 @@ async fn main() -> anyhow::Result<()> {
         .await?
         .with_chain_id(Some(POLYGON));
 
-    let client = Client::new("https://clob-v2.polymarket.com", Config::default())?
+    let client = Client::new(CLOB_HOST, Config::default())?
         .authentication_builder(&alloy_signer)
         .authenticate()
         .await?;

--- a/examples/clob/builder_authenticated.rs
+++ b/examples/clob/builder_authenticated.rs
@@ -19,6 +19,7 @@ use polymarket_client_sdk_v2::clob::types::request::TradesRequest;
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::types::{B256, U256};
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 use tracing::{error, info};
 
 #[tokio::main]
@@ -32,7 +33,7 @@ async fn main() -> anyhow::Result<()> {
     let signer = LocalSigner::from_str(&private_key)?.with_chain_id(Some(POLYGON));
 
     let config = Config::builder().builder_code(builder_code).build();
-    let client = Client::new("https://clob-v2.polymarket.com", config)?
+    let client = Client::new(CLOB_HOST, config)?
         .authentication_builder(&signer)
         .authenticate()
         .await?;

--- a/examples/clob/heartbeats.rs
+++ b/examples/clob/heartbeats.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 use polymarket_client_sdk_v2::auth::{LocalSigner, Signer as _};
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -23,7 +24,7 @@ async fn main() -> anyhow::Result<()> {
         .use_server_time(true)
         .heartbeat_interval(Duration::from_secs(1))
         .build();
-    let client = Client::new("https://clob-v2.polymarket.com", config)?
+    let client = Client::new(CLOB_HOST, config)?
         .authentication_builder(&signer)
         .authenticate()
         .await?;

--- a/examples/clob/keys/create_or_derive_api_key.rs
+++ b/examples/clob/keys/create_or_derive_api_key.rs
@@ -11,11 +11,12 @@ use alloy::signers::Signer as _;
 use alloy::signers::local::LocalSigner;
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| CLOB_HOST.into());
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));
 

--- a/examples/clob/keys/delete_api_key.rs
+++ b/examples/clob/keys/delete_api_key.rs
@@ -11,11 +11,12 @@ use alloy::signers::Signer as _;
 use alloy::signers::local::LocalSigner;
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| CLOB_HOST.into());
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));
 

--- a/examples/clob/keys/get_api_keys.rs
+++ b/examples/clob/keys/get_api_keys.rs
@@ -11,11 +11,12 @@ use alloy::signers::Signer as _;
 use alloy::signers::local::LocalSigner;
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| CLOB_HOST.into());
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));
 

--- a/examples/clob/market/get_last_trade_price.rs
+++ b/examples/clob/market/get_last_trade_price.rs
@@ -10,11 +10,12 @@ use std::str::FromStr as _;
 use polymarket_client_sdk_v2::clob::types::request::LastTradePriceRequest;
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::types::U256;
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| CLOB_HOST.into());
     let token_id = U256::from_str(&std::env::var("TOKEN_ID")?)?;
 
     let client = Client::new(&host, Config::default())?;

--- a/examples/clob/market/get_midpoint.rs
+++ b/examples/clob/market/get_midpoint.rs
@@ -10,11 +10,12 @@ use std::str::FromStr as _;
 use polymarket_client_sdk_v2::clob::types::request::MidpointRequest;
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::types::U256;
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| CLOB_HOST.into());
     let token_id = U256::from_str(&std::env::var("TOKEN_ID")?)?;
 
     let client = Client::new(&host, Config::default())?;

--- a/examples/clob/market/get_orderbook.rs
+++ b/examples/clob/market/get_orderbook.rs
@@ -10,11 +10,12 @@ use std::str::FromStr as _;
 use polymarket_client_sdk_v2::clob::types::request::OrderBookSummaryRequest;
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::types::U256;
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| CLOB_HOST.into());
     let token_id = U256::from_str(&std::env::var("TOKEN_ID")?)?;
 
     let client = Client::new(&host, Config::default())?;

--- a/examples/clob/market/get_price.rs
+++ b/examples/clob/market/get_price.rs
@@ -11,11 +11,12 @@ use polymarket_client_sdk_v2::clob::types::Side;
 use polymarket_client_sdk_v2::clob::types::request::PriceRequest;
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::types::U256;
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| CLOB_HOST.into());
     let token_id = U256::from_str(&std::env::var("TOKEN_ID")?)?;
 
     let client = Client::new(&host, Config::default())?;

--- a/examples/clob/market/get_server_time.rs
+++ b/examples/clob/market/get_server_time.rs
@@ -6,11 +6,12 @@
 //! Fetch the CLOB server's current Unix timestamp.
 
 use polymarket_client_sdk_v2::clob::{Client, Config};
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| CLOB_HOST.into());
 
     let client = Client::new(&host, Config::default())?;
     println!("{}", client.server_time().await?);

--- a/examples/clob/market/get_spread.rs
+++ b/examples/clob/market/get_spread.rs
@@ -10,11 +10,12 @@ use std::str::FromStr as _;
 use polymarket_client_sdk_v2::clob::types::request::SpreadRequest;
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::types::U256;
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| CLOB_HOST.into());
     let token_id = U256::from_str(&std::env::var("TOKEN_ID")?)?;
 
     let client = Client::new(&host, Config::default())?;

--- a/examples/clob/orders/cancel_all.rs
+++ b/examples/clob/orders/cancel_all.rs
@@ -11,11 +11,12 @@ use alloy::signers::Signer as _;
 use alloy::signers::local::LocalSigner;
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| CLOB_HOST.into());
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));
 

--- a/examples/clob/orders/cancel_order.rs
+++ b/examples/clob/orders/cancel_order.rs
@@ -11,11 +11,12 @@ use alloy::signers::Signer as _;
 use alloy::signers::local::LocalSigner;
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| CLOB_HOST.into());
     let order_id = std::env::var("ORDER_ID")?;
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));

--- a/examples/clob/orders/gtc_limit_buy.rs
+++ b/examples/clob/orders/gtc_limit_buy.rs
@@ -13,11 +13,12 @@ use polymarket_client_sdk_v2::clob::types::{OrderType, Side};
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::types::{Decimal, U256};
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| CLOB_HOST.into());
     let token_id = U256::from_str(&std::env::var("TOKEN_ID")?)?;
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));

--- a/examples/clob/orders/gtc_limit_sell.rs
+++ b/examples/clob/orders/gtc_limit_sell.rs
@@ -13,11 +13,12 @@ use polymarket_client_sdk_v2::clob::types::{OrderType, Side};
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::types::{Decimal, U256};
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| CLOB_HOST.into());
     let token_id = U256::from_str(&std::env::var("TOKEN_ID")?)?;
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));

--- a/examples/clob/orders/market_buy.rs
+++ b/examples/clob/orders/market_buy.rs
@@ -13,11 +13,12 @@ use polymarket_client_sdk_v2::clob::types::{Amount, OrderType, Side};
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::types::{Decimal, U256};
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| CLOB_HOST.into());
     let token_id = U256::from_str(&std::env::var("TOKEN_ID")?)?;
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));

--- a/examples/clob/rfq/quotes.rs
+++ b/examples/clob/rfq/quotes.rs
@@ -27,6 +27,7 @@ use alloy::signers::local::LocalSigner;
 use polymarket_client_sdk_v2::clob::types::{RfqQuotesRequest, RfqSortBy, RfqSortDir, RfqState};
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 use tracing::{debug, error, info};
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::layer::SubscriberExt as _;
@@ -51,7 +52,7 @@ async fn main() -> anyhow::Result<()> {
     let private_key = std::env::var(PRIVATE_KEY_VAR).expect("Need POLYMARKET_PRIVATE_KEY");
     let signer = LocalSigner::from_str(&private_key)?.with_chain_id(Some(POLYGON));
 
-    let client = Client::new("https://clob-v2.polymarket.com", Config::default())?
+    let client = Client::new(CLOB_HOST, Config::default())?
         .authentication_builder(&signer)
         .authenticate()
         .await?;

--- a/examples/clob/rfq/requests.rs
+++ b/examples/clob/rfq/requests.rs
@@ -27,6 +27,7 @@ use alloy::signers::local::LocalSigner;
 use polymarket_client_sdk_v2::clob::types::{RfqRequestsRequest, RfqSortBy, RfqSortDir, RfqState};
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 use tracing::{debug, error, info};
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::layer::SubscriberExt as _;
@@ -51,7 +52,7 @@ async fn main() -> anyhow::Result<()> {
     let private_key = std::env::var(PRIVATE_KEY_VAR).expect("Need POLYMARKET_PRIVATE_KEY");
     let signer = LocalSigner::from_str(&private_key)?.with_chain_id(Some(POLYGON));
 
-    let client = Client::new("https://clob-v2.polymarket.com", Config::default())?
+    let client = Client::new(CLOB_HOST, Config::default())?
         .authentication_builder(&signer)
         .authenticate()
         .await?;

--- a/examples/clob/scoring/get_closed_only_mode.rs
+++ b/examples/clob/scoring/get_closed_only_mode.rs
@@ -11,11 +11,12 @@ use alloy::signers::Signer as _;
 use alloy::signers::local::LocalSigner;
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| CLOB_HOST.into());
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));
 

--- a/examples/clob/scoring/is_order_scoring.rs
+++ b/examples/clob/scoring/is_order_scoring.rs
@@ -11,11 +11,12 @@ use alloy::signers::Signer as _;
 use alloy::signers::local::LocalSigner;
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| CLOB_HOST.into());
     let order_id = std::env::var("ORDER_ID")?;
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));

--- a/examples/clob/streaming.rs
+++ b/examples/clob/streaming.rs
@@ -28,6 +28,7 @@ use futures::{StreamExt as _, future};
 use polymarket_client_sdk_v2::clob::types::request::TradesRequest;
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk_v2::CLOB_HOST;
 use tokio::join;
 use tracing::{debug, info, warn};
 use tracing_subscriber::EnvFilter;
@@ -56,7 +57,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn unauthenticated() -> anyhow::Result<()> {
-    let client = Client::new("https://clob-v2.polymarket.com", Config::default())?;
+    let client = Client::new(CLOB_HOST, Config::default())?;
 
     info!(
         stream = "sampling_markets",
@@ -114,7 +115,7 @@ async fn authenticated() -> anyhow::Result<()> {
 
     let signer = LocalSigner::from_str(&private_key)?.with_chain_id(Some(POLYGON));
 
-    let client = Client::new("https://clob-v2.polymarket.com", Config::default())?
+    let client = Client::new(CLOB_HOST, Config::default())?
         .authentication_builder(&signer)
         .authenticate()
         .await?;

--- a/examples/clob/unauthenticated.rs
+++ b/examples/clob/unauthenticated.rs
@@ -24,6 +24,7 @@ use polymarket_client_sdk_v2::clob::types::request::{
 };
 use polymarket_client_sdk_v2::clob::{Client, Config};
 use polymarket_client_sdk_v2::types::{B256, Decimal, U256};
+use polymarket_client_sdk_v2::CLOB_HOST;
 use tracing::{error, info, warn};
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::layer::SubscriberExt as _;
@@ -103,7 +104,7 @@ async fn main() -> anyhow::Result<()> {
         tracing_subscriber::fmt::init();
     }
 
-    let client = Client::new("https://clob-v2.polymarket.com", Config::default())?;
+    let client = Client::new(CLOB_HOST, Config::default())?;
 
     // Health check endpoints
     match client.ok().await {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,12 @@ pub const AMOY: ChainId = 80002;
 
 pub const PRIVATE_KEY_VAR: &str = "POLYMARKET_PRIVATE_KEY";
 
+/// Default CLOB API host URL.
+///
+/// As of April 28 2026, the canonical CLOB endpoint is `https://clob.polymarket.com`.
+/// See <https://docs.polymarket.com/v2-migration>.
+pub const CLOB_HOST: &str = "https://clob.polymarket.com";
+
 /// Timestamp in seconds since [`std::time::UNIX_EPOCH`]
 pub(crate) type Timestamp = i64;
 


### PR DESCRIPTION
Fixes #27.

The examples hardcoded `https://clob-v2.polymarket.com`, but per the v2 migration docs (https://docs.polymarket.com/v2-migration), as of April 28 2026 the CLOB endpoint is `https://clob.polymarket.com`.

This PR:
- Adds a top-level `pub const CLOB_HOST: &str = "https://clob.polymarket.com";` in `src/lib.rs`.
- Updates all `examples/clob/**` to import and use `CLOB_HOST` rather than the stale literal.

`cargo check --examples --all-features` passes locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope is a new public constant and example-only URL defaults; library client behavior is unchanged aside from exporting the canonical host for callers to reuse.
> 
> **Overview**
> Introduces a public **`CLOB_HOST`** constant (`https://clob.polymarket.com`) in the crate root, replacing the outdated `https://clob-v2.polymarket.com` default that examples had inlined.
> 
> All **`examples/clob/**`** binaries now import **`CLOB_HOST`** for `Client::new` and for the `CLOB_API_URL` fallback (`unwrap_or_else(|_| CLOB_HOST.into())`), so copy-paste samples track the v2 migration endpoint without scattered literals. **`CLOB_API_URL`** still overrides the default when set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20cbd33d5507b86f58484b16061453bbd9283520. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->