### PR TITLE
feat: add deposit wallet order support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "polymarket_client_sdk_v2"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "polymarket_client_sdk_v2"
-version = "0.6.0"
+version = "0.6.0-canary.1"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "polymarket_client_sdk_v2"
 description = "Polymarket CLOB (Central Limit Order Book) API client SDK"
-version = "0.5.1"
+version = "0.6.0"
 authors = [
     "Polymarket Engineering <engineering@polymarket.com>",
     "Chaz Byrnes <chaz@polymarket.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "polymarket_client_sdk_v2"
 description = "Polymarket CLOB (Central Limit Order Book) API client SDK"
-version = "0.6.0"
+version = "0.6.0-canary.1"
 authors = [
     "Polymarket Engineering <engineering@polymarket.com>",
     "Chaz Byrnes <chaz@polymarket.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,6 +206,11 @@ path = "examples/clob/orders/gtc_limit_buy.rs"
 required-features = ["clob"]
 
 [[example]]
+name = "gtc_limit_buy_deposit_wallet"
+path = "examples/clob/orders/gtc_limit_buy_deposit_wallet.rs"
+required-features = ["clob"]
+
+[[example]]
 name = "gtc_limit_sell"
 path = "examples/clob/orders/gtc_limit_sell.rs"
 required-features = ["clob"]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Add the crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-polymarket_client_sdk_v2 = "0.5"
+polymarket_client_sdk_v2 = "0.6"
 ```
 
 or
@@ -83,7 +83,7 @@ Enable features in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-polymarket_client_sdk_v2 = { version = "0.5", features = ["ws", "data"] }
+polymarket_client_sdk_v2 = { version = "0.6", features = ["ws", "data"] }
 ```
 
 ## Re-exported Types
@@ -410,7 +410,7 @@ async fn main() -> anyhow::Result<()> {
 Real-time orderbook and user event streaming. Requires the `ws` feature.
 
 ```toml
-polymarket_client_sdk_v2 = { version = "0.5", features = ["ws"] }
+polymarket_client_sdk_v2 = { version = "0.6", features = ["ws"] }
 ```
 
 ```rust,ignore

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Add the crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-polymarket_client_sdk_v2 = "0.6"
+polymarket_client_sdk_v2 = "=0.6.0-canary.1"
 ```
 
 or
@@ -83,7 +83,7 @@ Enable features in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-polymarket_client_sdk_v2 = { version = "0.6", features = ["ws", "data"] }
+polymarket_client_sdk_v2 = { version = "=0.6.0-canary.1", features = ["ws", "data"] }
 ```
 
 ## Re-exported Types
@@ -410,7 +410,7 @@ async fn main() -> anyhow::Result<()> {
 Real-time orderbook and user event streaming. Requires the `ws` feature.
 
 ```toml
-polymarket_client_sdk_v2 = { version = "0.6", features = ["ws"] }
+polymarket_client_sdk_v2 = { version = "=0.6.0-canary.1", features = ["ws"] }
 ```
 
 ```rust,ignore

--- a/README.md
+++ b/README.md
@@ -228,6 +228,17 @@ The **signature_type** parameter tells the system how to verify your signatures:
 
 See [`SignatureType`](src/clob/types/mod.rs) for more information.
 
+For deposit wallets, pass the deployed deposit wallet as the funder and use `SignatureType::Poly1271`:
+
+```rust,ignore
+let client = Client::new("https://clob-v2.polymarket.com", Config::default())?
+    .authentication_builder(&signer)
+    .funder(deposit_wallet)
+    .signature_type(SignatureType::Poly1271)
+    .authenticate()
+    .await?;
+```
+
 ##### Place a market order
 
 ```rust,ignore

--- a/examples/clob/orders/gtc_limit_buy_deposit_wallet.rs
+++ b/examples/clob/orders/gtc_limit_buy_deposit_wallet.rs
@@ -1,0 +1,49 @@
+#![allow(
+    clippy::print_stdout,
+    reason = "Examples print their results to stdout"
+)]
+
+//! Place a resting GTC limit buy from a deployed deposit wallet.
+
+use std::str::FromStr as _;
+
+use alloy::signers::Signer as _;
+use alloy::signers::local::LocalSigner;
+use polymarket_client_sdk_v2::clob::types::{OrderType, Side, SignatureType};
+use polymarket_client_sdk_v2::clob::{Client, Config};
+use polymarket_client_sdk_v2::types::{Address, Decimal, U256};
+use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let host =
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+    let token_id = U256::from_str(&std::env::var("TOKEN_ID")?)?;
+    let deposit_wallet = Address::from_str(&std::env::var("DEPOSIT_WALLET")?)?;
+    let price =
+        Decimal::from_str(&std::env::var("ORDER_PRICE").unwrap_or_else(|_| "0.4".to_owned()))?;
+    let size =
+        Decimal::from_str(&std::env::var("ORDER_SIZE").unwrap_or_else(|_| "100".to_owned()))?;
+    let signer =
+        LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));
+
+    let client = Client::new(&host, Config::default())?
+        .authentication_builder(&signer)
+        .funder(deposit_wallet)
+        .signature_type(SignatureType::Poly1271)
+        .authenticate()
+        .await?;
+
+    let resp = client
+        .limit_order()
+        .token_id(token_id)
+        .side(Side::Buy)
+        .price(price)
+        .size(size)
+        .order_type(OrderType::GTC)
+        .build_sign_and_post(&signer)
+        .await?;
+
+    println!("order_id={} status={}", resp.order_id, resp.status);
+    Ok(())
+}

--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -7,9 +7,10 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
 use alloy::dyn_abi::Eip712Domain;
-use alloy::primitives::U256;
+use alloy::primitives::{Signature, U256, keccak256};
 use alloy::signers::Signer;
 use alloy::sol_types::SolStruct as _;
+use alloy::sol_types::SolValue as _;
 use async_stream::try_stream;
 use bon::Builder;
 use chrono::{NaiveDate, Utc};
@@ -54,7 +55,8 @@ use crate::clob::types::{
     RfqRequestsRequest,
 };
 use crate::clob::types::{
-    Amount, OrderPayload, OrderType, Side, SignableOrder, SignatureType, SignedOrder, TickSize,
+    Amount, OrderPayload, OrderSignature, OrderType, Side, SignableOrder, SignatureType,
+    SignedOrder, TickSize,
 };
 use crate::error::{Error, Kind as ErrorKind, Synchronization};
 use crate::types::{Address, B256, Decimal};
@@ -66,10 +68,41 @@ use crate::{
 const ORDER_NAME: Option<Cow<'static, str>> = Some(Cow::Borrowed("Polymarket CTF Exchange"));
 const VERSION_V1: Option<Cow<'static, str>> = Some(Cow::Borrowed("1"));
 const VERSION_V2: Option<Cow<'static, str>> = Some(Cow::Borrowed("2"));
+const DEPOSIT_WALLET_NAME: &str = "DepositWallet";
+const DEPOSIT_WALLET_VERSION: &str = "1";
+const ORDER_TYPE_STRING: &str = concat!(
+    "Order(uint256 salt,address maker,address signer,uint256 tokenId,",
+    "uint256 makerAmount,uint256 takerAmount,uint8 side,uint8 signatureType,",
+    "uint256 timestamp,bytes32 metadata,bytes32 builder)"
+);
+const SOLADY_TYPE_STRING: &str = concat!(
+    "TypedDataSign(Order contents,string name,string version,uint256 chainId,",
+    "address verifyingContract,bytes32 salt)",
+    "Order(uint256 salt,address maker,address signer,uint256 tokenId,",
+    "uint256 makerAmount,uint256 takerAmount,uint8 side,uint8 signatureType,",
+    "uint256 timestamp,bytes32 metadata,bytes32 builder)"
+);
 
 const TERMINAL_CURSOR: &str = "LTE="; // base64("-1")
 
 pub(crate) const ORDER_VERSION_MISMATCH_ERROR: &str = "order_version_mismatch";
+
+fn push_hex(out: &mut String, bytes: &[u8]) {
+    const LUT: &[u8; 16] = b"0123456789abcdef";
+    out.reserve(bytes.len() * 2);
+    for byte in bytes {
+        out.push(LUT[(byte >> 4) as usize] as char);
+        out.push(LUT[(byte & 0x0f) as usize] as char);
+    }
+}
+
+fn signature_hex_no_prefix(signature: &Signature) -> String {
+    let signature = signature.to_string();
+    signature
+        .strip_prefix("0x")
+        .unwrap_or(&signature)
+        .to_owned()
+}
 
 /// The type used to build a request to authenticate the inner [`Client<Unauthorized>`]. Calling
 /// `authenticate` on this will elevate that inner `client` into an [`Client<Authenticated<K>>`].
@@ -87,8 +120,8 @@ pub struct AuthenticationBuilder<'signer, S: Signer, K: Kind = Normal> {
     /// headers for different types of authentication, e.g. Builder.
     kind: K,
     /// The optional [`Address`] used to represent the funder for this `client`. If a funder is set
-    /// then `signature_type` must match `Some(SignatureType::Proxy | Signature::GnosisSafe)`. Conversely,
-    /// if funder is not set, then `signature_type` must be `Some(SignatureType::Eoa)`.
+    /// then `signature_type` must match `Some(SignatureType::Proxy | SignatureType::GnosisSafe | SignatureType::Poly1271)`.
+    /// Conversely, if funder is not set, then `signature_type` must be `Some(SignatureType::Eoa)`.
     funder: Option<Address>,
     /// The optional [`SignatureType`], see `funder` for more information.
     signature_type: Option<SignatureType>,
@@ -179,9 +212,18 @@ impl<S: Signer, K: Kind> AuthenticationBuilder<'_, S, K> {
                     "Cannot have a funder address with a {sig} signature type"
                 )));
             }
+            (None, Some(SignatureType::Poly1271)) => {
+                return Err(Error::validation(
+                    "A deposit wallet funder address is required with a Poly1271 signature type",
+                ));
+            }
             (
                 Some(Address::ZERO),
-                Some(sig @ (SignatureType::Proxy | SignatureType::GnosisSafe)),
+                Some(
+                    sig @ (SignatureType::Proxy
+                    | SignatureType::GnosisSafe
+                    | SignatureType::Poly1271),
+                ),
             ) => {
                 return Err(Error::validation(format!(
                     "Cannot have a zero funder address with a {sig} signature type"
@@ -913,8 +955,8 @@ impl<S: State> Client<S> {
         Ok(response)
     }
 
-    /// Resolves the V1 `feeRateBps` to apply to an order. Mirrors the TS client's
-    /// `_resolveFeeRateBps`: fetches the market rate via [`Self::fee_rate_bps`] and,
+    /// Resolves the V1 `feeRateBps` to apply to an order: fetches the market rate via
+    /// [`Self::fee_rate_bps`] and,
     /// when the caller supplied an override, validates that it matches.
     ///
     /// # Errors
@@ -1714,9 +1756,15 @@ impl<K: Kind> Client<Authenticated<K>> {
                     verifying_contract: Some(exchange),
                     ..Eip712Domain::default()
                 };
-                signer
-                    .sign_hash(&p.order.eip712_signing_hash(&domain))
-                    .await?
+                if p.order.signatureType == SignatureType::Poly1271 as u8 {
+                    self.sign_poly1271_order(signer, &p.order, &domain, chain_id)
+                        .await?
+                } else {
+                    signer
+                        .sign_hash(&p.order.eip712_signing_hash(&domain))
+                        .await?
+                        .into()
+                }
             }
             OrderPayload::V1(p) => {
                 let domain = Eip712Domain {
@@ -1729,6 +1777,7 @@ impl<K: Kind> Client<Authenticated<K>> {
                 signer
                     .sign_hash(&p.order.eip712_signing_hash(&domain))
                     .await?
+                    .into()
             }
         };
 
@@ -1740,6 +1789,51 @@ impl<K: Kind> Client<Authenticated<K>> {
             post_only,
             defer_exec,
         })
+    }
+
+    async fn sign_poly1271_order<S: Signer>(
+        &self,
+        signer: &S,
+        order: &crate::clob::types::OrderV2,
+        app_domain: &Eip712Domain,
+        chain_id: u64,
+    ) -> Result<OrderSignature> {
+        let contents_hash = order.eip712_hash_struct();
+        let app_domain_separator = app_domain.hash_struct();
+
+        let typed_data_sign_struct_hash = keccak256(
+            (
+                keccak256(SOLADY_TYPE_STRING.as_bytes()),
+                contents_hash,
+                keccak256(DEPOSIT_WALLET_NAME.as_bytes()),
+                keccak256(DEPOSIT_WALLET_VERSION.as_bytes()),
+                U256::from(chain_id),
+                order.signer,
+                B256::ZERO,
+            )
+                .abi_encode(),
+        );
+
+        let mut digest_input = [0_u8; 66];
+        digest_input[0] = 0x19;
+        digest_input[1] = 0x01;
+        digest_input[2..34].copy_from_slice(app_domain_separator.as_slice());
+        digest_input[34..66].copy_from_slice(typed_data_sign_struct_hash.as_slice());
+        let digest = keccak256(digest_input);
+
+        let inner_signature = signer.sign_hash(&digest).await?;
+        let mut wrapped =
+            String::with_capacity(2 + 130 + 64 + 64 + (ORDER_TYPE_STRING.len() * 2) + 4);
+        wrapped.push_str("0x");
+        wrapped.push_str(&signature_hex_no_prefix(&inner_signature));
+        push_hex(&mut wrapped, app_domain_separator.as_slice());
+        push_hex(&mut wrapped, contents_hash.as_slice());
+        push_hex(&mut wrapped, ORDER_TYPE_STRING.as_bytes());
+        let contents_type_len =
+            u16::try_from(ORDER_TYPE_STRING.len()).expect("order type string length fits in u16");
+        push_hex(&mut wrapped, &contents_type_len.to_be_bytes());
+
+        Ok(OrderSignature::Wrapped(wrapped))
     }
 
     /// Posts a signed order to the orderbook.

--- a/src/clob/order_builder.rs
+++ b/src/clob/order_builder.rs
@@ -158,6 +158,15 @@ impl<OrderKind, K: AuthKind> OrderBuilder<OrderKind, K> {
     ) -> Result<OrderPayload> {
         let version = self.client.resolve_version(false).await?;
         let maker = self.funder.unwrap_or(self.signer);
+        let signer = if matches!(self.signature_type, SignatureType::Poly1271) {
+            self.funder.ok_or_else(|| {
+                Error::validation(
+                    "A deposit wallet funder address is required with a Poly1271 signature type",
+                )
+            })?
+        } else {
+            self.signer
+        };
 
         match version {
             1 => {
@@ -194,7 +203,7 @@ impl<OrderKind, K: AuthKind> OrderBuilder<OrderKind, K> {
                     OrderV2 {
                         salt: U256::from(salt),
                         maker,
-                        signer: self.signer,
+                        signer,
                         tokenId: token_id,
                         makerAmount: U256::from(maker_amount),
                         takerAmount: U256::from(taker_amount),
@@ -378,19 +387,17 @@ impl<K: AuthKind> OrderBuilder<Limit, K> {
         let order = self.build().await?;
         let signed = client.sign(signer, order).await?;
         let result = client.post_order(signed).await;
-        if let Err(err) = &result {
-            if let Some(status) = err.downcast_ref::<crate::error::Status>() {
-                if status
-                    .message
-                    .contains(crate::clob::client::ORDER_VERSION_MISMATCH_ERROR)
-                {
-                    let after_version = client.resolve_version(false).await.unwrap_or(0);
-                    if after_version != before_version {
-                        let order = retry.build().await?;
-                        let signed = client.sign(signer, order).await?;
-                        return client.post_order(signed).await;
-                    }
-                }
+        if let Err(err) = &result
+            && let Some(status) = err.downcast_ref::<crate::error::Status>()
+            && status
+                .message
+                .contains(crate::clob::client::ORDER_VERSION_MISMATCH_ERROR)
+        {
+            let after_version = client.resolve_version(false).await.unwrap_or(0);
+            if after_version != before_version {
+                let order = retry.build().await?;
+                let signed = client.sign(signer, order).await?;
+                return client.post_order(signed).await;
             }
         }
         result
@@ -633,19 +640,17 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
         let order = self.build().await?;
         let signed = client.sign(signer, order).await?;
         let result = client.post_order(signed).await;
-        if let Err(err) = &result {
-            if let Some(status) = err.downcast_ref::<crate::error::Status>() {
-                if status
-                    .message
-                    .contains(crate::clob::client::ORDER_VERSION_MISMATCH_ERROR)
-                {
-                    let after_version = client.resolve_version(false).await.unwrap_or(0);
-                    if after_version != before_version {
-                        let order = retry.build().await?;
-                        let signed = client.sign(signer, order).await?;
-                        return client.post_order(signed).await;
-                    }
-                }
+        if let Err(err) = &result
+            && let Some(status) = err.downcast_ref::<crate::error::Status>()
+            && status
+                .message
+                .contains(crate::clob::client::ORDER_VERSION_MISMATCH_ERROR)
+        {
+            let after_version = client.resolve_version(false).await.unwrap_or(0);
+            if after_version != before_version {
+                let order = retry.build().await?;
+                let signed = client.sign(signer, order).await?;
+                return client.post_order(signed).await;
             }
         }
         result

--- a/src/clob/types/mod.rs
+++ b/src/clob/types/mod.rs
@@ -649,11 +649,92 @@ pub struct SignableOrder {
 #[derive(Debug, Builder, PartialEq)]
 pub struct SignedOrder {
     pub payload: OrderPayload,
-    pub signature: Signature,
+    #[builder(into)]
+    pub signature: OrderSignature,
     pub order_type: OrderType,
     pub owner: ApiKey,
     pub post_only: Option<bool>,
     pub defer_exec: Option<bool>,
+}
+
+/// Signature material attached to a signed order.
+///
+/// Most orders carry a normal 65-byte ECDSA signature. Deposit wallet orders
+/// using [`SignatureType::Poly1271`] carry the longer wrapped signature that the
+/// deposit wallet validates through EIP-1271.
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq)]
+pub enum OrderSignature {
+    Ecdsa(Signature),
+    Wrapped(String),
+}
+
+impl OrderSignature {
+    /// Returns the ECDSA `r` value for a normal order signature.
+    ///
+    /// # Panics
+    ///
+    /// Panics when called on a wrapped deposit wallet signature.
+    #[must_use]
+    pub fn r(&self) -> U256 {
+        match self {
+            OrderSignature::Ecdsa(sig) => sig.r(),
+            OrderSignature::Wrapped(_) => {
+                panic!("wrapped deposit wallet signatures do not expose an ECDSA r value")
+            }
+        }
+    }
+
+    /// Returns the ECDSA `s` value for a normal order signature.
+    ///
+    /// # Panics
+    ///
+    /// Panics when called on a wrapped deposit wallet signature.
+    #[must_use]
+    pub fn s(&self) -> U256 {
+        match self {
+            OrderSignature::Ecdsa(sig) => sig.s(),
+            OrderSignature::Wrapped(_) => {
+                panic!("wrapped deposit wallet signatures do not expose an ECDSA s value")
+            }
+        }
+    }
+}
+
+impl From<Signature> for OrderSignature {
+    fn from(signature: Signature) -> Self {
+        OrderSignature::Ecdsa(signature)
+    }
+}
+
+impl From<String> for OrderSignature {
+    fn from(signature: String) -> Self {
+        OrderSignature::Wrapped(signature)
+    }
+}
+
+impl From<&str> for OrderSignature {
+    fn from(signature: &str) -> Self {
+        OrderSignature::Wrapped(signature.to_owned())
+    }
+}
+
+impl fmt::Display for OrderSignature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OrderSignature::Ecdsa(sig) => write!(f, "{sig}"),
+            OrderSignature::Wrapped(sig) => f.write_str(sig),
+        }
+    }
+}
+
+impl PartialEq<Signature> for OrderSignature {
+    fn eq(&self, other: &Signature) -> bool {
+        match self {
+            OrderSignature::Ecdsa(sig) => sig == other,
+            OrderSignature::Wrapped(_) => false,
+        }
+    }
 }
 
 /// V2 `order` body with the signature folded in.
@@ -944,7 +1025,7 @@ mod tests {
     fn signed_order_serialization_omits_post_only_when_none() {
         let signed_order = SignedOrder {
             payload: OrderPayload::default(),
-            signature: Signature::new(U256::ZERO, U256::ZERO, false),
+            signature: Signature::new(U256::ZERO, U256::ZERO, false).into(),
             order_type: OrderType::GTC,
             owner: ApiKey::nil(),
             post_only: None,
@@ -964,7 +1045,7 @@ mod tests {
     fn signed_order_serialization_includes_fields() {
         let signed_order = SignedOrder {
             payload: OrderPayload::default(),
-            signature: Signature::new(U256::ZERO, U256::ZERO, false),
+            signature: Signature::new(U256::ZERO, U256::ZERO, false).into(),
             order_type: OrderType::GTC,
             owner: ApiKey::nil(),
             post_only: None,
@@ -986,5 +1067,26 @@ mod tests {
         assert!(!order_obj.contains_key("feeRateBps"));
         // deferExec should be present
         assert!(object.contains_key("deferExec"));
+    }
+
+    #[test]
+    fn signed_order_serialization_uses_wrapped_signature() {
+        let signed_order = SignedOrder {
+            payload: OrderPayload::default(),
+            signature: OrderSignature::Wrapped("0xwrapped".to_owned()),
+            order_type: OrderType::GTC,
+            owner: ApiKey::nil(),
+            post_only: None,
+            defer_exec: None,
+        };
+
+        let value = to_value(&signed_order).expect("serialize SignedOrder");
+        let order_obj = value
+            .as_object()
+            .and_then(|object| object.get("order"))
+            .and_then(serde_json::Value::as_object)
+            .expect("order object");
+
+        assert_eq!(order_obj["signature"], "0xwrapped");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,14 +59,14 @@ pub(crate) type Timestamp = i64;
 static CONFIG: phf::Map<ChainId, ContractConfig> = phf_map! {
     137_u64 => ContractConfig {
         exchange: address!("0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E"),
-        collateral: address!("0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"),
+        collateral: address!("0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB"),
         conditional_tokens: address!("0x4D97DCd97eC945f40cF65F87097ACe5EA0476045"),
         neg_risk_adapter: None,
         exchange_v2: Some(address!("0xE111180000d2663C0091e4f400237545B87B996B")),
     },
     80002_u64 => ContractConfig {
         exchange: address!("0xdFE02Eb6733538f8Ea35D585af8DE5958AD99E40"),
-        collateral: address!("0x9c4e1703476e875070ee25b56a58b008cfb8fa78"),
+        collateral: address!("0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB"),
         conditional_tokens: address!("0x69308FB512518e39F9b16112fA8d994F4e2Bf8bB"),
         neg_risk_adapter: None,
         exchange_v2: Some(address!("0xE111180000d2663C0091e4f400237545B87B996B")),
@@ -76,14 +76,14 @@ static CONFIG: phf::Map<ChainId, ContractConfig> = phf_map! {
 static NEG_RISK_CONFIG: phf::Map<ChainId, ContractConfig> = phf_map! {
     137_u64 => ContractConfig {
         exchange: address!("0xC5d563A36AE78145C45a50134d48A1215220f80a"),
-        collateral: address!("0x2791bca1f2de4661ed88a30c99a7a9449aa84174"),
+        collateral: address!("0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB"),
         conditional_tokens: address!("0x4D97DCd97eC945f40cF65F87097ACe5EA0476045"),
         neg_risk_adapter: Some(address!("0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296")),
         exchange_v2: Some(address!("0xe2222d279d744050d28e00520010520000310F59")),
     },
     80002_u64 => ContractConfig {
-        exchange: address!("0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296"),
-        collateral: address!("0x9c4e1703476e875070ee25b56a58b008cfb8fa78"),
+        exchange: address!("0xC5d563A36AE78145C45a50134d48A1215220f80a"),
+        collateral: address!("0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB"),
         conditional_tokens: address!("0x69308FB512518e39F9b16112fA8d994F4e2Bf8bB"),
         neg_risk_adapter: Some(address!("0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296")),
         exchange_v2: Some(address!("0xe2222d279d744050d28e00520010520000310F59")),
@@ -319,6 +319,10 @@ mod tests {
             cfg.exchange,
             address!("0xdFE02Eb6733538f8Ea35D585af8DE5958AD99E40")
         );
+        assert_eq!(
+            cfg.collateral,
+            address!("0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB")
+        );
     }
 
     #[test]
@@ -326,7 +330,11 @@ mod tests {
         let cfg = contract_config(AMOY, true).expect("missing config");
         assert_eq!(
             cfg.exchange,
-            address!("0xd91e80cf2e7be2e162c6513ced06f1dd0da35296")
+            address!("0xC5d563A36AE78145C45a50134d48A1215220f80a")
+        );
+        assert_eq!(
+            cfg.collateral,
+            address!("0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB")
         );
     }
 

--- a/tests/order.rs
+++ b/tests/order.rs
@@ -339,6 +339,33 @@ mod lifecycle {
             "Cannot have a zero funder address with a GnosisSafe signature type"
         );
 
+        let err = Client::new(&server.base_url(), Config::default())?
+            .authentication_builder(&signer)
+            .signature_type(SignatureType::Poly1271)
+            .authenticate()
+            .await
+            .unwrap_err();
+        let msg = &err.downcast_ref::<Validation>().unwrap().reason;
+
+        assert_eq!(
+            msg,
+            "A deposit wallet funder address is required with a Poly1271 signature type"
+        );
+
+        let err = Client::new(&server.base_url(), Config::default())?
+            .authentication_builder(&signer)
+            .funder(Address::ZERO)
+            .signature_type(SignatureType::Poly1271)
+            .authenticate()
+            .await
+            .unwrap_err();
+        let msg = &err.downcast_ref::<Validation>().unwrap().reason;
+
+        assert_eq!(
+            msg,
+            "Cannot have a zero funder address with a Poly1271 signature type"
+        );
+
         Ok(())
     }
 
@@ -3428,6 +3455,8 @@ mod v2 {
                 .await?;
 
             let order = &signable.v2().order;
+            assert_eq!(order.maker, funder);
+            assert_eq!(order.signer, funder);
             assert_eq!(order.signatureType, SignatureType::Poly1271 as u8);
 
             Ok(())
@@ -3860,12 +3889,27 @@ mod v2 {
     mod signing {
         use alloy::signers::Signer as _;
         use alloy::signers::local::LocalSigner;
-        use polymarket_client_sdk_v2::POLYGON;
+        use polymarket_client_sdk_v2::auth::Credentials;
+        use polymarket_client_sdk_v2::clob::types::{OrderPayload, OrderV2, SignableOrder};
         use polymarket_client_sdk_v2::clob::{Client, Config};
+        use polymarket_client_sdk_v2::{AMOY, POLYGON};
         use serde_json::json;
 
         use super::*;
         use crate::common::{API_KEY, PASSPHRASE, POLY_ADDRESS, PRIVATE_KEY, SECRET};
+
+        const EXPECTED_POLY_1271_SIGNATURE: &str = concat!(
+            "0xa3a093c83b6c20c83355c16ce94c92e6e9fcbdeb840618cc74f6c57a42ad145b",
+            "2b98db73d2c73cbf1f2b6af288566ae81960ddbc3a13921027358a8bff3be6ff1c",
+            "a440cbd865bc0c6243d7a8df9a8bf48a8827b0a4abbb61c30e96d305423af148",
+            "d23d42d3ad94e65d78258cecaf8dcbaddac0f73dc085040f2c12bb595dd83804",
+            "4f726465722875696e743235362073616c742c61646472657373206d616b65722c",
+            "61646472657373207369676e65722c75696e7432353620746f6b656e49642c75",
+            "696e74323536206d616b6572416d6f756e742c75696e743235362074616b6572",
+            "416d6f756e742c75696e743820736964652c75696e7438207369676e61747572",
+            "65547970652c75696e743235362074696d657374616d702c6279746573333220",
+            "6d657461646174612c62797465733332206275696c6465722900ba"
+        );
 
         #[tokio::test]
         async fn v2_sign_produces_valid_signature() -> anyhow::Result<()> {
@@ -3915,6 +3959,59 @@ mod v2 {
 
             // Verify owner is set
             assert_eq!(signed.owner, API_KEY);
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn v2_poly1271_signing_matches_deposit_wallet_signature() -> anyhow::Result<()> {
+            let server = MockServer::start();
+            let signer = LocalSigner::from_str(PRIVATE_KEY)?.with_chain_id(Some(AMOY));
+            let deposit_wallet = address!("0x1111111111111111111111111111111111111111");
+
+            let client = Client::new(&server.base_url(), Config::default())?
+                .authentication_builder(&signer)
+                .credentials(Credentials::new(
+                    API_KEY,
+                    SECRET.to_owned(),
+                    PASSPHRASE.to_owned(),
+                ))
+                .funder(deposit_wallet)
+                .signature_type(SignatureType::Poly1271)
+                .authenticate()
+                .await?;
+
+            server.mock(|when, then| {
+                when.method(httpmock::Method::GET).path("/neg-risk");
+                then.status(StatusCode::OK)
+                    .json_body(json!({ "neg_risk": false }));
+            });
+
+            let mut order = OrderV2::default();
+            order.salt = U256::from(479_249_096_354_u64);
+            order.maker = deposit_wallet;
+            order.signer = deposit_wallet;
+            order.tokenId = U256::from(1234_u64);
+            order.makerAmount = U256::from(100_000_000_u64);
+            order.takerAmount = U256::from(50_000_000_u64);
+            order.side = Side::Buy as u8;
+            order.signatureType = SignatureType::Poly1271 as u8;
+            order.timestamp = U256::from(1_710_000_000_000_u64);
+            order.metadata = B256::ZERO;
+            order.builder = B256::ZERO;
+
+            let signable = SignableOrder::builder()
+                .payload(OrderPayload::new(order, U256::ZERO))
+                .order_type(OrderType::GTC)
+                .build();
+
+            let signed = client.sign(&signer, signable).await?;
+
+            assert_eq!(signed.signature.to_string(), EXPECTED_POLY_1271_SIGNATURE);
+            assert_eq!(
+                signed.signature.to_string().len(),
+                2 + 130 + 64 + 64 + (186 * 2) + 4
+            );
 
             Ok(())
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new signature format and signing path for `SignatureType::Poly1271`, which directly affects order authentication/signing correctness. Also updates on-chain contract config addresses, which can impact approvals and trading behavior if misconfigured.
> 
> **Overview**
> Adds deposit wallet order support via `SignatureType::Poly1271`: authentication now validates a required non-zero `funder`, V2 order building sets `maker`/`signer` to the deposit wallet, and `Client::sign` can emit a new wrapped EIP-1271-compatible signature (`OrderSignature`) instead of a plain ECDSA signature.
> 
> Updates crate version to `0.6.0-canary.1`, documents deposit wallet usage in `README.md`, adds a `gtc_limit_buy_deposit_wallet` example, and expands tests to cover Poly1271 validation, serialization, and deterministic wrapped signature generation.
> 
> Adjusts Polygon/Amoy contract config (notably `collateral` and Amoy neg-risk `exchange`) and updates related config assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c5e10c7aa91c60223f5719004bb181ebd15afac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->