### PR TITLE
add event_metadata & teams for Event

### DIFF
--- a/src/gamma/types/response.rs
+++ b/src/gamma/types/response.rs
@@ -6,6 +6,7 @@
 use bon::Builder;
 use chrono::{DateTime, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use serde_with::NoneAsEmptyString;
 use serde_with::json::JsonString;
 use serde_with::{DisplayFromStr, StringWithSeparator, formats::CommaSeparator, serde_as};
@@ -334,6 +335,39 @@ pub struct Event {
     pub cumulative_markets: Option<bool>,
     pub away_team_name: Option<String>,
     pub home_team_name: Option<String>,
+    pub event_metadata: Option<EventMetadata>,
+    pub teams: Option<Vec<Team>>,
+}
+
+/// A event metadata enum.
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+#[non_exhaustive]
+pub enum EventMetadata {
+    UpDown(UpDownEventMetadata),
+    Contexted(ContextedEventMetadata),
+    Other(Value),
+}
+
+/// A up-down event metadata.
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Builder)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct UpDownEventMetadata {
+    pub final_price: Option<f64>,
+    pub price_to_beat: f64,
+}
+
+/// A contexted event metadata.
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Builder)]
+#[non_exhaustive]
+pub struct ContextedEventMetadata {
+    pub context_description: String,
+    pub context_requires_regen: bool,
+    pub context_updated_at: DateTime<Utc>,
 }
 
 /// A prediction market.


### PR DESCRIPTION
added `event_metadata` field; it typically contains the event context, or `final_price` and `price_to_beat` in the case of an up/down event. In all other cases, the enum accepts any JSON value or `null`.

added `teams` field, which lists the participating teams for sporting events.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional serde fields on API response types; no auth or runtime behavior changes.
> 
> **Overview**
> Extends the Gamma **`Event`** response model so clients can deserialize two new API fields.
> 
> **`event_metadata`** is modeled as an untagged **`EventMetadata`** enum: **`UpDownEventMetadata`** (`final_price`, `price_to_beat`) for up/down markets, **`ContextedEventMetadata`** (context text, regen flag, timestamp) for context-driven events, and **`Other(serde_json::Value)`** for any other JSON shape or future variants.
> 
> **`teams`** is an optional list of existing **`Team`** records for sporting events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22908203821e6f20491f1160633915faff22e7d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->