### PR TITLE
feat(ws): expose broadcast_capacity in Config (default 65536)

### DIFF
--- a/src/ws/config.rs
+++ b/src/ws/config.rs
@@ -12,6 +12,12 @@ const DEFAULT_HEARTBEAT_TIMEOUT_DURATION: Duration = Duration::from_secs(15);
 const DEFAULT_INITIAL_BACKOFF_DURATION: Duration = Duration::from_secs(1);
 const DEFAULT_MAX_BACKOFF_DURATION: Duration = Duration::from_secs(60);
 const DEFAULT_BACKOFF_MULTIPLIER: f64 = 2.0;
+/// Default tokio broadcast channel capacity for incoming messages. The
+/// previous hardcoded value of 1024 was insufficient under bursty market
+/// data load (V2 wire protocol fires 100s of price_change events per
+/// second per asset; with thousands of subscribed assets, slow consumers
+/// trigger `Lagged(N)` errors and drop messages).
+const DEFAULT_BROADCAST_CAPACITY: usize = 65_536;
 
 /// Configuration for WebSocket client behavior.
 #[non_exhaustive]
@@ -23,6 +29,11 @@ pub struct Config {
     pub heartbeat_timeout: Duration,
     /// Reconnection strategy configuration
     pub reconnect: ReconnectConfig,
+    /// Capacity of the tokio broadcast channel used to fan out incoming
+    /// messages to typed subscribers. Increase if subscribers can briefly
+    /// fall behind the producer (e.g., CPU-bound deserialization) and you
+    /// see `RecvError::Lagged(N)` events. Default 65_536.
+    pub broadcast_capacity: usize,
 }
 
 impl Default for Config {
@@ -31,6 +42,7 @@ impl Default for Config {
             heartbeat_interval: DEFAULT_HEARTBEAT_INTERVAL_DURATION,
             heartbeat_timeout: DEFAULT_HEARTBEAT_TIMEOUT_DURATION,
             reconnect: ReconnectConfig::default(),
+            broadcast_capacity: DEFAULT_BROADCAST_CAPACITY,
         }
     }
 }

--- a/src/ws/config.rs
+++ b/src/ws/config.rs
@@ -33,6 +33,10 @@ pub struct Config {
     /// messages to typed subscribers. Increase if subscribers can briefly
     /// fall behind the producer (e.g., CPU-bound deserialization) and you
     /// see `RecvError::Lagged(N)` events. Default 65_536.
+    ///
+    /// Must be greater than 0 — `ConnectionManager::new` returns a
+    /// validation error otherwise (the underlying `tokio::sync::broadcast`
+    /// channel panics on zero capacity).
     pub broadcast_capacity: usize,
 }
 

--- a/src/ws/connection.rs
+++ b/src/ws/connection.rs
@@ -26,8 +26,9 @@ use crate::{Result, error::Error};
 
 type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
-/// Broadcast channel capacity for incoming messages.
-const BROADCAST_CAPACITY: usize = 1024;
+// Broadcast channel capacity is now configurable via `Config::broadcast_capacity`
+// (see `src/ws/config.rs`). Default raised to 65_536 to absorb bursty market
+// data when consumers are briefly CPU-bound.
 
 /// Connection state tracking.
 #[non_exhaustive]
