### PR TITLE
feat(clob): add batch price history endpoint

### DIFF
--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -30,17 +30,17 @@ use crate::auth::state::{Authenticated, State, Unauthenticated};
 use crate::auth::{Credentials, Kind, Normal};
 use crate::clob::order_builder::{Limit, Market, OrderBuilder, generate_seed};
 use crate::clob::types::request::{
-    BalanceAllowanceRequest, CancelMarketOrderRequest, DeleteNotificationsRequest,
-    LastTradePriceRequest, MidpointRequest, OrderBookSummaryRequest, OrdersRequest,
-    PriceHistoryRequest, PriceRequest, SpreadRequest, TradesRequest, UpdateBalanceAllowanceRequest,
-    UserRewardsEarningRequest,
+    BalanceAllowanceRequest, BatchPriceHistoryRequest, CancelMarketOrderRequest,
+    DeleteNotificationsRequest, LastTradePriceRequest, MidpointRequest, OrderBookSummaryRequest,
+    OrdersRequest, PriceHistoryRequest, PriceRequest, SpreadRequest, TradesRequest,
+    UpdateBalanceAllowanceRequest, UserRewardsEarningRequest,
 };
 use crate::clob::types::response::{
-    ApiKeysResponse, BalanceAllowanceResponse, BanStatusResponse, BuilderApiKeyResponse,
-    BuilderFeeRateResponse, BuilderTradeResponse, CancelOrdersResponse, ClobMarketInfoResponse,
-    CurrentRewardResponse, FeeInfo, FeeRateResponse, GeoblockResponse, HeartbeatResponse,
-    LastTradePriceResponse, LastTradesPricesResponse, MarketByTokenResponse, MarketResponse,
-    MarketRewardResponse, MidpointResponse, MidpointsResponse, NegRiskResponse,
+    ApiKeysResponse, BalanceAllowanceResponse, BanStatusResponse, BatchPriceHistoryResponse,
+    BuilderApiKeyResponse, BuilderFeeRateResponse, BuilderTradeResponse, CancelOrdersResponse,
+    ClobMarketInfoResponse, CurrentRewardResponse, FeeInfo, FeeRateResponse, GeoblockResponse,
+    HeartbeatResponse, LastTradePriceResponse, LastTradesPricesResponse, MarketByTokenResponse,
+    MarketResponse, MarketRewardResponse, MidpointResponse, MidpointsResponse, NegRiskResponse,
     NotificationResponse, OpenOrderResponse, OrderBookSummaryResponse, OrderScoringResponse,
     OrdersScoringResponse, Page, PostOrderResponse, PriceHistoryResponse, PriceResponse,
     PricesResponse, ReadonlyApiKeyResponse, RewardsPercentagesResponse, SimplifiedMarketResponse,
@@ -803,6 +803,26 @@ impl<S: State> Client<S> {
             Method::GET,
             format!("{}prices-history{params}", self.host()),
         );
+
+        crate::request(&self.inner.client, req.build()?, None).await
+    }
+
+    /// Retrieves historical price data for multiple market outcome tokens.
+    ///
+    /// This is the batch version of [`Self::price_history`]. It accepts up to 20
+    /// market asset IDs and returns time-series price data keyed by token ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or any token ID is invalid.
+    pub async fn batch_price_history(
+        &self,
+        request: &BatchPriceHistoryRequest,
+    ) -> Result<BatchPriceHistoryResponse> {
+        let req = self
+            .client()
+            .request(Method::POST, format!("{}batch-prices-history", self.host()))
+            .json(request);
 
         crate::request(&self.inner.client, req.build()?, None).await
     }

--- a/src/clob/mod.rs
+++ b/src/clob/mod.rs
@@ -50,6 +50,7 @@
 //! | `/simplified-markets` | Markets with reduced detail |
 //! | `/sampling-simplified-markets` | Simplified sampling markets |
 //! | `/prices-history` | Historical price data |
+//! | `/batch-prices-history` | Batch historical price data |
 //! | `/geoblock` | Geographic restriction check |
 //!
 //! ## Authenticated Endpoints

