### PR TITLE
fix(clob): tolerate empty-string Decimals and missing tx_hash when deserializing fills

### DIFF
--- a/src/clob/types/response.rs
+++ b/src/clob/types/response.rs
@@ -387,8 +387,11 @@ pub struct TradeResponse {
     pub market: B256,
     pub asset_id: U256,
     pub side: Side,
+    #[serde(deserialize_with = "empty_string_as_zero")]
     pub size: Decimal,
+    #[serde(deserialize_with = "empty_string_as_zero")]
     pub fee_rate_bps: Decimal,
+    #[serde(deserialize_with = "empty_string_as_zero")]
     pub price: Decimal,
     pub status: TradeStatusType,
     #[serde_as(as = "TimestampSeconds<String>")]
@@ -403,6 +406,7 @@ pub struct TradeResponse {
     #[serde_as(deserialize_as = "DefaultOnNull")]
     pub maker_orders: Vec<MakerOrder>,
     /// On-chain transaction hash.
+    #[serde(default)]
     pub transaction_hash: B256,
     pub trader_side: TraderSide,
     #[serde(default)]
@@ -516,8 +520,11 @@ pub struct MakerOrder {
     pub order_id: String,
     pub owner: ApiKey,
     pub maker_address: Address,
+    #[serde(deserialize_with = "empty_string_as_zero")]
     pub matched_amount: Decimal,
+    #[serde(deserialize_with = "empty_string_as_zero")]
     pub price: Decimal,
+    #[serde(deserialize_with = "empty_string_as_zero")]
     pub fee_rate_bps: Decimal,
     pub asset_id: U256,
     pub outcome: String,


### PR DESCRIPTION
## Problem

The live Polymarket CLOB API occasionally serializes `Decimal` money fields as empty strings (`""`) and omits `transaction_hash` for maker fills that are not yet on-chain. With the current strict typing this makes the **entire `/trades` response batch fail to deserialize** — a single `""` in one record fails the whole `Page<TradeResponse>` parse, silently dropping every fill in that batch.

Observed in production on `GET /trades`:

- `TradeResponse.size`, `TradeResponse.fee_rate_bps`, `TradeResponse.price` → sometimes `""`
- `MakerOrder.matched_amount`, `MakerOrder.price`, `MakerOrder.fee_rate_bps` → sometimes `""`
- `TradeResponse.transaction_hash` → absent for maker fills not yet settled on-chain

## Fix

- Apply the existing `empty_string_as_zero` deserializer (already used on `PostOrderResponse.making_amount` / `taking_amount`) to the six `Decimal` fields above, so `""` parses as `Decimal::ZERO` instead of erroring.
- Mark `TradeResponse.transaction_hash` as `#[serde(default)]`, so a missing hash deserializes to `B256::default()` (the zero hash) rather than failing.

## Compatibility

Backward compatible: well-formed responses with present, non-empty values deserialize exactly as before. Only the previously-fatal empty/missing cases change — from "whole batch errors out" to "that field is zero / default". `empty_string_as_zero` already exists in `response.rs`, so this is attribute-only — no new helpers and no API/signature changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Attribute-only serde changes on response DTOs; no API or logic changes, with backward-compatible parsing for well-formed payloads.
> 
> **Overview**
> **Hardens `/trades` deserialization** so a single malformed field no longer fails an entire `Page<TradeResponse>` batch from the live CLOB API.
> 
> On **`TradeResponse`**, `size`, `fee_rate_bps`, and `price` now use the existing `empty_string_as_zero` deserializer (same pattern as `PostOrderResponse`), so `""` becomes `Decimal::ZERO`. **`transaction_hash`** gets `#[serde(default)]`, so omitted hashes (e.g. maker fills not yet on-chain) deserialize to the default `B256` instead of erroring.
> 
> On **`MakerOrder`**, `matched_amount`, `price`, and `fee_rate_bps` get the same `empty_string_as_zero` treatment. Normal non-empty values behave unchanged; only previously fatal empty/missing wire shapes are relaxed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d36cc61f4c47baafa1b8b3b776765574b1e78b64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->