### PR TITLE
ws: add subscribe_new_markets_unfiltered for market discovery

### DIFF
--- a/src/clob/ws/client.rs
+++ b/src/clob/ws/client.rs
@@ -336,6 +336,37 @@ impl<S: State> Client<S> {
         }))
     }
 
+    /// Subscribe to all `new_market` events on the market channel without
+    /// asset-id filtering.
+    ///
+    /// Unlike [`subscribe_new_markets`](Self::subscribe_new_markets), this
+    /// does not require a list of known asset IDs and yields events for any
+    /// newly created market — useful for real-time market discovery.
+    ///
+    /// Requires that another market subscription on the same channel has
+    /// enabled `custom_features` (e.g. via
+    /// [`subscribe_market_resolutions`](Self::subscribe_market_resolutions)
+    /// or [`subscribe_best_bid_ask`](Self::subscribe_best_bid_ask));
+    /// otherwise the server will not broadcast `new_market` events to this
+    /// channel.
+    pub fn subscribe_new_markets_unfiltered(
+        &self,
+    ) -> Result<impl Stream<Item = Result<NewMarket>> + use<S>> {
+        let stream = self
+            .inner
+            .get_or_create_channel(ChannelType::Market)?
+            .subscriptions
+            .subscribe_market_unfiltered()?;
+
+        Ok(stream.filter_map(|msg_result| async move {
+            match msg_result {
+                Ok(WsMessage::NewMarket(nm)) => Some(Ok(nm)),
+                Err(e) => Some(Err(e)),
+                _ => None,
+            }
+        }))
+    }
+
     /// Subscribe to market resolved events with custom features enabled.
     ///
     /// Requires `custom_features_enabled` flag on the server side.

--- a/src/clob/ws/subscription.rs
+++ b/src/clob/ws/subscription.rs
@@ -327,6 +327,40 @@ impl SubscriptionManager {
         })
     }
 
+    /// Subscribe to public market data channel without asset-id filtering.
+    ///
+    /// Returns the raw stream of [`WsMessage`] events on the market channel,
+    /// including `new_market` events for markets whose asset IDs are not yet
+    /// known to the caller. Useful for market discovery.
+    ///
+    /// Does not send a subscription request to the server — relies on another
+    /// market subscription on this channel being already active. For custom
+    /// message types (`best_bid_ask`, `new_market`, `market_resolved`), that
+    /// other subscription must have been created with `custom_features = true`.
+    pub fn subscribe_market_unfiltered(
+        &self,
+    ) -> Result<impl Stream<Item = Result<WsMessage>> + use<>> {
+        self.interest.add(MessageInterest::MARKET);
+        self.custom_features_enabled.store(true, Ordering::Relaxed);
+
+        let mut rx = self.connection.subscribe();
+
+        Ok(try_stream! {
+            loop {
+                match rx.recv().await {
+                    Ok(msg) => yield msg,
+                    Err(RecvError::Lagged(_n)) => {
+                        #[cfg(feature = "tracing")]
+                        tracing::warn!(
+                            "Unfiltered market subscription lagged, missed {_n} messages — continuing"
+                        );
+                    }
+                    Err(RecvError::Closed) => break,
+                }
+            }
+        })
+    }
+
     /// Subscribe to authenticated user channel.
     pub fn subscribe_user(
         &self,


### PR DESCRIPTION
Adds SubscriptionManager::subscribe_market_unfiltered() returning the raw WsMessage stream on the market channel without asset-id filtering, and Client::subscribe_new_markets_unfiltered() as a typed wrapper.

Use case: real-time discovery of newly created markets whose asset IDs are not known in advance. Requires another market subscription on the same channel to have enabled custom_features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public WebSocket API with no auth or persistence changes; main caveat is relying on another subscription to enable custom features on the channel.
> 
> **Overview**
> Adds **unfiltered** market WebSocket subscriptions so callers can discover **new markets** without prelisting asset IDs.
> 
> `SubscriptionManager::subscribe_market_unfiltered` taps the shared market channel broadcast and yields every `WsMessage` (no per-asset filtering and **no** new server subscribe payload). It still registers market interest and marks `custom_features` as enabled for reconnect behavior. `Client::subscribe_new_markets_unfiltered` is the typed wrapper that keeps only `NewMarket` events—parallel to the existing asset-scoped `subscribe_new_markets`, but with an empty asset list.
> 
> Docs note an operational requirement: **`new_market` only flows if another subscription on the same channel already turned on custom features** (e.g. `subscribe_best_bid_ask` or `subscribe_market_resolutions`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d9f6abb3a337e2f1255a0c3e77d9cf5773a72f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->