### PR TITLE
fix(examples): install a rustls crypto provider so WebSocket examples don't panic/hang

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3654,6 +3654,7 @@ dependencies = [
  "reqwest 0.13.2",
  "rust_decimal",
  "rust_decimal_macros",
+ "rustls 0.23.38",
  "secrecy",
  "serde",
  "serde_html_form",
@@ -4342,6 +4343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ aws-sdk-kms = "1.99.0"
 criterion = { version = "0.8.2", features = ["html_reports"] }
 futures-util = "0.3.31"
 httpmock = "0.8.3"
+rustls = "0.23.38"
 tokio = { version = "1.50.0", features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/examples/clob/ws/orderbook.rs
+++ b/examples/clob/ws/orderbook.rs
@@ -28,6 +28,12 @@ use tracing_subscriber::util::SubscriberInitExt as _;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // rustls cannot auto-select a crypto provider when more than one
+    // (`aws-lc-rs` and `ring`) is in the dependency graph, so the WebSocket TLS
+    // handshake panics on a background task and the connection hangs forever.
+    // Install one explicitly before connecting. See issue #57.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     if let Ok(path) = std::env::var("LOG_FILE") {
         let file = File::create(path)?;
         tracing_subscriber::registry()

--- a/examples/clob/ws/unsubscribe.rs
+++ b/examples/clob/ws/unsubscribe.rs
@@ -35,6 +35,12 @@ use tracing_subscriber::util::SubscriberInitExt as _;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // rustls cannot auto-select a crypto provider when more than one
+    // (`aws-lc-rs` and `ring`) is in the dependency graph, so the WebSocket TLS
+    // handshake panics on a background task and the connection hangs forever.
+    // Install one explicitly before connecting. See issue #57.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     if let Ok(path) = std::env::var("LOG_FILE") {
         let file = File::create(path)?;
         tracing_subscriber::registry()

--- a/examples/clob/ws/user.rs
+++ b/examples/clob/ws/user.rs
@@ -36,6 +36,12 @@ use uuid::Uuid;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // rustls cannot auto-select a crypto provider when more than one
+    // (`aws-lc-rs` and `ring`) is in the dependency graph, so the WebSocket TLS
+    // handshake panics on a background task and the connection hangs forever.
+    // Install one explicitly before connecting. See issue #57.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     if let Ok(path) = std::env::var("LOG_FILE") {
         let file = File::create(path)?;
         tracing_subscriber::registry()

--- a/examples/rtds_crypto_prices.rs
+++ b/examples/rtds_crypto_prices.rs
@@ -22,6 +22,12 @@ use tracing::{debug, info, warn};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // rustls cannot auto-select a crypto provider when more than one
+    // (`aws-lc-rs` and `ring`) is in the dependency graph, so the WebSocket TLS
+    // handshake panics on a background task and the connection hangs forever.
+    // Install one explicitly before connecting. See issue #57.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     tracing_subscriber::fmt::init();
 
     let client = Client::default();


### PR DESCRIPTION
## Summary

The WebSocket examples currently **panic on a background task and then hang forever with no output** when run out of the box, e.g.:

```sh
cargo run --example websocket_orderbook --features clob,ws,tracing
# connects to nothing — no data, no error, just hangs
```

Root cause (full writeup in #57): the WS examples connect via `tokio-tungstenite` + `rustls`. This repo's `dev-dependencies` pull in **two** rustls crypto providers — `aws-lc-rs` (rustls' default, via `reqwest`) **and** `ring` (via the `alloy` `signer-aws` dev-dependency used by the `aws_authenticated` example). With more than one provider present, rustls cannot auto-select a process-level `CryptoProvider`, so the TLS handshake panics:

```
thread 'tokio-rt-worker' panicked at rustls-0.23.38/src/crypto/mod.rs:249:
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
... make sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
```

Because the connection runs in a detached `tokio::spawn` task, the panic never surfaces — the connection state stays `Connecting` and the subscription stream pends forever.

## Fix

Install rustls' default provider (`aws_lc_rs`, unconditionally present via `reqwest`) at the start of each WebSocket example, and add `rustls` as a `dev-dependency` so the examples can name it.

Affected examples (the ones that open a `tokio-tungstenite` connection):
- `websocket_orderbook`
- `websocket_user`
- `websocket_unsubscribe`
- `rtds_crypto_prices`

REST/`reqwest`-based examples (`gamma_streaming`, `streaming`, `heartbeats`, …) are unaffected — `reqwest` configures its own provider.

## Verification

- **Before:** `websocket_orderbook` stays stuck at `connection_state == Connecting` for the entire run, zero messages.
- **After:** connects immediately and streams the initial book snapshot followed by live updates.

> Note: `rtds_crypto_prices` additionally needs the `clob` feature to compile today, due to an unrelated, pre-existing feature-gating bug in `src/serde_helpers.rs` (the `serde_json::Value` import is missing under `rtds,tracing` alone). That's out of scope for this PR — happy to file/fix it separately.

Refs #57

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to dev-dependencies and example binaries, explicitly selecting a rustls crypto provider to avoid a TLS-handshake panic/hang when multiple providers are present.
> 
> **Overview**
> Fixes WebSocket examples that could silently hang by **explicitly installing** the `rustls` `aws_lc_rs` crypto provider before establishing TLS connections.
> 
> Adds `rustls` as a `dev-dependency` (and updates `Cargo.lock`) so examples can call `rustls::crypto::aws_lc_rs::default_provider().install_default()` in `websocket_orderbook`, `websocket_user`, `websocket_unsubscribe`, and `rtds_crypto_prices`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8f2e5f8b4873ad0367bc0304711e35512b4f98e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->