--- a/src/clob/types/mod.rs
+++ b/src/clob/types/mod.rs
@@ -111,6 +111,10 @@ pub enum Interval {
     #[serde(rename = "1w")]
     #[strum(serialize = "1w")]
     OneWeek,
+    /// All available history
+    #[serde(rename = "all")]
+    #[strum(serialize = "all")]
+    All,
     /// Maximum available history
     #[serde(rename = "max")]
     #[strum(serialize = "max")]
@@ -930,6 +934,11 @@ mod tests {
         assert_eq!(shares.as_inner(), Decimal::ONE_HUNDRED);
 
         Ok(())
+    }
+
+    #[test]
+    fn interval_all_should_serialize() {
+        assert_eq!(serde_json::to_string(&Interval::All).unwrap(), r#""all""#);
     }
 
     #[test]

--- a/src/clob/types/request.rs
+++ b/src/clob/types/request.rs
@@ -15,7 +15,7 @@ use {
     crate::{Timestamp, auth::ApiKey, types::Decimal},
 };
 
-use crate::clob::types::{AssetType, Side, SignatureType, TimeRange};
+use crate::clob::types::{AssetType, Interval, Side, SignatureType, TimeRange};
 use crate::types::U256;
 use crate::types::{Address, B256};
 
@@ -83,7 +83,68 @@ pub struct PriceHistoryRequest {
     #[serde(flatten)]
     #[builder(into)]
     pub time_range: TimeRange,
-    /// Optional fidelity (number of data points).
+    /// Optional fidelity/resolution in minutes (defaults to 1 minute).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fidelity: Option<u32>,
+}
+
+/// Time range specification for batch price history request bodies.
+///
+/// The batch endpoint accepts snake_case `start_ts` and `end_ts` JSON keys, while the
+/// single-market endpoint accepts camelCase query parameters.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(untagged)]
+pub enum BatchPriceHistoryTimeRange {
+    /// Use a predefined interval (e.g. last day, last week, max history).
+    Interval {
+        /// The time interval.
+        interval: Interval,
+    },
+    /// Use explicit start and end timestamps.
+    Range {
+        /// Start timestamp (Unix seconds).
+        start_ts: i64,
+        /// End timestamp (Unix seconds).
+        end_ts: i64,
+    },
+}
+
+impl BatchPriceHistoryTimeRange {
+    /// Create a batch price history range from a predefined interval.
+    #[must_use]
+    pub const fn from_interval(interval: Interval) -> Self {
+        Self::Interval { interval }
+    }
+
+    /// Create a batch price history range from explicit timestamps.
+    #[must_use]
+    pub const fn from_range(start_ts: i64, end_ts: i64) -> Self {
+        Self::Range { start_ts, end_ts }
+    }
+}
+
+impl From<Interval> for BatchPriceHistoryTimeRange {
+    fn from(interval: Interval) -> Self {
+        Self::from_interval(interval)
+    }
+}
+
+#[serde_as]
+#[non_exhaustive]
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Builder)]
+#[builder(on(String, into))]
+pub struct BatchPriceHistoryRequest {
+    /// The CLOB token IDs to fetch price history for. The API accepts at most 20.
+    #[serde_as(as = "Vec<DisplayFromStr>")]
+    pub markets: Vec<U256>,
+    /// The time range for the price history query.
+    /// Either a predefined interval or explicit start/end timestamps.
+    #[serde(flatten)]
+    #[builder(into)]
+    pub time_range: BatchPriceHistoryTimeRange,
+    /// Optional fidelity/resolution in minutes (defaults to 1 minute).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fidelity: Option<u32>,
 }

