### PR TITLE
fix(clob): accept "" as Decimal::ZERO for fee_rate_bps on V2 trade responses

### DIFF
--- a/src/clob/types/response.rs
+++ b/src/clob/types/response.rs
@@ -21,6 +21,28 @@ use crate::clob::types::{OrderStatusType, OrderType, Side, TickSize, TradeStatus
 use crate::serde_helpers::StringFromAny;
 use crate::types::{Address, B256, Decimal, U256};
 
+/// Deserialize a `Decimal` while accepting the empty string `""` as
+/// `Decimal::ZERO`.
+///
+/// V2 production CLOB returns `""` for `fee_rate_bps` on trade responses
+/// because per-order fees are protocol-controlled in V2 — the field is
+/// effectively informational. Strict `Decimal` parsing rejects `""` and
+/// fails the entire `Page<TradeResponse>` deserialization, which is a
+/// poor failure mode for a deprecated field.
+fn deserialize_decimal_empty_as_zero<'de, D>(
+    deserializer: D,
+) -> core::result::Result<Decimal, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    if s.is_empty() {
+        Ok(Decimal::ZERO)
+    } else {
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
 #[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, Builder, PartialEq)]
 pub struct MidpointResponse {
@@ -388,6 +410,13 @@ pub struct TradeResponse {
     pub asset_id: U256,
     pub side: Side,
     pub size: Decimal,
+    /// Per-trade fee rate in basis points.
+    ///
+    /// **V2 note:** fees are protocol-controlled per market and no longer
+    /// per-trade, so the production server may return `""` here. The
+    /// custom deserializer maps `""` → `Decimal::ZERO` so this doesn't
+    /// fail the whole response.
+    #[serde(deserialize_with = "deserialize_decimal_empty_as_zero")]
     pub fee_rate_bps: Decimal,
     pub price: Decimal,
     pub status: TradeStatusType,
@@ -518,6 +547,13 @@ pub struct MakerOrder {
     pub maker_address: Address,
     pub matched_amount: Decimal,
     pub price: Decimal,
+    /// Per-maker-order fee rate in basis points.
+    ///
+    /// **V2 note:** fees are protocol-controlled per market and no longer
+    /// per-maker, so the production server may return `""` here. The
+    /// custom deserializer maps `""` → `Decimal::ZERO` so this doesn't
+    /// fail the whole response.
+    #[serde(deserialize_with = "deserialize_decimal_empty_as_zero")]
     pub fee_rate_bps: Decimal,
     pub asset_id: U256,
     pub outcome: String,

--- a/src/clob/types/response.rs
+++ b/src/clob/types/response.rs
@@ -21,28 +21,6 @@ use crate::clob::types::{OrderStatusType, OrderType, Side, TickSize, TradeStatus
 use crate::serde_helpers::StringFromAny;
 use crate::types::{Address, B256, Decimal, U256};
 
-/// Deserialize a `Decimal` while accepting the empty string `""` as
-/// `Decimal::ZERO`.
-///
-/// V2 production CLOB returns `""` for `fee_rate_bps` on trade responses
-/// because per-order fees are protocol-controlled in V2 — the field is
-/// effectively informational. Strict `Decimal` parsing rejects `""` and
-/// fails the entire `Page<TradeResponse>` deserialization, which is a
-/// poor failure mode for a deprecated field.
-fn deserialize_decimal_empty_as_zero<'de, D>(
-    deserializer: D,
-) -> core::result::Result<Decimal, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s = String::deserialize(deserializer)?;
-    if s.is_empty() {
-        Ok(Decimal::ZERO)
-    } else {
-        s.parse().map_err(serde::de::Error::custom)
-    }
-}
-
 #[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, Builder, PartialEq)]
 pub struct MidpointResponse {
@@ -416,7 +394,7 @@ pub struct TradeResponse {
     /// per-trade, so the production server may return `""` here. The
     /// custom deserializer maps `""` → `Decimal::ZERO` so this doesn't
     /// fail the whole response.
-    #[serde(deserialize_with = "deserialize_decimal_empty_as_zero")]
+    #[serde(deserialize_with = "empty_string_as_zero")]
     pub fee_rate_bps: Decimal,
     pub price: Decimal,
     pub status: TradeStatusType,
@@ -553,7 +531,7 @@ pub struct MakerOrder {
     /// per-maker, so the production server may return `""` here. The
     /// custom deserializer maps `""` → `Decimal::ZERO` so this doesn't
     /// fail the whole response.
-    #[serde(deserialize_with = "deserialize_decimal_empty_as_zero")]
+    #[serde(deserialize_with = "empty_string_as_zero")]
     pub fee_rate_bps: Decimal,
     pub asset_id: U256,
     pub outcome: String,

--- a/tests/clob.rs
+++ b/tests/clob.rs
@@ -2146,6 +2146,74 @@ mod authenticated {
     }
 
     #[tokio::test]
+    async fn trades_should_handle_empty_fee_rate_bps() -> anyhow::Result<()> {
+        // Regression test: V2 production CLOB returns "" for fee_rate_bps on
+        // both TradeResponse and the nested MakerOrder, because fees are
+        // protocol-controlled per market in V2 and no longer per-trade.
+        // Strict Decimal deserialization rejected "" and failed the entire
+        // Page<TradeResponse>; the lenient deserializer maps "" -> 0.
+        let server = MockServer::start();
+        let client = create_authenticated(&server).await?;
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/data/trades");
+            then.status(StatusCode::OK).json_body(json!({
+                "data": [
+                    {
+                        "id": "1",
+                        "taker_order_id": "taker_123",
+                        "market": "0x000000000000000000000000000000000000000000000000000000006d61726b",
+                        "asset_id": token_1(),
+                        "side": "BUY",
+                        "size": "12.5",
+                        "fee_rate_bps": "",
+                        "price": "0.42",
+                        "status": "MATCHED",
+                        "match_time": "1705322096",
+                        "last_update": "1705322130",
+                        "outcome": "YES",
+                        "bucket_index": 2,
+                        "owner": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+                        "maker_address": "0x2222222222222222222222222222222222222222",
+                        "maker_orders": [
+                            {
+                                "order_id": "maker_001",
+                                "owner": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+                                "maker_address": "0x4444444444444444444444444444444444444444",
+                                "matched_amount": "5.0",
+                                "price": "0.42",
+                                "fee_rate_bps": "",
+                                "asset_id": token_1(),
+                                "outcome": "YES",
+                                "side": "SELL"
+                            }
+                        ],
+                        "transaction_hash": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+                        "trader_side": "TAKER"
+                    }
+                ],
+                "limit": 1,
+                "count": 1,
+                "next_cursor": "next"
+            }));
+        });
+
+        let request = TradesRequest::builder().build();
+        let response = client.trades(&request, None).await?;
+        mock.assert();
+
+        assert_eq!(response.data.len(), 1);
+        assert_eq!(response.data[0].fee_rate_bps, dec!(0));
+        assert_eq!(response.data[0].maker_orders.len(), 1);
+        assert_eq!(response.data[0].maker_orders[0].fee_rate_bps, dec!(0));
+        // Other Decimal fields still parse strictly.
+        assert_eq!(response.data[0].size, dec!(12.5));
+        assert_eq!(response.data[0].price, dec!(0.42));
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn notifications_should_succeed() -> anyhow::Result<()> {
         let server = MockServer::start();
         let client = create_authenticated(&server).await?;


### PR DESCRIPTION
## Summary

Fixes #34. V2 production CLOB (`https://clob.polymarket.com`) returns `""` for `fee_rate_bps` on both `TradeResponse` and the nested `MakerOrder`, because per-trade/per-maker fees are protocol-controlled per market in V2 — the field is effectively informational ([V2 migration guide](https://docs.polymarket.com/v2-migration)). Strict `Decimal` deserialization rejected `""` and failed the entire `Page<TradeResponse>` with `invalid value: string ""`, blocking any caller that hits a trade response with this shape.

## Change

A lenient deserializer maps `""` → `Decimal::ZERO` so a deprecated informational field can't break the whole response. Applied to:
- `TradeResponse.fee_rate_bps`
- `MakerOrder.fee_rate_bps`

Other `Decimal` fields (`size`, `price`, `matched_amount`) remain strict — only `fee_rate_bps` gets the empty-string allowance, since it's the field V2 explicitly deprecates.

## Test plan

- [x] New regression test `trades_should_handle_empty_fee_rate_bps` exercising `""` for both the top-level and nested fields
- [x] Existing `trades_should_succeed` (with `"5"` value) still passes — strict parsing preserved for non-empty inputs
- [x] `cargo build --features clob,data,ctf,tracing`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --features clob,data,ctf,tracing --tests`

## Real-world impact this addresses

In a downstream live-trading project, the bug caused ~22k retry-loop warnings in 16h on production from 2 stuck `order_id`s that fell back to the HTTP trade-history reconcile path after WS fill-confirmation drops. The retry storm propagated to a single-leg unwind subsystem that drained one exchange's positions on plans where reconcile kept failing, leaving naked directional exposure on the other exchange that had to be manually flattened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrowly relaxes deserialization for `fee_rate_bps` on trade responses to tolerate V2 servers returning an empty string, with regression coverage; other decimal parsing remains strict.
> 
> **Overview**
> Fixes V2 trade-history deserialization by allowing `fee_rate_bps` to be returned as `""` and mapping it to `Decimal::ZERO` on both `TradeResponse` and nested `MakerOrder`.
> 
> Adds a regression test ensuring `GET /data/trades` succeeds when `fee_rate_bps` is empty while other `Decimal` fields (e.g., `size`, `price`) continue to parse strictly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e86f6bbec6a913840c45ff47582ede578cf2a515. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->