@@ -116,7 +117,7 @@ where
     /// handles reconnection according to the config's `ReconnectConfig`.
     pub fn new(endpoint: String, config: Config, parser: P) -> Result<Self> {
         let (sender_tx, sender_rx) = mpsc::unbounded_channel();
-        let (broadcast_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
+        let (broadcast_tx, _) = broadcast::channel(config.broadcast_capacity);
         let (state_tx, state_rx) = watch::channel(ConnectionState::Disconnected);
 
         // Spawn connection task

--- a/src/ws/connection.rs
+++ b/src/ws/connection.rs
@@ -116,6 +116,11 @@ where
     /// The connection loop runs in a background task and automatically
     /// handles reconnection according to the config's `ReconnectConfig`.
     pub fn new(endpoint: String, config: Config, parser: P) -> Result<Self> {
+        if config.broadcast_capacity == 0 {
+            return Err(Error::validation(
+                "Config::broadcast_capacity must be greater than 0",
+            ));
+        }
         let (sender_tx, sender_rx) = mpsc::unbounded_channel();
         let (broadcast_tx, _) = broadcast::channel(config.broadcast_capacity);
         let (state_tx, state_rx) = watch::channel(ConnectionState::Disconnected);


### PR DESCRIPTION
## Summary

Replaces the hardcoded `BROADCAST_CAPACITY = 1024` private constant in `src/ws/connection.rs` with a public `broadcast_capacity: usize` field on `clob::ws::Config`. Default raised to **65,536** (64×).

## Motivation

The hardcoded 1024-slot capacity is insufficient for high-volume market-data subscribers. We hit this in production while ingesting all Polymarket markets: typed-stream subscribers (`subscribe_orderbook`, `subscribe_prices`, etc.) briefly fall behind the producer when CPU-bound deserialising messages, and the broadcast channel emits `RecvError::Lagged(N)` warnings while silently dropping messages.

Symptoms before the patch (~38K assets subscribed):
- Hundreds of `Subscription lagged, missed N messages` warnings per minute
- `ResetWithoutClosingHandshake` storms (~70/min) as the SDK's reconnect-and-resubscribe path repeatedly fired
- Effective msg ingest rate of 3–11 msg/s while the wire actually carried 100s/sec

After patching to 65,536:
- 0 lag warnings
- 0 resets
- 31–73 msg/s sustained, climbing
- CPU dropped from 197% to 13.6%
- Memory only marginally higher (broadcast slots are mostly empty)

## Changes

- `src/ws/config.rs`: add `pub broadcast_capacity: usize` to `Config`. `Config` is already `#[non_exhaustive]`, so this is a non-breaking addition.
- `src/ws/connection.rs`: use `config.broadcast_capacity` in `broadcast::channel(...)` instead of the const. Const removed.

## Backwards compatibility

- `Config::default()` callers automatically get the new default of 65,536 — strictly more permissive than the prior 1024, no behaviour regression possible.
- Custom `Config` builders continue to work via the existing `..Default::default()` syntax.
- Existing tests still pass (verified locally).

## Verification

- SDK unit tests: pass (`cargo test --features clob,ws,tracing --lib`)
- Local validation (`Client::default()` against `wss://ws-subscriptions-clob.polymarket.com`, ~16K subscribed assets, 5 min run): 0 lag warnings, msg rate 86 → 128/s climbing
- Production deploy (~38K subscribed assets, 5 min run): 0 lag warnings, msg rate 31 → 73/s climbing, CPU dropped 14×

## Notes

The default value of 65,536 is conservative — at ~1 KB per typed message, the maximum buffered memory is ~65 MB even when fully filled. Heavy subscribers (markets-wide ingestion) easily justify it; light subscribers (a few tokens) are unaffected.

Happy to adjust the default value if 65,536 feels too high for the common case — even 8,192 or 16,384 would resolve the issue we hit. The important thing is exposing the knob at all.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Raises the default inbound broadcast buffer size substantially and makes it user-configurable, which can increase memory usage under load and changes runtime behavior for any callers that previously (intentionally or accidentally) used a zero capacity.
> 
> **Overview**
> **WebSocket message fan-out buffering is now configurable.** The PR replaces the hardcoded inbound broadcast channel capacity with a new `Config::broadcast_capacity` knob and increases the default from `1024` to `65_536` to reduce `broadcast` lag/dropped messages under bursty market-data loads.
> 
> `ConnectionManager::new` now validates `broadcast_capacity > 0` and returns a validation error instead of allowing a zero-capacity configuration that would panic inside `tokio::sync::broadcast`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0db0ccb2f5cbe89a1b3cb4c4b41260acb87c208. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->