--- a/src/clob/types/response.rs
+++ b/src/clob/types/response.rs
@@ -67,6 +67,12 @@ pub struct PriceHistoryResponse {
 
 #[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, Builder, PartialEq)]
+pub struct BatchPriceHistoryResponse {
+    pub history: HashMap<U256, Vec<PricePoint>>,
+}
+
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize, Builder, PartialEq)]
 pub struct PricePoint {
     pub t: i64,
     pub p: Decimal,

--- a/tests/clob.rs
+++ b/tests/clob.rs
@@ -32,15 +32,15 @@ mod unauthenticated {
     use futures_util::future;
     use futures_util::stream::StreamExt as _;
     use polymarket_client_sdk_v2::clob::types::request::{
-        LastTradePriceRequest, MidpointRequest, OrderBookSummaryRequest, PriceHistoryRequest,
-        PriceRequest, SpreadRequest,
+        BatchPriceHistoryRequest, BatchPriceHistoryTimeRange, LastTradePriceRequest,
+        MidpointRequest, OrderBookSummaryRequest, PriceHistoryRequest, PriceRequest, SpreadRequest,
     };
     use polymarket_client_sdk_v2::clob::types::response::{
-        FeeRateResponse, GeoblockResponse, LastTradePriceResponse, LastTradesPricesResponse,
-        MarketResponse, MidpointResponse, MidpointsResponse, NegRiskResponse,
-        OrderBookSummaryResponse, OrderSummary, Page, PriceHistoryResponse, PricePoint,
-        PriceResponse, PricesResponse, Rewards, SimplifiedMarketResponse, SpreadResponse,
-        SpreadsResponse, TickSizeResponse, Token,
+        BatchPriceHistoryResponse, FeeRateResponse, GeoblockResponse, LastTradePriceResponse,
+        LastTradesPricesResponse, MarketResponse, MidpointResponse, MidpointsResponse,
+        NegRiskResponse, OrderBookSummaryResponse, OrderSummary, Page, PriceHistoryResponse,
+        PricePoint, PriceResponse, PricesResponse, Rewards, SimplifiedMarketResponse,
+        SpreadResponse, SpreadsResponse, TickSizeResponse, Token,
     };
     use polymarket_client_sdk_v2::clob::types::{Interval, Side, TickSize, TimeRange};
     use polymarket_client_sdk_v2::error::Status;
@@ -288,6 +288,141 @@ mod unauthenticated {
 
         assert_eq!(response, expected);
         mock.assert();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn batch_price_history_with_interval_should_succeed() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = Client::new(&server.base_url(), Config::default())?;
+
+        let market_1 = U256::from(0x123);
+        let market_2 = U256::from(0x456);
+        let mock = server.mock(|when, then| {
+            when.method(httpmock::Method::POST)
+                .path("/batch-prices-history");
+            then.status(StatusCode::OK).json_body(json!({
+                "history": {
+                    market_1.to_string(): [
+                        { "t": 1000, "p": "0.5" },
+                        { "t": 1500, "p": "0.55" }
+                    ],
+                    market_2.to_string(): [
+                        { "t": 1000, "p": "0.6" }
+                    ]
+                }
+            }));
+        });
+
+        let request = BatchPriceHistoryRequest::builder()
+            .markets(vec![market_1, market_2])
+            .time_range(BatchPriceHistoryTimeRange::from_interval(Interval::OneHour))
+            .fidelity(10)
+            .build();
+        let response = client.batch_price_history(&request).await?;
+
+        let expected = BatchPriceHistoryResponse::builder()
+            .history(HashMap::from([
+                (
+                    market_1,
+                    vec![
+                        PricePoint::builder().t(1000).p(dec!(0.5)).build(),
+                        PricePoint::builder().t(1500).p(dec!(0.55)).build(),
+                    ],
+                ),
+                (
+                    market_2,
+                    vec![PricePoint::builder().t(1000).p(dec!(0.6)).build()],
+                ),
+            ]))
+            .build();
+
+        assert_eq!(response, expected);
+        mock.assert();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn batch_price_history_with_range_should_succeed() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = Client::new(&server.base_url(), Config::default())?;
+
+        let market = U256::from(0x123);
+        let mock = server.mock(|when, then| {
+            when.method(httpmock::Method::POST)
+                .path("/batch-prices-history");
+            then.status(StatusCode::OK).json_body(json!({
+                "history": {
+                    market.to_string(): [
+                        { "t": 1000, "p": "0.5" },
+                        { "t": 2000, "p": "0.6" }
+                    ]
+                }
+            }));
+        });
+
+        let request = BatchPriceHistoryRequest::builder()
+            .markets(vec![market])
+            .time_range(BatchPriceHistoryTimeRange::from_range(1000, 2000))
+            .build();
+        let response = client.batch_price_history(&request).await?;
+
+        let expected = BatchPriceHistoryResponse::builder()
+            .history(HashMap::from([(
+                market,
+                vec![
+                    PricePoint::builder().t(1000).p(dec!(0.5)).build(),
+                    PricePoint::builder().t(2000).p(dec!(0.6)).build(),
+                ],
+            )]))
+            .build();
+
+        assert_eq!(response, expected);
+        mock.assert();
+
+        Ok(())
+    }
+
+    #[test]
+    fn batch_price_history_interval_request_serializes_body() -> anyhow::Result<()> {
+        let market_1 = U256::from(0x123);
+        let market_2 = U256::from(0x456);
+        let request = BatchPriceHistoryRequest::builder()
+            .markets(vec![market_1, market_2])
+            .time_range(BatchPriceHistoryTimeRange::from_interval(Interval::OneHour))
+            .fidelity(10)
+            .build();
+
+        assert_eq!(
+            serde_json::to_value(&request)?,
+            json!({
+                "markets": [market_1.to_string(), market_2.to_string()],
+                "interval": "1h",
+                "fidelity": 10,
+            })
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn batch_price_history_range_request_serializes_body() -> anyhow::Result<()> {
+        let market = U256::from(0x123);
+        let request = BatchPriceHistoryRequest::builder()
+            .markets(vec![market])
+            .time_range(BatchPriceHistoryTimeRange::from_range(1000, 2000))
+            .build();
+
+        assert_eq!(
+            serde_json::to_value(&request)?,
+            json!({
+                "markets": [market.to_string()],
+                "start_ts": 1000,
+                "end_ts": 2000,
+            })
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Add typed request and response models for `POST /batch-prices-history`
- Expose `Client::batch_price_history` for fetching multiple market price histories in one call
- Support the documented `all` price-history interval
- Cover interval and explicit `start_ts`/`end_ts` request bodies with CLOB tests


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new unauthenticated client method and typed request/response models without changing existing endpoint behavior; main risk is mismatched JSON shape for the new POST body.
> 
> **Overview**
> Adds a new `Client::batch_price_history` method plus `BatchPriceHistoryRequest`/`BatchPriceHistoryResponse` models to call `POST /batch-prices-history` and return per-token time-series history.
> 
> Extends `Interval` with an `all` variant and updates docs/tests to cover both interval-based and explicit `start_ts`/`end_ts` batch request bodies, including JSON serialization expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f628fe0369682cb4d1cce606c9e1baa9790d2ac3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->