### PR TITLE
Normalize taker and maker amounts in orders

### DIFF
--- a/src/clob/order_builder.rs
+++ b/src/clob/order_builder.rs
@@ -343,6 +343,9 @@ impl<K: AuthKind> OrderBuilder<Limit, K> {
             side => return Err(Error::validation(format!("Invalid side: {side}"))),
         };
 
+        taker_amount.normalize_assign();
+        maker_amount.normalize_assign();
+
         let salt = to_ieee_754_int((self.salt_generator)());
         let expiration_u256 = U256::from(expiration.timestamp().to_u64().ok_or(
             Error::validation(format!(


### PR DESCRIPTION
When creating an order, the price is multiplied by the size. Often rust overestimates the scale of the product. This can lead to decimal number such as 1567300*10^(-5) instead of 15673*10^(-3) and subsequently this may be rejected by the server. Normalizing the amounts before creating the order solves this problem.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two-line normalization in limit order build only; intended numeric values unchanged, reduces spurious server rejections.
> 
> **Overview**
> Limit order construction now **canonicalizes** `taker_amount` and `maker_amount` with `normalize_assign()` right after `size * price` is truncated, and before those values are passed through `to_fixed_u128` into the order payload.
> 
> That addresses cases where `rust_decimal` keeps an inflated scale on the product (same value, different representation), which the CLOB server can reject even though `to_fixed_u128` already normalizes at encode time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2256069ce739882c7a951c8d3baa815f8a667af3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->