### PR TITLE
feat: slippage-fee-calculation

### DIFF
--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -2932,8 +2932,8 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use crate::auth::{Credentials, Normal};
     use crate::auth::state::Authenticated;
+    use crate::auth::{Credentials, Normal};
     use crate::clob::types::response::FeeInfo;
 
     #[test]
@@ -2987,9 +2987,8 @@ mod tests {
     // ── Integration: order builder fee adjustment ─────────────────────────────
 
     const TEST_TOKEN_ID: u64 = 123;
-    const TEST_SIGNER: Address = alloy::primitives::address!(
-        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
-    );
+    const TEST_SIGNER: Address =
+        alloy::primitives::address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
 
     fn make_cached_client(fee_slippage: Decimal) -> Client<Authenticated<Normal>> {
         let config = Config {
@@ -3004,9 +3003,13 @@ mod tests {
         inner
             .tick_sizes
             .insert(token_id, crate::clob::types::TickSize::Hundredth);
-        inner
-            .fee_infos
-            .insert(token_id, FeeInfo { rate: dec!(0.25), exponent: 2 });
+        inner.fee_infos.insert(
+            token_id,
+            FeeInfo {
+                rate: dec!(0.25),
+                exponent: 2,
+            },
+        );
         inner.neg_risk.insert(token_id, false);
         inner.cached_version.store(2, Ordering::Relaxed);
 

--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -3070,10 +3070,10 @@ mod tests {
     async fn v2_buy_market_with_balance_and_fee_slippage() {
         // amount=50, user_usdc_balance=50, fee_slippage=20, price=0.5
         // adjusted_raw = 50 - 1.875 = 48.125
-        // trunc to LOT_SIZE_SCALE(2) → 48.12
-        // shares = 48.12 / 0.5 = 96.24, trunc(4) → 96.24
-        // makerAmount = 48.12 → 48_120_000
-        // takerAmount = 96.24 → 96_240_000
+        // trunc to USDC_DECIMALS(6) → 48.125
+        // shares = 48.125 / 0.5 = 96.25, trunc(4) → 96.25
+        // makerAmount = 48.125 → 48_125_000
+        // takerAmount = 96.25 → 96_250_000
         let client = make_cached_client(dec!(20));
         let order = client
             .market_order()
@@ -3087,8 +3087,8 @@ mod tests {
             .unwrap();
 
         let v2 = order.payload.as_v2().expect("V2 order");
-        assert_eq!(v2.makerAmount, U256::from(48_120_000_u64));
-        assert_eq!(v2.takerAmount, U256::from(96_240_000_u64));
+        assert_eq!(v2.makerAmount, U256::from(48_125_000_u64));
+        assert_eq!(v2.takerAmount, U256::from(96_250_000_u64));
     }
 
     #[tokio::test]

--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -421,6 +421,10 @@ pub struct Config {
     /// Default builder code inherited by orders built via [`Client::limit_order`] or
     /// [`Client::market_order`] when not set on the order itself.
     builder_code: Option<B256>,
+    /// Default fee slippage percentage (0 or 1–100) passed to every order builder.
+    /// Pads the platform-fee reserve to guard against price movement between signing and fill.
+    #[builder(default)]
+    pub(crate) fee_slippage: Decimal,
     #[cfg(feature = "heartbeats")]
     #[builder(default = Duration::from_secs(5))]
     /// How often the [`Client`] will automatically submit heartbeats. The default is five (5) seconds.
@@ -433,6 +437,7 @@ impl Default for Config {
             use_server_time: false,
             geoblock_host: None,
             builder_code: None,
+            fee_slippage: Decimal::ZERO,
             #[cfg(feature = "heartbeats")]
             heartbeat_interval: Duration::from_secs(5),
         }
@@ -1464,6 +1469,8 @@ impl Client<Unauthenticated> {
     /// # }
     /// ```
     pub fn new(host: &str, config: Config) -> Result<Client<Unauthenticated>> {
+        crate::clob::fees::validate_fee_slippage(config.fee_slippage)?;
+
         let mut headers = HeaderMap::new();
 
         headers.insert("User-Agent", HeaderValue::from_static("rs_clob_client"));
@@ -2902,6 +2909,7 @@ impl<K: Kind> Client<Authenticated<K>> {
             builder_code: self.inner.config.builder_code,
             defer_exec: None,
             user_usdc_balance: None,
+            fee_slippage: Some(self.inner.config.fee_slippage),
             taker: None,
             nonce: None,
             fee_rate_bps: None,
@@ -2917,10 +2925,210 @@ impl<K: Kind> Client<Authenticated<K>> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::Ordering;
+
+    use alloy::primitives::U256;
+    use rust_decimal_macros::dec;
+    use uuid::Uuid;
+
     use super::*;
+    use crate::auth::{Credentials, Normal};
+    use crate::auth::state::Authenticated;
+    use crate::clob::types::response::FeeInfo;
 
     #[test]
     fn client_default_should_succeed() {
         _ = Client::default();
+    }
+
+    // ── Config fee_slippage validation ────────────────────────────────────────
+
+    #[test]
+    fn config_fee_slippage_defaults_to_zero() {
+        assert_eq!(Config::default().fee_slippage, Decimal::ZERO);
+    }
+
+    #[test]
+    fn client_new_rejects_invalid_fee_slippage() {
+        let config = Config {
+            fee_slippage: dec!(0.5),
+            ..Config::default()
+        };
+        Client::new("https://clob-v2.polymarket.com", config).unwrap_err();
+    }
+
+    #[test]
+    fn client_new_rejects_fee_slippage_above_100() {
+        let config = Config {
+            fee_slippage: dec!(101),
+            ..Config::default()
+        };
+        Client::new("https://clob-v2.polymarket.com", config).unwrap_err();
+    }
+
+    #[test]
+    fn client_new_accepts_zero_fee_slippage() {
+        let config = Config {
+            fee_slippage: Decimal::ZERO,
+            ..Config::default()
+        };
+        Client::new("https://clob-v2.polymarket.com", config).unwrap();
+    }
+
+    #[test]
+    fn client_new_accepts_fee_slippage_in_range() {
+        let config = Config {
+            fee_slippage: dec!(20),
+            ..Config::default()
+        };
+        Client::new("https://clob-v2.polymarket.com", config).unwrap();
+    }
+
+    // ── Integration: order builder fee adjustment ─────────────────────────────
+
+    const TEST_TOKEN_ID: u64 = 123;
+    const TEST_SIGNER: Address = alloy::primitives::address!(
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    );
+
+    fn make_cached_client(fee_slippage: Decimal) -> Client<Authenticated<Normal>> {
+        let config = Config {
+            fee_slippage,
+            ..Config::default()
+        };
+        let unauth =
+            Client::<Unauthenticated>::new("https://clob-v2.polymarket.com", config).unwrap();
+        let inner = Arc::into_inner(unauth.inner).unwrap();
+
+        let token_id = U256::from(TEST_TOKEN_ID);
+        inner
+            .tick_sizes
+            .insert(token_id, crate::clob::types::TickSize::Hundredth);
+        inner
+            .fee_infos
+            .insert(token_id, FeeInfo { rate: dec!(0.25), exponent: 2 });
+        inner.neg_risk.insert(token_id, false);
+        inner.cached_version.store(2, Ordering::Relaxed);
+
+        Client {
+            inner: Arc::new(ClientInner {
+                state: Authenticated {
+                    address: TEST_SIGNER,
+                    credentials: Credentials::new(
+                        Uuid::nil(),
+                        "secret".into(),
+                        "passphrase".into(),
+                    ),
+                    kind: Normal,
+                },
+                config: inner.config,
+                host: inner.host,
+                geoblock_host: inner.geoblock_host,
+                client: inner.client,
+                tick_sizes: inner.tick_sizes,
+                neg_risk: inner.neg_risk,
+                fee_rate_bps: inner.fee_rate_bps,
+                fee_infos: inner.fee_infos,
+                token_condition_map: inner.token_condition_map,
+                builder_fee_rates: inner.builder_fee_rates,
+                cached_version: inner.cached_version,
+                funder: None,
+                signature_type: SignatureType::Eoa,
+                salt_generator: || 0,
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn v2_buy_limit_with_balance_and_fee_slippage() {
+        // user_usdc_balance=50, fee_slippage=20, price=0.5, size=100
+        // notional = 100 * 0.5 = 50 = balance → fee_base = 50
+        // effective_rate = 0.015625 * 1.2 = 0.01875
+        // platform_fee = (50/0.5) * 0.01875 = 1.875
+        // adjusted_notional = 50 - 1.875 = 48.125
+        // adjusted_size = 48.125 / 0.5 = 96.25
+        // makerAmount = trunc(96.25 * 0.5, 4) = 48.125 → 48_125_000
+        // takerAmount = 96.25 → 96_250_000
+        let client = make_cached_client(dec!(20));
+        let order = client
+            .limit_order()
+            .token_id(U256::from(TEST_TOKEN_ID))
+            .side(Side::Buy)
+            .price(dec!(0.5))
+            .size(dec!(100))
+            .user_usdc_balance(dec!(50))
+            .build()
+            .await
+            .unwrap();
+
+        let v2 = order.payload.as_v2().expect("V2 order");
+        assert_eq!(v2.makerAmount, U256::from(48_125_000_u64));
+        assert_eq!(v2.takerAmount, U256::from(96_250_000_u64));
+    }
+
+    #[tokio::test]
+    async fn v2_buy_market_with_balance_and_fee_slippage() {
+        // amount=50, user_usdc_balance=50, fee_slippage=20, price=0.5
+        // adjusted_raw = 50 - 1.875 = 48.125
+        // trunc to LOT_SIZE_SCALE(2) → 48.12
+        // shares = 48.12 / 0.5 = 96.24, trunc(4) → 96.24
+        // makerAmount = 48.12 → 48_120_000
+        // takerAmount = 96.24 → 96_240_000
+        let client = make_cached_client(dec!(20));
+        let order = client
+            .market_order()
+            .token_id(U256::from(TEST_TOKEN_ID))
+            .side(Side::Buy)
+            .price(dec!(0.5))
+            .amount(Amount::usdc(dec!(50)).unwrap())
+            .user_usdc_balance(dec!(50))
+            .build()
+            .await
+            .unwrap();
+
+        let v2 = order.payload.as_v2().expect("V2 order");
+        assert_eq!(v2.makerAmount, U256::from(48_120_000_u64));
+        assert_eq!(v2.takerAmount, U256::from(96_240_000_u64));
+    }
+
+    #[tokio::test]
+    async fn v2_buy_limit_without_balance_unchanged() {
+        // No user_usdc_balance → size * price = 100 * 0.5 = 50 unchanged
+        // makerAmount = 50_000_000, takerAmount = 100_000_000
+        let client = make_cached_client(dec!(20));
+        let order = client
+            .limit_order()
+            .token_id(U256::from(TEST_TOKEN_ID))
+            .side(Side::Buy)
+            .price(dec!(0.5))
+            .size(dec!(100))
+            .build()
+            .await
+            .unwrap();
+
+        let v2 = order.payload.as_v2().expect("V2 order");
+        assert_eq!(v2.makerAmount, U256::from(50_000_000_u64));
+        assert_eq!(v2.takerAmount, U256::from(100_000_000_u64));
+    }
+
+    #[tokio::test]
+    async fn v2_sell_limit_with_balance_unchanged() {
+        // SELL orders ignore user_usdc_balance — amounts are untouched.
+        // size=100, price=0.5 → makerAmount=100_000_000, takerAmount=50_000_000
+        let client = make_cached_client(dec!(20));
+        let order = client
+            .limit_order()
+            .token_id(U256::from(TEST_TOKEN_ID))
+            .side(Side::Sell)
+            .price(dec!(0.5))
+            .size(dec!(100))
+            .user_usdc_balance(dec!(50))
+            .build()
+            .await
+            .unwrap();
+
+        let v2 = order.payload.as_v2().expect("V2 order");
+        assert_eq!(v2.makerAmount, U256::from(100_000_000_u64));
+        assert_eq!(v2.takerAmount, U256::from(50_000_000_u64));
     }
 }

--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -3067,13 +3067,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn v2_buy_limit_when_notional_exceeds_balance() {
+        // price=0.51, size=100, balance=50, fee_slippage=20
+        // notional = 100 * 0.51 = 51 > balance=50 → fee_base = min(51,50) = 50
+        // platform_fee_rate = 0.25 * (0.51*0.49)^2 = 0.0156125025
+        // effective_rate = 0.0156125025 * 1.2 = 0.018735003
+        // platform_fee = (50/0.51) * 0.018735003 ≈ 1.836765
+        // adjusted_notional = 50 - 1.836765 ≈ 48.163235
+        // adjusted_size = 48.163235 / 0.51 ≈ 94.437 → trunc(2) = 94.43
+        // makerAmount = trunc(94.43 * 0.51, 4) = 48.1593 → 48_159_300
+        // takerAmount = 94.43 → 94_430_000
+        let client = make_cached_client(dec!(20));
+        let order = client
+            .limit_order()
+            .token_id(U256::from(TEST_TOKEN_ID))
+            .side(Side::Buy)
+            .price(dec!(0.51))
+            .size(dec!(100))
+            .user_usdc_balance(dec!(50))
+            .build()
+            .await
+            .unwrap();
+
+        let v2 = order.payload.as_v2().expect("V2 order");
+        assert_eq!(v2.makerAmount, U256::from(48_159_300_u64));
+        assert_eq!(v2.takerAmount, U256::from(94_430_000_u64));
+    }
+
+    #[tokio::test]
     async fn v2_buy_market_with_balance_and_fee_slippage() {
         // amount=50, user_usdc_balance=50, fee_slippage=20, price=0.5
         // adjusted_raw = 50 - 1.875 = 48.125
-        // trunc to USDC_DECIMALS(6) → 48.125
-        // shares = 48.125 / 0.5 = 96.25, trunc(4) → 96.25
-        // makerAmount = 48.125 → 48_125_000
-        // takerAmount = 96.25 → 96_250_000
+        // trunc to LOT_SIZE_SCALE(2) → 48.12
+        // shares = 48.12 / 0.5 = 96.24, trunc(4) → 96.24
+        // makerAmount = 48.12 → 48_120_000
+        // takerAmount = 96.24 → 96_240_000
         let client = make_cached_client(dec!(20));
         let order = client
             .market_order()
@@ -3087,8 +3115,8 @@ mod tests {
             .unwrap();
 
         let v2 = order.payload.as_v2().expect("V2 order");
-        assert_eq!(v2.makerAmount, U256::from(48_125_000_u64));
-        assert_eq!(v2.takerAmount, U256::from(96_250_000_u64));
+        assert_eq!(v2.makerAmount, U256::from(48_120_000_u64));
+        assert_eq!(v2.takerAmount, U256::from(96_240_000_u64));
     }
 
     #[tokio::test]

--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -3039,6 +3039,8 @@ mod tests {
                 signature_type: SignatureType::Eoa,
                 salt_generator: || 0,
             }),
+            #[cfg(feature = "heartbeats")]
+            heartbeat_token: DroppingCancellationToken(None),
         }
     }
 

--- a/src/clob/fees.rs
+++ b/src/clob/fees.rs
@@ -1,0 +1,374 @@
+//! Fee reservation utilities for buy orders.
+
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+
+use crate::Result;
+use crate::error::Error;
+
+/// Validates that `fee_slippage` is either 0 or a value in [1, 100].
+///
+/// Values like 0.5, negatives, or values above 100 are rejected because they produce
+/// nonsensical fee padding (sub-1% fractions are likely user error, negatives would
+/// reduce the reserve).
+pub fn validate_fee_slippage(fee_slippage: Decimal) -> Result<()> {
+    if fee_slippage.is_sign_negative()
+        || fee_slippage > dec!(100)
+        || (fee_slippage > Decimal::ZERO && fee_slippage < Decimal::ONE)
+    {
+        return Err(Error::validation(
+            "fee_slippage must be 0 or a percentage between 1 and 100",
+        ));
+    }
+    Ok(())
+}
+
+/// Conservatively adjusts a BUY USDC `amount` so that `amount + fees ≤ user_usdc_balance`.
+///
+/// Returns `amount` unchanged when the balance comfortably covers the total cost.
+/// Otherwise returns `balance − estimated_fees`, where fees are computed on
+/// `min(amount, balance)` so that an oversized `amount` does not inflate the reserve.
+///
+/// `fee_slippage` pads only the platform fee component (not the builder fee) to guard
+/// against on-chain price movement between signing and matching.
+///
+/// # Errors
+///
+/// Returns an error if `fee_slippage` is invalid (see [`validate_fee_slippage`]).
+#[expect(
+    clippy::module_name_repetitions,
+    reason = "name mirrors the Python reference implementation"
+)]
+pub fn adjust_buy_amount_for_fees(
+    amount: Decimal,
+    price: Decimal,
+    user_usdc_balance: Decimal,
+    fee_rate: Decimal,
+    fee_exponent: Decimal,
+    builder_taker_fee_rate: Decimal,
+    fee_slippage: Decimal,
+) -> Result<Decimal> {
+    validate_fee_slippage(fee_slippage)?;
+
+    let base = price * (Decimal::ONE - price);
+    let base_f64: f64 = base.try_into().unwrap_or(0.0);
+    let exp_f64: f64 = fee_exponent.try_into().unwrap_or(0.0);
+    let platform_fee_rate =
+        fee_rate * Decimal::try_from(base_f64.powf(exp_f64)).unwrap_or(Decimal::ZERO);
+
+    let effective_platform_fee_rate =
+        platform_fee_rate * (Decimal::ONE + fee_slippage / dec!(100));
+
+    let fee_base_amount = amount.min(user_usdc_balance);
+    let platform_fee = (fee_base_amount / price) * effective_platform_fee_rate;
+    let builder_fee = fee_base_amount * builder_taker_fee_rate;
+    let total_cost = amount + platform_fee + builder_fee;
+
+    if user_usdc_balance <= total_cost {
+        Ok((user_usdc_balance - platform_fee - builder_fee).max(Decimal::ZERO))
+    } else {
+        Ok(amount)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rust_decimal_macros::dec;
+
+    use super::*;
+
+    fn close_to(actual: Decimal, expected: Decimal, tol: Decimal) {
+        let diff = (actual - expected).abs();
+        assert!(
+            diff <= tol,
+            "|{actual} − {expected}| = {diff} exceeds tolerance {tol}"
+        );
+    }
+
+    // ── validate_fee_slippage ──────────────────────────────────────────────────
+
+    #[test]
+    fn validate_fee_slippage_accepts_zero() {
+        validate_fee_slippage(Decimal::ZERO).unwrap();
+    }
+
+    #[test]
+    fn validate_fee_slippage_accepts_max() {
+        validate_fee_slippage(dec!(100)).unwrap();
+    }
+
+    #[test]
+    fn validate_fee_slippage_accepts_fractional_between_1_and_100() {
+        validate_fee_slippage(dec!(12.5)).unwrap();
+        validate_fee_slippage(dec!(99.9)).unwrap();
+    }
+
+    #[test]
+    fn validate_fee_slippage_accepts_exactly_1() {
+        validate_fee_slippage(Decimal::ONE).unwrap();
+    }
+
+    #[test]
+    fn validate_fee_slippage_rejects_fraction_below_1() {
+        validate_fee_slippage(dec!(0.5)).unwrap_err();
+    }
+
+    #[test]
+    fn validate_fee_slippage_rejects_above_100() {
+        validate_fee_slippage(dec!(101)).unwrap_err();
+    }
+
+    #[test]
+    fn validate_fee_slippage_rejects_negative() {
+        validate_fee_slippage(dec!(-1)).unwrap_err();
+    }
+
+    // ── adjust_buy_amount_for_fees — no adjustment paths ──────────────────────
+
+    #[test]
+    fn no_adjustment_zero_fees() {
+        let result = adjust_buy_amount_for_fees(
+            dec!(50), dec!(0.5), dec!(50),
+            Decimal::ZERO, Decimal::ZERO, Decimal::ZERO, Decimal::ZERO,
+        )
+        .unwrap();
+        assert_eq!(result, dec!(50));
+    }
+
+    #[test]
+    fn no_adjustment_when_balance_exceeds_total_cost() {
+        let result = adjust_buy_amount_for_fees(
+            dec!(50), dec!(0.5), dec!(1000),
+            dec!(0.25), dec!(2), Decimal::ZERO, Decimal::ZERO,
+        )
+        .unwrap();
+        assert_eq!(result, dec!(50));
+    }
+
+    #[test]
+    fn balance_exactly_equal_to_amount_plus_reserved_fee_returns_amount() {
+        // balance = amount + platform_fee(amount) = 50 + 1.5625 = 51.5625
+        // total_cost == balance → triggers adjust branch but result == amount
+        let result = adjust_buy_amount_for_fees(
+            dec!(50), dec!(0.5), dec!(51.5625),
+            dec!(0.25), dec!(2), Decimal::ZERO, Decimal::ZERO,
+        )
+        .unwrap();
+        assert_eq!(result, dec!(50));
+    }
+
+    // ── adjust_buy_amount_for_fees — platform fee only ────────────────────────
+    //
+    // rate=0.25, exp=2, price=0.5 → platform_fee_rate = 0.25*(0.5*0.5)^2 = 0.015625
+
+    #[test]
+    fn platform_fee_only_reserves_original_fee() {
+        // platform_fee = (50/0.5)*0.015625 = 1.5625 → adjusted = 48.4375
+        let adj = adjust_buy_amount_for_fees(
+            dec!(50), dec!(0.5), dec!(50),
+            dec!(0.25), dec!(2), Decimal::ZERO, Decimal::ZERO,
+        )
+        .unwrap();
+        close_to(adj, dec!(48.4375), dec!(0.000001));
+        let adjusted_fee = (adj / dec!(0.5)) * dec!(0.015625);
+        close_to(adjusted_fee, dec!(1.513671875), dec!(0.000001));
+        close_to(adj + adjusted_fee, dec!(49.951171875), dec!(0.000001));
+    }
+
+    // ── adjust_buy_amount_for_fees — builder fee only ─────────────────────────
+
+    #[test]
+    fn builder_fee_only_reserves_original_fee() {
+        // builder_fee = 50*0.01 = 0.5 → adjusted = 49.5
+        let adj = adjust_buy_amount_for_fees(
+            dec!(50), dec!(0.5), dec!(50),
+            Decimal::ZERO, Decimal::ZERO, dec!(0.01), Decimal::ZERO,
+        )
+        .unwrap();
+        close_to(adj, dec!(49.5), dec!(0.000001));
+        let adjusted_fee = adj * dec!(0.01);
+        close_to(adjusted_fee, dec!(0.495), dec!(0.000001));
+        close_to(adj + adjusted_fee, dec!(49.995), dec!(0.000001));
+    }
+
+    // ── adjust_buy_amount_for_fees — platform + builder ───────────────────────
+
+    #[test]
+    fn platform_and_builder_fee_reserves_original_fees() {
+        // platform_fee = 1.5625, builder_fee = 0.5 → adjusted = 47.9375
+        let adj = adjust_buy_amount_for_fees(
+            dec!(50), dec!(0.5), dec!(50),
+            dec!(0.25), dec!(2), dec!(0.01), Decimal::ZERO,
+        )
+        .unwrap();
+        close_to(adj, dec!(47.9375), dec!(0.000001));
+        let adjusted_platform_fee = (adj / dec!(0.5)) * dec!(0.015625);
+        let adjusted_builder_fee = adj * dec!(0.01);
+        close_to(adjusted_platform_fee, dec!(1.498046875), dec!(0.000001));
+        close_to(adjusted_builder_fee, dec!(0.479375), dec!(0.000001));
+        close_to(adj + adjusted_platform_fee + adjusted_builder_fee, dec!(49.914921875), dec!(0.000001));
+    }
+
+    #[test]
+    fn price_0_3_platform_and_builder_reserves_original_fees() {
+        // rate=0.25, exp=2, price=0.3 → platform_fee_rate = 0.25*(0.3*0.7)^2 ≈ 0.011025
+        // amount=balance=30, builder=0.02
+        // platform_fee ≈ (30/0.3)*0.011025 = 1.1025, builder_fee = 0.6 → adjusted ≈ 28.2975
+        let adj = adjust_buy_amount_for_fees(
+            dec!(30), dec!(0.3), dec!(30),
+            dec!(0.25), dec!(2), dec!(0.02), Decimal::ZERO,
+        )
+        .unwrap();
+        close_to(adj, dec!(28.2975), dec!(0.000001));
+        let adjusted_platform_fee = (adj / dec!(0.3)) * dec!(0.011025);
+        let adjusted_builder_fee = adj * dec!(0.02);
+        close_to(adjusted_platform_fee, dec!(1.039933125), dec!(0.000001));
+        close_to(adjusted_builder_fee, dec!(0.56595), dec!(0.000001));
+        close_to(adj + adjusted_platform_fee + adjusted_builder_fee, dec!(29.903383125), dec!(0.000001));
+    }
+
+    // ── fee_base capping: amount > balance ────────────────────────────────────
+
+    #[test]
+    fn fee_base_amount_capped_at_balance() {
+        // amount=100 > balance=1 → fee_base=1
+        // rate=0.072, exp=1, price=0.3 → platform_fee_rate = 0.072*0.21 = 0.01512
+        // reserved_fee = (1/0.3)*0.01512 = 0.0504 → adjusted = 0.9496
+        let adj = adjust_buy_amount_for_fees(
+            dec!(100), dec!(0.3), dec!(1),
+            dec!(0.072), Decimal::ONE, Decimal::ZERO, Decimal::ZERO,
+        )
+        .unwrap();
+        assert_eq!(adj, dec!(0.9496));
+        let adjusted_fee = (adj / dec!(0.3)) * dec!(0.01512);
+        close_to(adjusted_fee, dec!(0.04785984), dec!(0.000001));
+        close_to(adj + adjusted_fee, dec!(0.99745984), dec!(0.000001));
+    }
+
+    // ── fee_slippage ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn pads_only_platform_fee_by_percentage() {
+        // fee_slippage=20 → effective_rate = 0.015625*1.2 = 0.01875
+        // platform_fee = (50/0.5)*0.01875 = 1.875, builder_fee = 0.5 → adjusted = 47.625
+        let adj = adjust_buy_amount_for_fees(
+            dec!(50), dec!(0.5), dec!(50),
+            dec!(0.25), dec!(2), dec!(0.01), dec!(20),
+        )
+        .unwrap();
+        close_to(adj, dec!(47.625), dec!(0.000001));
+        let adjusted_platform_fee = (adj / dec!(0.5)) * dec!(0.015625) * dec!(1.2);
+        let adjusted_builder_fee = adj * dec!(0.01);
+        close_to(adjusted_platform_fee, dec!(1.7859375), dec!(0.000001));
+        close_to(adjusted_builder_fee, dec!(0.47625), dec!(0.000001));
+        close_to(adj + adjusted_platform_fee + adjusted_builder_fee, dec!(49.8871875), dec!(0.000001));
+    }
+
+    #[test]
+    fn adjusts_when_balance_covers_unpadded_but_not_padded_fees() {
+        // balance = 50 + 1.5625 + (1.875 - 1.5625)/2 = 51.71875
+        // padded platform_fee = 1.875 > (balance - amount) so adjustment fires
+        let adj = adjust_buy_amount_for_fees(
+            dec!(50), dec!(0.5), dec!(51.71875),
+            dec!(0.25), dec!(2), Decimal::ZERO, dec!(20),
+        )
+        .unwrap();
+        assert_eq!(adj, dec!(49.84375));
+    }
+
+    #[test]
+    fn accepts_float_percentages_between_1_and_100() {
+        // fee_slippage=1.5 → effective_rate = 0.015625*1.015 = 0.015859375
+        // platform_fee = (50/0.5)*0.015859375 = 1.5859375 → adjusted = 48.4140625
+        let adj = adjust_buy_amount_for_fees(
+            dec!(50), dec!(0.5), dec!(50),
+            dec!(0.25), dec!(2), Decimal::ZERO, dec!(1.5),
+        )
+        .unwrap();
+        assert_eq!(adj, dec!(48.4140625));
+        let adjusted_platform_fee = (adj / dec!(0.5)) * dec!(0.015625) * dec!(1.015);
+        close_to(adjusted_platform_fee, dec!(1.535633544922), dec!(0.000001));
+        close_to(adj + adjusted_platform_fee, dec!(49.949696044922), dec!(0.000001));
+    }
+
+    // ── Production V2 fee tiers (amount=balance=100, no builder fee) ──────────
+    //
+    // Columns: (price, adjusted, platform_fee_rate, adjusted_fee, final)
+    // platform_fee_rate = fee_rate * price * (1-price)  (exp=1)
+
+    #[test]
+    fn production_sports_v2_fee_slippage_0() {
+        // rate=0.03, exp=1
+        for (price, expected_adj, pfr, expected_adj_fee, expected_final) in [
+            (dec!(0.5), dec!(98.5),  dec!(0.0075),  dec!(1.4775),   dec!(99.9775)),
+            (dec!(0.3), dec!(97.9),  dec!(0.0063),  dec!(2.0559),   dec!(99.9559)),
+            (dec!(0.7), dec!(99.1),  dec!(0.0063),  dec!(0.8919),   dec!(99.9919)),
+        ] {
+            let adj = adjust_buy_amount_for_fees(
+                dec!(100), price, dec!(100), dec!(0.03), Decimal::ONE, Decimal::ZERO, Decimal::ZERO,
+            )
+            .unwrap();
+            assert_eq!(adj, expected_adj);
+            let adjusted_fee = (adj / price) * pfr;
+            close_to(adjusted_fee, expected_adj_fee, dec!(0.0001));
+            close_to(adj + adjusted_fee, expected_final, dec!(0.0001));
+        }
+    }
+
+    #[test]
+    fn production_politics_fee_slippage_0() {
+        // rate=0.04, exp=1
+        for (price, expected_adj, pfr, expected_adj_fee, expected_final) in [
+            (dec!(0.5), dec!(98.0),  dec!(0.01),    dec!(1.96),     dec!(99.96)),
+            (dec!(0.3), dec!(97.2),  dec!(0.0084),  dec!(2.7216),   dec!(99.9216)),
+            (dec!(0.7), dec!(98.8),  dec!(0.0084),  dec!(1.1856),   dec!(99.9856)),
+        ] {
+            let adj = adjust_buy_amount_for_fees(
+                dec!(100), price, dec!(100), dec!(0.04), Decimal::ONE, Decimal::ZERO, Decimal::ZERO,
+            )
+            .unwrap();
+            assert_eq!(adj, expected_adj);
+            let adjusted_fee = (adj / price) * pfr;
+            close_to(adjusted_fee, expected_adj_fee, dec!(0.0001));
+            close_to(adj + adjusted_fee, expected_final, dec!(0.0001));
+        }
+    }
+
+    #[test]
+    fn production_culture_fee_slippage_0() {
+        // rate=0.05, exp=1
+        for (price, expected_adj, pfr, expected_adj_fee, expected_final) in [
+            (dec!(0.5), dec!(97.5),  dec!(0.0125),  dec!(2.4375),   dec!(99.9375)),
+            (dec!(0.3), dec!(96.5),  dec!(0.0105),  dec!(3.3775),   dec!(99.8775)),
+            (dec!(0.7), dec!(98.5),  dec!(0.0105),  dec!(1.4775),   dec!(99.9775)),
+        ] {
+            let adj = adjust_buy_amount_for_fees(
+                dec!(100), price, dec!(100), dec!(0.05), Decimal::ONE, Decimal::ZERO, Decimal::ZERO,
+            )
+            .unwrap();
+            assert_eq!(adj, expected_adj);
+            let adjusted_fee = (adj / price) * pfr;
+            close_to(adjusted_fee, expected_adj_fee, dec!(0.0001));
+            close_to(adj + adjusted_fee, expected_final, dec!(0.0001));
+        }
+    }
+
+    #[test]
+    fn production_crypto_v2_fee_slippage_0() {
+        // rate=0.072, exp=1
+        for (price, expected_adj, pfr, expected_adj_fee, expected_final) in [
+            (dec!(0.5), dec!(96.4),  dec!(0.018),   dec!(3.4704),   dec!(99.8704)),
+            (dec!(0.3), dec!(94.96), dec!(0.01512),  dec!(4.785984), dec!(99.745984)),
+            (dec!(0.7), dec!(97.84), dec!(0.01512),  dec!(2.113344), dec!(99.953344)),
+        ] {
+            let adj = adjust_buy_amount_for_fees(
+                dec!(100), price, dec!(100), dec!(0.072), Decimal::ONE, Decimal::ZERO, Decimal::ZERO,
+            )
+            .unwrap();
+            assert_eq!(adj, expected_adj);
+            let adjusted_fee = (adj / price) * pfr;
+            close_to(adjusted_fee, expected_adj_fee, dec!(0.0001));
+            close_to(adj + adjusted_fee, expected_final, dec!(0.0001));
+        }
+    }
+}

--- a/src/clob/fees.rs
+++ b/src/clob/fees.rs
@@ -56,8 +56,7 @@ pub fn adjust_buy_amount_for_fees(
     let platform_fee_rate =
         fee_rate * Decimal::try_from(base_f64.powf(exp_f64)).unwrap_or(Decimal::ZERO);
 
-    let effective_platform_fee_rate =
-        platform_fee_rate * (Decimal::ONE + fee_slippage / dec!(100));
+    let effective_platform_fee_rate = platform_fee_rate * (Decimal::ONE + fee_slippage / dec!(100));
 
     let fee_base_amount = amount.min(user_usdc_balance);
     let platform_fee = (fee_base_amount / price) * effective_platform_fee_rate;
@@ -128,8 +127,13 @@ mod tests {
     #[test]
     fn no_adjustment_zero_fees() {
         let result = adjust_buy_amount_for_fees(
-            dec!(50), dec!(0.5), dec!(50),
-            Decimal::ZERO, Decimal::ZERO, Decimal::ZERO, Decimal::ZERO,
+            dec!(50),
+            dec!(0.5),
+            dec!(50),
+            Decimal::ZERO,
+            Decimal::ZERO,
+            Decimal::ZERO,
+            Decimal::ZERO,
         )
         .unwrap();
         assert_eq!(result, dec!(50));
@@ -138,8 +142,13 @@ mod tests {
     #[test]
     fn no_adjustment_when_balance_exceeds_total_cost() {
         let result = adjust_buy_amount_for_fees(
-            dec!(50), dec!(0.5), dec!(1000),
-            dec!(0.25), dec!(2), Decimal::ZERO, Decimal::ZERO,
+            dec!(50),
+            dec!(0.5),
+            dec!(1000),
+            dec!(0.25),
+            dec!(2),
+            Decimal::ZERO,
+            Decimal::ZERO,
         )
         .unwrap();
         assert_eq!(result, dec!(50));
@@ -150,8 +159,13 @@ mod tests {
         // balance = amount + platform_fee(amount) = 50 + 1.5625 = 51.5625
         // total_cost == balance → triggers adjust branch but result == amount
         let result = adjust_buy_amount_for_fees(
-            dec!(50), dec!(0.5), dec!(51.5625),
-            dec!(0.25), dec!(2), Decimal::ZERO, Decimal::ZERO,
+            dec!(50),
+            dec!(0.5),
+            dec!(51.5625),
+            dec!(0.25),
+            dec!(2),
+            Decimal::ZERO,
+            Decimal::ZERO,
         )
         .unwrap();
         assert_eq!(result, dec!(50));
@@ -165,8 +179,13 @@ mod tests {
     fn platform_fee_only_reserves_original_fee() {
         // platform_fee = (50/0.5)*0.015625 = 1.5625 → adjusted = 48.4375
         let adj = adjust_buy_amount_for_fees(
-            dec!(50), dec!(0.5), dec!(50),
-            dec!(0.25), dec!(2), Decimal::ZERO, Decimal::ZERO,
+            dec!(50),
+            dec!(0.5),
+            dec!(50),
+            dec!(0.25),
+            dec!(2),
+            Decimal::ZERO,
+            Decimal::ZERO,
         )
         .unwrap();
         close_to(adj, dec!(48.4375), dec!(0.000001));
@@ -181,8 +200,13 @@ mod tests {
     fn builder_fee_only_reserves_original_fee() {
         // builder_fee = 50*0.01 = 0.5 → adjusted = 49.5
         let adj = adjust_buy_amount_for_fees(
-            dec!(50), dec!(0.5), dec!(50),
-            Decimal::ZERO, Decimal::ZERO, dec!(0.01), Decimal::ZERO,
+            dec!(50),
+            dec!(0.5),
+            dec!(50),
+            Decimal::ZERO,
+            Decimal::ZERO,
+            dec!(0.01),
+            Decimal::ZERO,
         )
         .unwrap();
         close_to(adj, dec!(49.5), dec!(0.000001));
@@ -197,8 +221,13 @@ mod tests {
     fn platform_and_builder_fee_reserves_original_fees() {
         // platform_fee = 1.5625, builder_fee = 0.5 → adjusted = 47.9375
         let adj = adjust_buy_amount_for_fees(
-            dec!(50), dec!(0.5), dec!(50),
-            dec!(0.25), dec!(2), dec!(0.01), Decimal::ZERO,
+            dec!(50),
+            dec!(0.5),
+            dec!(50),
+            dec!(0.25),
+            dec!(2),
+            dec!(0.01),
+            Decimal::ZERO,
         )
         .unwrap();
         close_to(adj, dec!(47.9375), dec!(0.000001));
@@ -206,7 +235,11 @@ mod tests {
         let adjusted_builder_fee = adj * dec!(0.01);
         close_to(adjusted_platform_fee, dec!(1.498046875), dec!(0.000001));
         close_to(adjusted_builder_fee, dec!(0.479375), dec!(0.000001));
-        close_to(adj + adjusted_platform_fee + adjusted_builder_fee, dec!(49.914921875), dec!(0.000001));
+        close_to(
+            adj + adjusted_platform_fee + adjusted_builder_fee,
+            dec!(49.914921875),
+            dec!(0.000001),
+        );
     }
 
     #[test]
@@ -215,8 +248,13 @@ mod tests {
         // amount=balance=30, builder=0.02
         // platform_fee ≈ (30/0.3)*0.011025 = 1.1025, builder_fee = 0.6 → adjusted ≈ 28.2975
         let adj = adjust_buy_amount_for_fees(
-            dec!(30), dec!(0.3), dec!(30),
-            dec!(0.25), dec!(2), dec!(0.02), Decimal::ZERO,
+            dec!(30),
+            dec!(0.3),
+            dec!(30),
+            dec!(0.25),
+            dec!(2),
+            dec!(0.02),
+            Decimal::ZERO,
         )
         .unwrap();
         close_to(adj, dec!(28.2975), dec!(0.000001));
@@ -224,7 +262,11 @@ mod tests {
         let adjusted_builder_fee = adj * dec!(0.02);
         close_to(adjusted_platform_fee, dec!(1.039933125), dec!(0.000001));
         close_to(adjusted_builder_fee, dec!(0.56595), dec!(0.000001));
-        close_to(adj + adjusted_platform_fee + adjusted_builder_fee, dec!(29.903383125), dec!(0.000001));
+        close_to(
+            adj + adjusted_platform_fee + adjusted_builder_fee,
+            dec!(29.903383125),
+            dec!(0.000001),
+        );
     }
 
     // ── fee_base capping: amount > balance ────────────────────────────────────
@@ -235,8 +277,13 @@ mod tests {
         // rate=0.072, exp=1, price=0.3 → platform_fee_rate = 0.072*0.21 = 0.01512
         // reserved_fee = (1/0.3)*0.01512 = 0.0504 → adjusted = 0.9496
         let adj = adjust_buy_amount_for_fees(
-            dec!(100), dec!(0.3), dec!(1),
-            dec!(0.072), Decimal::ONE, Decimal::ZERO, Decimal::ZERO,
+            dec!(100),
+            dec!(0.3),
+            dec!(1),
+            dec!(0.072),
+            Decimal::ONE,
+            Decimal::ZERO,
+            Decimal::ZERO,
         )
         .unwrap();
         assert_eq!(adj, dec!(0.9496));
@@ -252,8 +299,13 @@ mod tests {
         // fee_slippage=20 → effective_rate = 0.015625*1.2 = 0.01875
         // platform_fee = (50/0.5)*0.01875 = 1.875, builder_fee = 0.5 → adjusted = 47.625
         let adj = adjust_buy_amount_for_fees(
-            dec!(50), dec!(0.5), dec!(50),
-            dec!(0.25), dec!(2), dec!(0.01), dec!(20),
+            dec!(50),
+            dec!(0.5),
+            dec!(50),
+            dec!(0.25),
+            dec!(2),
+            dec!(0.01),
+            dec!(20),
         )
         .unwrap();
         close_to(adj, dec!(47.625), dec!(0.000001));
@@ -261,7 +313,11 @@ mod tests {
         let adjusted_builder_fee = adj * dec!(0.01);
         close_to(adjusted_platform_fee, dec!(1.7859375), dec!(0.000001));
         close_to(adjusted_builder_fee, dec!(0.47625), dec!(0.000001));
-        close_to(adj + adjusted_platform_fee + adjusted_builder_fee, dec!(49.8871875), dec!(0.000001));
+        close_to(
+            adj + adjusted_platform_fee + adjusted_builder_fee,
+            dec!(49.8871875),
+            dec!(0.000001),
+        );
     }
 
     #[test]
@@ -269,8 +325,13 @@ mod tests {
         // balance = 50 + 1.5625 + (1.875 - 1.5625)/2 = 51.71875
         // padded platform_fee = 1.875 > (balance - amount) so adjustment fires
         let adj = adjust_buy_amount_for_fees(
-            dec!(50), dec!(0.5), dec!(51.71875),
-            dec!(0.25), dec!(2), Decimal::ZERO, dec!(20),
+            dec!(50),
+            dec!(0.5),
+            dec!(51.71875),
+            dec!(0.25),
+            dec!(2),
+            Decimal::ZERO,
+            dec!(20),
         )
         .unwrap();
         assert_eq!(adj, dec!(49.84375));
@@ -281,14 +342,23 @@ mod tests {
         // fee_slippage=1.5 → effective_rate = 0.015625*1.015 = 0.015859375
         // platform_fee = (50/0.5)*0.015859375 = 1.5859375 → adjusted = 48.4140625
         let adj = adjust_buy_amount_for_fees(
-            dec!(50), dec!(0.5), dec!(50),
-            dec!(0.25), dec!(2), Decimal::ZERO, dec!(1.5),
+            dec!(50),
+            dec!(0.5),
+            dec!(50),
+            dec!(0.25),
+            dec!(2),
+            Decimal::ZERO,
+            dec!(1.5),
         )
         .unwrap();
         assert_eq!(adj, dec!(48.4140625));
         let adjusted_platform_fee = (adj / dec!(0.5)) * dec!(0.015625) * dec!(1.015);
         close_to(adjusted_platform_fee, dec!(1.535633544922), dec!(0.000001));
-        close_to(adj + adjusted_platform_fee, dec!(49.949696044922), dec!(0.000001));
+        close_to(
+            adj + adjusted_platform_fee,
+            dec!(49.949696044922),
+            dec!(0.000001),
+        );
     }
 
     // ── Production V2 fee tiers (amount=balance=100, no builder fee) ──────────
@@ -300,12 +370,36 @@ mod tests {
     fn production_sports_v2_fee_slippage_0() {
         // rate=0.03, exp=1
         for (price, expected_adj, pfr, expected_adj_fee, expected_final) in [
-            (dec!(0.5), dec!(98.5),  dec!(0.0075),  dec!(1.4775),   dec!(99.9775)),
-            (dec!(0.3), dec!(97.9),  dec!(0.0063),  dec!(2.0559),   dec!(99.9559)),
-            (dec!(0.7), dec!(99.1),  dec!(0.0063),  dec!(0.8919),   dec!(99.9919)),
+            (
+                dec!(0.5),
+                dec!(98.5),
+                dec!(0.0075),
+                dec!(1.4775),
+                dec!(99.9775),
+            ),
+            (
+                dec!(0.3),
+                dec!(97.9),
+                dec!(0.0063),
+                dec!(2.0559),
+                dec!(99.9559),
+            ),
+            (
+                dec!(0.7),
+                dec!(99.1),
+                dec!(0.0063),
+                dec!(0.8919),
+                dec!(99.9919),
+            ),
         ] {
             let adj = adjust_buy_amount_for_fees(
-                dec!(100), price, dec!(100), dec!(0.03), Decimal::ONE, Decimal::ZERO, Decimal::ZERO,
+                dec!(100),
+                price,
+                dec!(100),
+                dec!(0.03),
+                Decimal::ONE,
+                Decimal::ZERO,
+                Decimal::ZERO,
             )
             .unwrap();
             assert_eq!(adj, expected_adj);
@@ -319,12 +413,30 @@ mod tests {
     fn production_politics_fee_slippage_0() {
         // rate=0.04, exp=1
         for (price, expected_adj, pfr, expected_adj_fee, expected_final) in [
-            (dec!(0.5), dec!(98.0),  dec!(0.01),    dec!(1.96),     dec!(99.96)),
-            (dec!(0.3), dec!(97.2),  dec!(0.0084),  dec!(2.7216),   dec!(99.9216)),
-            (dec!(0.7), dec!(98.8),  dec!(0.0084),  dec!(1.1856),   dec!(99.9856)),
+            (dec!(0.5), dec!(98.0), dec!(0.01), dec!(1.96), dec!(99.96)),
+            (
+                dec!(0.3),
+                dec!(97.2),
+                dec!(0.0084),
+                dec!(2.7216),
+                dec!(99.9216),
+            ),
+            (
+                dec!(0.7),
+                dec!(98.8),
+                dec!(0.0084),
+                dec!(1.1856),
+                dec!(99.9856),
+            ),
         ] {
             let adj = adjust_buy_amount_for_fees(
-                dec!(100), price, dec!(100), dec!(0.04), Decimal::ONE, Decimal::ZERO, Decimal::ZERO,
+                dec!(100),
+                price,
+                dec!(100),
+                dec!(0.04),
+                Decimal::ONE,
+                Decimal::ZERO,
+                Decimal::ZERO,
             )
             .unwrap();
             assert_eq!(adj, expected_adj);
@@ -338,12 +450,36 @@ mod tests {
     fn production_culture_fee_slippage_0() {
         // rate=0.05, exp=1
         for (price, expected_adj, pfr, expected_adj_fee, expected_final) in [
-            (dec!(0.5), dec!(97.5),  dec!(0.0125),  dec!(2.4375),   dec!(99.9375)),
-            (dec!(0.3), dec!(96.5),  dec!(0.0105),  dec!(3.3775),   dec!(99.8775)),
-            (dec!(0.7), dec!(98.5),  dec!(0.0105),  dec!(1.4775),   dec!(99.9775)),
+            (
+                dec!(0.5),
+                dec!(97.5),
+                dec!(0.0125),
+                dec!(2.4375),
+                dec!(99.9375),
+            ),
+            (
+                dec!(0.3),
+                dec!(96.5),
+                dec!(0.0105),
+                dec!(3.3775),
+                dec!(99.8775),
+            ),
+            (
+                dec!(0.7),
+                dec!(98.5),
+                dec!(0.0105),
+                dec!(1.4775),
+                dec!(99.9775),
+            ),
         ] {
             let adj = adjust_buy_amount_for_fees(
-                dec!(100), price, dec!(100), dec!(0.05), Decimal::ONE, Decimal::ZERO, Decimal::ZERO,
+                dec!(100),
+                price,
+                dec!(100),
+                dec!(0.05),
+                Decimal::ONE,
+                Decimal::ZERO,
+                Decimal::ZERO,
             )
             .unwrap();
             assert_eq!(adj, expected_adj);
@@ -357,12 +493,36 @@ mod tests {
     fn production_crypto_v2_fee_slippage_0() {
         // rate=0.072, exp=1
         for (price, expected_adj, pfr, expected_adj_fee, expected_final) in [
-            (dec!(0.5), dec!(96.4),  dec!(0.018),   dec!(3.4704),   dec!(99.8704)),
-            (dec!(0.3), dec!(94.96), dec!(0.01512),  dec!(4.785984), dec!(99.745984)),
-            (dec!(0.7), dec!(97.84), dec!(0.01512),  dec!(2.113344), dec!(99.953344)),
+            (
+                dec!(0.5),
+                dec!(96.4),
+                dec!(0.018),
+                dec!(3.4704),
+                dec!(99.8704),
+            ),
+            (
+                dec!(0.3),
+                dec!(94.96),
+                dec!(0.01512),
+                dec!(4.785984),
+                dec!(99.745984),
+            ),
+            (
+                dec!(0.7),
+                dec!(97.84),
+                dec!(0.01512),
+                dec!(2.113344),
+                dec!(99.953344),
+            ),
         ] {
             let adj = adjust_buy_amount_for_fees(
-                dec!(100), price, dec!(100), dec!(0.072), Decimal::ONE, Decimal::ZERO, Decimal::ZERO,
+                dec!(100),
+                price,
+                dec!(100),
+                dec!(0.072),
+                Decimal::ONE,
+                Decimal::ZERO,
+                Decimal::ZERO,
             )
             .unwrap();
             assert_eq!(adj, expected_adj);

--- a/src/clob/mod.rs
+++ b/src/clob/mod.rs
@@ -153,6 +153,7 @@
 //! The default API endpoint is `https://clob-v2.polymarket.com`.
 
 pub mod client;
+pub mod fees;
 pub mod order_builder;
 pub mod types;
 pub mod utilities;

--- a/src/clob/order_builder.rs
+++ b/src/clob/order_builder.rs
@@ -373,7 +373,14 @@ impl<K: AuthKind> OrderBuilder<Limit, K> {
                     builder_taker_fee,
                     fee_slippage,
                 )?;
-                (adjusted_notional / price).trunc_with_scale(LOT_SIZE_SCALE)
+                let effective = (adjusted_notional / price).trunc_with_scale(LOT_SIZE_SCALE);
+                if effective.is_zero() {
+                    return Err(Error::validation(format!(
+                        "user_usdc_balance {balance} too small to cover fees at price {price}; \
+                         fee-adjusted size truncated to zero"
+                    )));
+                }
+                effective
             } else {
                 size
             }

--- a/src/clob/order_builder.rs
+++ b/src/clob/order_builder.rs
@@ -359,8 +359,7 @@ impl<K: AuthKind> OrderBuilder<Limit, K> {
                 let builder_taker_fee = match self.builder_code {
                     Some(code) if code != B256::ZERO => {
                         let rate = self.client.builder_fee_rate(code).await?;
-                        Decimal::from(rate.builder_taker_fee_rate_bps)
-                            / Decimal::from(10_000_u32)
+                        Decimal::from(rate.builder_taker_fee_rate_bps) / Decimal::from(10_000_u32)
                     }
                     _ => Decimal::ZERO,
                 };

--- a/src/clob/order_builder.rs
+++ b/src/clob/order_builder.rs
@@ -627,7 +627,7 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
                     builder_taker_fee,
                     fee_slippage,
                 )?;
-                let adjusted = adjusted_raw.trunc_with_scale(USDC_DECIMALS);
+                let adjusted = adjusted_raw.trunc_with_scale(LOT_SIZE_SCALE);
                 if adjusted.is_zero() {
                     return Err(Error::validation(format!(
                         "user_usdc_balance {balance} too small to cover fees at price {price}; \

--- a/src/clob/order_builder.rs
+++ b/src/clob/order_builder.rs
@@ -54,6 +54,8 @@ pub struct OrderBuilder<OrderKind, K: AuthKind> {
     pub(crate) builder_code: Option<B256>,
     pub(crate) defer_exec: Option<bool>,
     pub(crate) user_usdc_balance: Option<Decimal>,
+    /// Fee slippage percentage (0 or 1–100) to pad the platform fee reserve.
+    pub(crate) fee_slippage: Option<Decimal>,
     /// V1-only: explicit taker address. Defaults to the zero address (public order).
     pub(crate) taker: Option<Address>,
     /// V1-only: on-chain cancel nonce. Defaults to 0.
@@ -139,6 +141,15 @@ impl<OrderKind, K: AuthKind> OrderBuilder<OrderKind, K> {
     #[must_use]
     pub fn fee_rate_bps(mut self, fee_rate_bps: u32) -> Self {
         self.fee_rate_bps = Some(fee_rate_bps);
+        self
+    }
+
+    /// Sets the fee slippage percentage used to pad the platform-fee reserve.
+    ///
+    /// Must be `0` (no padding) or a value in `[1, 100]`. Validated at [`build`](Self) time.
+    #[must_use]
+    pub fn fee_slippage(mut self, fee_slippage: Decimal) -> Self {
+        self.fee_slippage = Some(fee_slippage);
         self
     }
 
@@ -238,6 +249,14 @@ impl<K: AuthKind> OrderBuilder<Limit, K> {
         self
     }
 
+    /// Sets the user's USDC balance. When set on a V2 BUY limit order, `build()` shrinks
+    /// the size so `size * price + fees ≤ balance`.
+    #[must_use]
+    pub fn user_usdc_balance(mut self, balance: Decimal) -> Self {
+        self.user_usdc_balance = Some(balance);
+        self
+    }
+
     /// Validates and transforms this limit builder into a [`SignableOrder`]
     ///
     /// # Panics
@@ -331,14 +350,46 @@ impl<K: AuthKind> OrderBuilder<Limit, K> {
             ));
         }
 
+        // For V2 BUY limit orders, shrink size so notional + fees ≤ user_usdc_balance.
+        let effective_size = if matches!(side, Side::Buy) {
+            if let Some(balance) = self.user_usdc_balance {
+                let fee = self.client.fee_info(token_id).await?;
+                let fee_slippage = self.fee_slippage.unwrap_or(Decimal::ZERO);
+                crate::clob::fees::validate_fee_slippage(fee_slippage)?;
+                let builder_taker_fee = match self.builder_code {
+                    Some(code) if code != B256::ZERO => {
+                        let rate = self.client.builder_fee_rate(code).await?;
+                        Decimal::from(rate.builder_taker_fee_rate_bps)
+                            / Decimal::from(10_000_u32)
+                    }
+                    _ => Decimal::ZERO,
+                };
+                let notional = size * price;
+                let adjusted_notional = crate::clob::fees::adjust_buy_amount_for_fees(
+                    notional,
+                    price,
+                    balance,
+                    fee.rate,
+                    Decimal::from(fee.exponent),
+                    builder_taker_fee,
+                    fee_slippage,
+                )?;
+                (adjusted_notional / price).trunc_with_scale(LOT_SIZE_SCALE)
+            } else {
+                size
+            }
+        } else {
+            size
+        };
+
         let (taker_amount, maker_amount) = match side {
             Side::Buy => (
-                size,
-                (size * price).trunc_with_scale(decimals + LOT_SIZE_SCALE),
+                effective_size,
+                (effective_size * price).trunc_with_scale(decimals + LOT_SIZE_SCALE),
             ),
             Side::Sell => (
-                (size * price).trunc_with_scale(decimals + LOT_SIZE_SCALE),
-                size,
+                (effective_size * price).trunc_with_scale(decimals + LOT_SIZE_SCALE),
+                effective_size,
             ),
             side => return Err(Error::validation(format!("Invalid side: {side}"))),
         };
@@ -564,15 +615,25 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
                     }
                     _ => Decimal::ZERO,
                 };
+                let fee_slippage = self.fee_slippage.unwrap_or(Decimal::ZERO);
+                crate::clob::fees::validate_fee_slippage(fee_slippage)?;
 
-                let adjusted = super::utilities::adjust_market_buy_amount(
+                let adjusted_raw = crate::clob::fees::adjust_buy_amount_for_fees(
                     raw,
-                    balance,
                     price,
+                    balance,
                     fee_rate,
                     fee_exponent,
                     builder_taker_fee,
+                    fee_slippage,
                 )?;
+                let adjusted = adjusted_raw.trunc_with_scale(LOT_SIZE_SCALE);
+                if adjusted.is_zero() {
+                    return Err(Error::validation(format!(
+                        "user_usdc_balance {balance} too small to cover fees at price {price}; \
+                         fee-adjusted amount truncated to zero"
+                    )));
+                }
                 Amount::usdc(adjusted)?
             }
             _ => amount,

--- a/src/clob/order_builder.rs
+++ b/src/clob/order_builder.rs
@@ -627,7 +627,7 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
                     builder_taker_fee,
                     fee_slippage,
                 )?;
-                let adjusted = adjusted_raw.trunc_with_scale(LOT_SIZE_SCALE);
+                let adjusted = adjusted_raw.trunc_with_scale(USDC_DECIMALS);
                 if adjusted.is_zero() {
                     return Err(Error::validation(format!(
                         "user_usdc_balance {balance} too small to cover fees at price {price}; \

--- a/src/clob/utilities.rs
+++ b/src/clob/utilities.rs
@@ -623,7 +623,11 @@ mod tests {
         assert!(adjusted < amount);
         // Fee computed on adjusted is less than fee on balance (conservative).
         let fee_on_adjusted = calc_platform_fee(adjusted, price, dec!(0.25), 2);
-        close_to(adjusted + fee_on_adjusted, dec!(49.951171875), dec!(0.000001));
+        close_to(
+            adjusted + fee_on_adjusted,
+            dec!(49.951171875),
+            dec!(0.000001),
+        );
     }
 
     #[test]
@@ -756,18 +760,18 @@ mod tests {
         let amount = dec!(100);
         // (tier_name, rate, exponent, price, expected_adjusted)
         let cases: &[(&str, Decimal, u32, Decimal, Decimal)] = &[
-            ("sports_v2 p=0.5",  dec!(0.03), 1, dec!(0.5), dec!(98.5)),
-            ("sports_v2 p=0.3",  dec!(0.03), 1, dec!(0.3), dec!(97.9)),
-            ("sports_v2 p=0.7",  dec!(0.03), 1, dec!(0.7), dec!(99.1)),
-            ("politics p=0.5",   dec!(0.04), 1, dec!(0.5), dec!(98.0)),
-            ("politics p=0.3",   dec!(0.04), 1, dec!(0.3), dec!(97.2)),
-            ("politics p=0.7",   dec!(0.04), 1, dec!(0.7), dec!(98.8)),
-            ("culture p=0.5",    dec!(0.05), 1, dec!(0.5), dec!(97.5)),
-            ("culture p=0.3",    dec!(0.05), 1, dec!(0.3), dec!(96.5)),
-            ("culture p=0.7",    dec!(0.05), 1, dec!(0.7), dec!(98.5)),
-            ("crypto_v2 p=0.5",  dec!(0.072), 1, dec!(0.5), dec!(96.4)),
-            ("crypto_v2 p=0.3",  dec!(0.072), 1, dec!(0.3), dec!(94.96)),
-            ("crypto_v2 p=0.7",  dec!(0.072), 1, dec!(0.7), dec!(97.84)),
+            ("sports_v2 p=0.5", dec!(0.03), 1, dec!(0.5), dec!(98.5)),
+            ("sports_v2 p=0.3", dec!(0.03), 1, dec!(0.3), dec!(97.9)),
+            ("sports_v2 p=0.7", dec!(0.03), 1, dec!(0.7), dec!(99.1)),
+            ("politics p=0.5", dec!(0.04), 1, dec!(0.5), dec!(98.0)),
+            ("politics p=0.3", dec!(0.04), 1, dec!(0.3), dec!(97.2)),
+            ("politics p=0.7", dec!(0.04), 1, dec!(0.7), dec!(98.8)),
+            ("culture p=0.5", dec!(0.05), 1, dec!(0.5), dec!(97.5)),
+            ("culture p=0.3", dec!(0.05), 1, dec!(0.3), dec!(96.5)),
+            ("culture p=0.7", dec!(0.05), 1, dec!(0.7), dec!(98.5)),
+            ("crypto_v2 p=0.5", dec!(0.072), 1, dec!(0.5), dec!(96.4)),
+            ("crypto_v2 p=0.3", dec!(0.072), 1, dec!(0.3), dec!(94.96)),
+            ("crypto_v2 p=0.7", dec!(0.072), 1, dec!(0.7), dec!(97.84)),
         ];
         for (name, rate, exponent, price, expected) in cases {
             let adjusted = adjust_market_buy_amount(
@@ -779,11 +783,7 @@ mod tests {
                 dec!(0),
             )
             .unwrap_or_else(|e| panic!("{name}: {e}"));
-            close_to(
-                adjusted,
-                *expected,
-                dec!(0.0001),
-            );
+            close_to(adjusted, *expected, dec!(0.0001));
         }
     }
 }

--- a/src/clob/utilities.rs
+++ b/src/clob/utilities.rs
@@ -171,9 +171,9 @@ pub fn orderbook_summary_hash(orderbook: &OrderBookSummaryResponse) -> String {
 
 /// Adjusts a market-buy USDC amount to account for platform and builder taker fees.
 ///
-/// Returns `amount` unchanged when `user_usdc_balance` already covers the total cost.
-/// Otherwise shrinks it so principal + fees = balance, then truncates to [`USDC_DECIMALS`]
-/// (matching the on-chain USDC scale). Returned amount is ready to pass to
+/// Delegates to [`super::fees::adjust_buy_amount_for_fees`] with `fee_slippage = 0`,
+/// then truncates to [`USDC_DECIMALS`] (matching the on-chain USDC scale).
+/// Returned amount is ready to pass to
 /// [`Amount::usdc`](super::types::Amount::usdc).
 ///
 /// # Errors
@@ -188,22 +188,15 @@ pub fn adjust_market_buy_amount(
     fee_exponent: Decimal,
     builder_taker_fee_rate: Decimal,
 ) -> Result<Decimal> {
-    let base = price * (Decimal::ONE - price);
-    let base_f64: f64 = base.try_into().unwrap_or(0.0);
-    let exp_f64: f64 = fee_exponent.try_into().unwrap_or(0.0);
-    let platform_fee_rate =
-        fee_rate * Decimal::try_from(base_f64.powf(exp_f64)).unwrap_or(Decimal::ZERO);
-
-    let platform_fee = amount / price * platform_fee_rate;
-    let total_cost = amount + platform_fee + amount * builder_taker_fee_rate;
-
-    // `<=` matches the TS client at the exact-equality boundary.
-    let raw = if user_usdc_balance <= total_cost {
-        let divisor = Decimal::ONE + platform_fee_rate / price + builder_taker_fee_rate;
-        user_usdc_balance / divisor
-    } else {
-        amount
-    };
+    let raw = super::fees::adjust_buy_amount_for_fees(
+        amount,
+        price,
+        user_usdc_balance,
+        fee_rate,
+        fee_exponent,
+        builder_taker_fee_rate,
+        Decimal::ZERO,
+    )?;
 
     let adjusted = raw.trunc_with_scale(USDC_DECIMALS);
     if adjusted.is_zero() {
@@ -468,9 +461,8 @@ mod tests {
             dec!(0.005),
         )
         .unwrap();
-        // effective * 1.005 = 100, truncated to 6 USDC decimals.
-        let expected = (dec!(100) / dec!(1.005)).trunc_with_scale(USDC_DECIMALS);
-        assert_eq!(result, expected);
+        // Invariant: adjusted = balance - builder_fee(balance) = 100 - 0.5 = 99.5
+        assert_eq!(result, dec!(99.5));
     }
 
     #[test]
@@ -606,9 +598,9 @@ mod tests {
     }
 
     #[test]
-    fn adjust_buy_balance_equal_to_total_cost_matches_divide_path() {
-        // TS boundary: at `balance == totalCost` the `<=` check fires and returns
-        // `balance / divisor`, which equals the original amount by construction.
+    fn adjust_buy_balance_equal_to_total_cost_returns_amount() {
+        // At `balance == totalCost` the `<=` check fires; adjusted = balance − fee(balance).
+        // When balance = amount + fee(amount), adjusted = amount + fee(amount) − fee(amount) = amount.
         let amount = dec!(50);
         let price = dec!(0.5);
         let fee = calc_platform_fee(amount, price, dec!(0.25), 2);
@@ -620,53 +612,56 @@ mod tests {
     }
 
     #[test]
-    fn adjust_buy_conserves_notional_platform_only() {
-        // balance = amount (no room for fees): adjusted + fee must reconstitute `amount`.
+    fn adjust_buy_platform_only_exact_value() {
+        // balance = amount = 50, price = 0.5, rate = 0.25, exp = 2.
+        // platform_fee = (50/0.5)*0.015625 = 1.5625 → adjusted = 48.4375
         let amount = dec!(50);
         let price = dec!(0.5);
         let adjusted =
             adjust_market_buy_amount(amount, amount, price, dec!(0.25), dec!(2), dec!(0)).unwrap();
-        let fee = calc_platform_fee(adjusted, price, dec!(0.25), 2);
-        close_to(adjusted + fee, amount, dec!(0.000001));
+        close_to(adjusted, dec!(48.4375), dec!(0.000001));
         assert!(adjusted < amount);
+        // Fee computed on adjusted is less than fee on balance (conservative).
+        let fee_on_adjusted = calc_platform_fee(adjusted, price, dec!(0.25), 2);
+        close_to(adjusted + fee_on_adjusted, dec!(49.951171875), dec!(0.000001));
     }
 
     #[test]
-    fn adjust_buy_conserves_notional_builder_only() {
+    fn adjust_buy_builder_only_exact_value() {
+        // adjusted = 50 − 50*0.01 = 49.5
         let amount = dec!(50);
         let price = dec!(0.5);
         let builder_rate = dec!(0.01);
         let adjusted =
             adjust_market_buy_amount(amount, amount, price, dec!(0), dec!(0), builder_rate)
                 .unwrap();
-        let fee = calc_builder_fee(adjusted, builder_rate);
-        close_to(adjusted + fee, amount, dec!(0.000001));
+        close_to(adjusted, dec!(49.5), dec!(0.000001));
     }
 
     #[test]
-    fn adjust_buy_conserves_notional_platform_and_builder() {
+    fn adjust_buy_combined_platform_and_builder_exact_value() {
+        // adjusted = 50 − 1.5625 − 0.5 = 47.9375
         let amount = dec!(50);
         let price = dec!(0.5);
         let builder_rate = dec!(0.01);
         let adjusted =
             adjust_market_buy_amount(amount, amount, price, dec!(0.25), dec!(2), builder_rate)
                 .unwrap();
-        let platform = calc_platform_fee(adjusted, price, dec!(0.25), 2);
-        let builder = calc_builder_fee(adjusted, builder_rate);
-        close_to(adjusted + platform + builder, amount, dec!(0.000001));
+        close_to(adjusted, dec!(47.9375), dec!(0.000001));
+        assert!(adjusted < amount);
     }
 
     #[test]
-    fn adjust_buy_conserves_notional_at_price_0_3() {
+    fn adjust_buy_at_price_0_3() {
+        // Verify adjusted < amount and adjusted > 0 for a non-midpoint price.
         let amount = dec!(30);
         let price = dec!(0.3);
         let builder_rate = dec!(0.02);
         let adjusted =
             adjust_market_buy_amount(amount, amount, price, dec!(0.25), dec!(2), builder_rate)
                 .unwrap();
-        let platform = calc_platform_fee(adjusted, price, dec!(0.25), 2);
-        let builder = calc_builder_fee(adjusted, builder_rate);
-        close_to(adjusted + platform + builder, amount, dec!(0.000001));
+        assert!(adjusted < amount);
+        assert!(adjusted > dec!(0));
     }
 
     // Production V2 fee tiers (all exp=1):
@@ -755,39 +750,40 @@ mod tests {
     }
 
     #[test]
-    fn production_adjust_buy_conserves_notional_across_all_tiers() {
-        // For every production tier at prices {0.3, 0.5, 0.7}, `adjust + fee ≈ amount`
-        // when `balance == amount` (i.e. the budget is fully consumed).
+    fn production_adjust_buy_exact_values_across_all_tiers() {
+        // For every production tier at prices {0.3, 0.5, 0.7}, verify the exact adjusted
+        // value when balance == amount (budget fully consumed, no builder fee).
         let amount = dec!(100);
-        let tiers: [(&str, Decimal, u32); 4] = [
-            ("sports_v2", dec!(0.03), 1),
-            ("politics_family", dec!(0.04), 1),
-            ("culture_family", dec!(0.05), 1),
-            ("crypto_v2", dec!(0.072), 1),
+        // (tier_name, rate, exponent, price, expected_adjusted)
+        let cases: &[(&str, Decimal, u32, Decimal, Decimal)] = &[
+            ("sports_v2 p=0.5",  dec!(0.03), 1, dec!(0.5), dec!(98.5)),
+            ("sports_v2 p=0.3",  dec!(0.03), 1, dec!(0.3), dec!(97.9)),
+            ("sports_v2 p=0.7",  dec!(0.03), 1, dec!(0.7), dec!(99.1)),
+            ("politics p=0.5",   dec!(0.04), 1, dec!(0.5), dec!(98.0)),
+            ("politics p=0.3",   dec!(0.04), 1, dec!(0.3), dec!(97.2)),
+            ("politics p=0.7",   dec!(0.04), 1, dec!(0.7), dec!(98.8)),
+            ("culture p=0.5",    dec!(0.05), 1, dec!(0.5), dec!(97.5)),
+            ("culture p=0.3",    dec!(0.05), 1, dec!(0.3), dec!(96.5)),
+            ("culture p=0.7",    dec!(0.05), 1, dec!(0.7), dec!(98.5)),
+            ("crypto_v2 p=0.5",  dec!(0.072), 1, dec!(0.5), dec!(96.4)),
+            ("crypto_v2 p=0.3",  dec!(0.072), 1, dec!(0.3), dec!(94.96)),
+            ("crypto_v2 p=0.7",  dec!(0.072), 1, dec!(0.7), dec!(97.84)),
         ];
-        let prices = [dec!(0.3), dec!(0.5), dec!(0.7)];
-        for (name, rate, exponent) in tiers {
-            for price in prices {
-                let adjusted = adjust_market_buy_amount(
-                    amount,
-                    amount,
-                    price,
-                    rate,
-                    Decimal::from(exponent),
-                    dec!(0),
-                )
-                .unwrap_or_else(|e| {
-                    panic!("adjust failed for {name} @ price={price}: {e}");
-                });
-                let fee = calc_platform_fee(adjusted, price, rate, exponent);
-                let diff = (adjusted + fee - amount).abs();
-                assert!(
-                    diff <= dec!(0.0001),
-                    "tier={name} price={price}: adjusted ({adjusted}) + fee ({fee}) = {} vs \
-                     amount {amount}, diff {diff}",
-                    adjusted + fee,
-                );
-            }
+        for (name, rate, exponent, price, expected) in cases {
+            let adjusted = adjust_market_buy_amount(
+                amount,
+                amount,
+                *price,
+                *rate,
+                Decimal::from(*exponent),
+                dec!(0),
+            )
+            .unwrap_or_else(|e| panic!("{name}: {e}"));
+            close_to(
+                adjusted,
+                *expected,
+                dec!(0.0001),
+            );
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how V2 BUY orders are sized when `user_usdc_balance` is provided, which can alter on-chain order amounts and potentially reject orders that previously succeeded. Risk is mitigated by strict validation, defaulting to no padding, and extensive unit/integration tests.
> 
> **Overview**
> Adds a new `fee_slippage` percentage (default `0`) at both `Config` and `OrderBuilder` levels to pad the **platform-fee reserve** for BUY orders, with validation that it is `0` or in `[1, 100]`.
> 
> Introduces `clob::fees` with shared fee-reservation logic and updates V2 BUY **limit** and **market** order building to conservatively shrink notional/size/amount when `user_usdc_balance` is set so `principal + (padded platform fee) + builder fee ≤ balance`, erroring if truncation would produce a zero-sized order. Existing `adjust_market_buy_amount` is refactored to delegate to the new logic (with slippage disabled), and tests are updated/added to lock in the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88080c9d58776e78ac579bbb84e3e45345f80998. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->