### PR TITLE
update request methods for readonly endpoints

### DIFF
--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -743,7 +743,7 @@ impl<S: State> Client<S> {
     pub async fn midpoints(&self, requests: &[MidpointRequest]) -> Result<MidpointsResponse> {
         let request = self
             .client()
-            .request(Method::POST, format!("{}midpoints", self.host()))
+            .request(Method::GET, format!("{}midpoints", self.host()))
             .json(requests)
             .build()?;
 
@@ -779,7 +779,7 @@ impl<S: State> Client<S> {
     pub async fn prices(&self, requests: &[PriceRequest]) -> Result<PricesResponse> {
         let request = self
             .client()
-            .request(Method::POST, format!("{}prices", self.host()))
+            .request(Method::GET, format!("{}prices", self.host()))
             .json(requests)
             .build()?;
 
@@ -837,7 +837,7 @@ impl<S: State> Client<S> {
     pub async fn spreads(&self, requests: &[SpreadRequest]) -> Result<SpreadsResponse> {
         let request = self
             .client()
-            .request(Method::POST, format!("{}spreads", self.host()))
+            .request(Method::GET, format!("{}spreads", self.host()))
             .json(requests)
             .build()?;
 
@@ -1082,7 +1082,7 @@ impl<S: State> Client<S> {
     ) -> Result<Vec<OrderBookSummaryResponse>> {
         let request = self
             .client()
-            .request(Method::POST, format!("{}books", self.host()))
+            .request(Method::GET, format!("{}books", self.host()))
             .json(requests)
             .build()?;
 


### PR DESCRIPTION
This PR updates the request methods to **GET** for some readonly batch endpoints:
`midpoints`, `prices`, `spreads` and `books`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing these batch endpoints from `POST` to `GET` can break compatibility if the server or intermediaries don’t accept GET requests with JSON bodies or if existing clients relied on POST behavior.
> 
> **Overview**
> Switches the batch read-only market-data calls (`midpoints`, `prices`, `spreads`, `books` via `order_books`) in `src/clob/client.rs` from `POST` to `GET` while keeping the same request payload/response handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 376df800f42f1c818672dac6b94d1ac53a0f5e28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->