### PR TITLE
feat(clob): add QuarterCent (0.0025) tick size

### DIFF
--- a/src/clob/order_builder.rs
+++ b/src/clob/order_builder.rs
@@ -24,6 +24,26 @@ use crate::types::{Address, Decimal};
 /// Maximum number of decimal places for `size`
 pub(crate) const LOT_SIZE_SCALE: u32 = 2;
 
+/// True when `price` lies exactly on the `tick` grid (an integer multiple of
+/// `tick`). Required for non-power-of-ten ticks such as `0.0025`, where
+/// `price.scale()` alone is insufficient: `0.0025` and `0.0001` both have
+/// `scale() == 4` but define different grids, so a scale check would wrongly
+/// accept off-grid prices like `0.5001` on a `0.0025` market.
+fn price_on_tick_grid(price: Decimal, tick: Decimal) -> bool {
+    tick > Decimal::ZERO && (price % tick) == Decimal::ZERO
+}
+
+/// Floor `price` down to the nearest multiple of `tick` — the marketable-price
+/// snap for market orders. Matches `trunc_with_scale(tick.scale())` for
+/// power-of-ten ticks and additionally aligns non-power-of-ten grids (`0.0025`),
+/// which a plain scale-truncation would leave off-grid (e.g. `0.5001`).
+fn snap_price_to_tick(price: Decimal, tick: Decimal) -> Decimal {
+    if tick <= Decimal::ZERO {
+        return price;
+    }
+    (price / tick).floor() * tick
+}
+
 /// Placeholder type for compile-time checks on limit order builders
 #[non_exhaustive]
 #[derive(Clone, Debug)]
@@ -281,12 +301,13 @@ impl<K: AuthKind> OrderBuilder<Limit, K> {
 
         let decimals = minimum_tick_size.scale();
 
-        if price.scale() > minimum_tick_size.scale() {
+        // Grid check by tick MULTIPLE, not decimal scale: a non-power-of-ten
+        // tick like 0.0025 has the same scale (4) as 0.0001 but a coarser grid,
+        // so a scale check would wrongly accept off-grid prices (e.g. 0.5001).
+        if !price_on_tick_grid(price, minimum_tick_size) {
             return Err(Error::validation(format!(
-                "Unable to build Order: Price {price} has {} decimal places. Minimum tick size \
-                {minimum_tick_size} has {} decimal places. Price decimal places <= minimum tick size decimal places",
-                price.scale(),
-                minimum_tick_size.scale()
+                "Unable to build Order: Price {price} is not a multiple of the minimum tick size \
+                {minimum_tick_size}. Adjust the price to a multiple of {minimum_tick_size}."
             )));
         }
 
@@ -542,8 +563,10 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
 
         let decimals = minimum_tick_size.scale();
 
-        // Ensure that the market price returned internally is truncated to our tick size
-        let price = price.trunc_with_scale(decimals);
+        // Snap the internal market price DOWN to the tick grid. `trunc_with_scale`
+        // alone only rounds by decimal count, which leaves non-power-of-ten grids
+        // (0.0025) off-grid (e.g. 0.5001) and the server would reject the order.
+        let price = snap_price_to_tick(price, minimum_tick_size);
         if price < minimum_tick_size || price > Decimal::ONE - minimum_tick_size {
             return Err(Error::validation(format!(
                 "Price {price} is too small or too large for the minimum tick size {minimum_tick_size}"
@@ -702,6 +725,35 @@ mod tests {
     use rust_decimal_macros::dec;
 
     use super::*;
+
+    #[test]
+    fn price_on_tick_grid_handles_quarter_cent() {
+        // 0.0025 grid: only multiples of 0.0025 are valid — NOT every 4-dp price.
+        assert!(price_on_tick_grid(dec!(0.5575), dec!(0.0025))); // 223 * 0.0025
+        assert!(price_on_tick_grid(dec!(0.5550), dec!(0.0025)));
+        assert!(!price_on_tick_grid(dec!(0.5001), dec!(0.0025))); // off-grid (was wrongly accepted by scale check)
+        assert!(!price_on_tick_grid(dec!(0.0001), dec!(0.0025)));
+        // Power-of-ten grids keep working exactly as the old scale check did.
+        assert!(price_on_tick_grid(dec!(0.55), dec!(0.01)));
+        assert!(!price_on_tick_grid(dec!(0.555), dec!(0.01)));
+        assert!(price_on_tick_grid(dec!(0.989), dec!(0.001)));
+        // A zero/invalid tick is never a valid grid.
+        assert!(!price_on_tick_grid(dec!(0.5), Decimal::ZERO));
+    }
+
+    #[test]
+    fn snap_price_to_tick_floors_to_grid() {
+        // 0.0025 grid: floor an off-grid price to the nearest lower multiple.
+        assert_eq!(snap_price_to_tick(dec!(0.5001), dec!(0.0025)), dec!(0.5000));
+        assert_eq!(snap_price_to_tick(dec!(0.5574), dec!(0.0025)), dec!(0.5550));
+        assert_eq!(snap_price_to_tick(dec!(0.5575), dec!(0.0025)), dec!(0.5575));
+        // Power-of-ten: equivalent to trunc_with_scale(scale).
+        assert_eq!(snap_price_to_tick(dec!(0.5567), dec!(0.01)), dec!(0.55));
+        assert_eq!(
+            snap_price_to_tick(dec!(0.5567), dec!(0.01)),
+            dec!(0.5567).trunc_with_scale(2)
+        );
+    }
 
     #[test]
     fn to_fixed_u128_should_succeed() {

--- a/src/clob/types/mod.rs
+++ b/src/clob/types/mod.rs
@@ -357,6 +357,9 @@ pub enum TraderSide {
 pub enum TickSize {
     Tenth,
     Hundredth,
+    /// 0.0025 — a quarter of a cent. Polymarket serves this grid on some
+    /// markets (e.g. sports spreads); it is NOT a power of ten like the others.
+    QuarterCent,
     Thousandth,
     TenThousandth,
 }
@@ -366,6 +369,7 @@ impl fmt::Display for TickSize {
         let name = match self {
             TickSize::Tenth => "Tenth",
             TickSize::Hundredth => "Hundredth",
+            TickSize::QuarterCent => "QuarterCent",
             TickSize::Thousandth => "Thousandth",
             TickSize::TenThousandth => "TenThousandth",
         };
@@ -380,6 +384,7 @@ impl TickSize {
         match self {
             TickSize::Tenth => dec!(0.1),
             TickSize::Hundredth => dec!(0.01),
+            TickSize::QuarterCent => dec!(0.0025),
             TickSize::Thousandth => dec!(0.001),
             TickSize::TenThousandth => dec!(0.0001),
         }
@@ -399,10 +404,11 @@ impl TryFrom<Decimal> for TickSize {
         match value {
             v if v == dec!(0.1) => Ok(TickSize::Tenth),
             v if v == dec!(0.01) => Ok(TickSize::Hundredth),
+            v if v == dec!(0.0025) => Ok(TickSize::QuarterCent),
             v if v == dec!(0.001) => Ok(TickSize::Thousandth),
             v if v == dec!(0.0001) => Ok(TickSize::TenThousandth),
             other => Err(Error::validation(format!(
-                "Unknown tick size: {other}. Expected one of: 0.1, 0.01, 0.001, 0.0001"
+                "Unknown tick size: {other}. Expected one of: 0.1, 0.01, 0.0025, 0.001, 0.0001"
             ))),
         }
     }
@@ -878,6 +884,7 @@ mod tests {
     fn tick_size_decimals_should_succeed() {
         assert_eq!(TickSize::Tenth.as_decimal().scale(), 1);
         assert_eq!(TickSize::Hundredth.as_decimal().scale(), 2);
+        assert_eq!(TickSize::QuarterCent.as_decimal(), dec!(0.0025));
         assert_eq!(TickSize::Thousandth.as_decimal().scale(), 3);
         assert_eq!(TickSize::TenThousandth.as_decimal().scale(), 4);
     }
@@ -886,6 +893,7 @@ mod tests {
     fn tick_size_should_display() {
         assert_eq!(format!("{}", TickSize::Tenth), "Tenth(0.1)");
         assert_eq!(format!("{}", TickSize::Hundredth), "Hundredth(0.01)");
+        assert_eq!(format!("{}", TickSize::QuarterCent), "QuarterCent(0.0025)");
         assert_eq!(format!("{}", TickSize::Thousandth), "Thousandth(0.001)");
         assert_eq!(
             format!("{}", TickSize::TenThousandth),
@@ -902,6 +910,10 @@ mod tests {
         assert_eq!(
             TickSize::try_from(dec!(0.001)).unwrap(),
             TickSize::Thousandth
+        );
+        assert_eq!(
+            TickSize::try_from(dec!(0.0025)).unwrap(),
+            TickSize::QuarterCent
         );
         assert_eq!(TickSize::try_from(dec!(0.01)).unwrap(), TickSize::Hundredth);
         assert_eq!(TickSize::try_from(dec!(0.1)).unwrap(), TickSize::Tenth);


### PR DESCRIPTION
## Summary

Polymarket's CLOB now serves a **0.0025 (quarter-cent)** minimum tick size on some markets — e.g. sports-spread markets (spreads/handicaps). The typed `TickSize` enum only models powers of ten (`0.1` / `0.01` / `0.001` / `0.0001`), so a `GET /tick-size` response of `"0.0025"` fails to deserialize:

```
Unknown tick size: 0.0025. Expected one of: 0.1, 0.01, 0.001, 0.0001
```

Because `TickSizeResponse.minimum_tick_size` is typed as `TickSize`, callers using the typed client can't resolve the tick for these markets and can't price/place orders on them, even though they're valid and actively trading. (The `/markets` descriptor already returns `minimum_tick_size` as a raw `Decimal`, so the two endpoints are currently inconsistent.)

## Change

Add a `QuarterCent` variant (`0.0025`) and wire it through the three exhaustive matches — `Display`, `as_decimal`, and `TryFrom<Decimal>` (plus the error hint). `Deserialize`, `PartialEq`, and `From<TickSize>` all delegate to those, so no other changes are needed. The enum is `#[non_exhaustive]`, so this is additive for downstream matchers.

## Tests

Extended the existing `TickSize` tests to cover the new variant (`as_decimal` value, `Display` = `QuarterCent(0.0025)`, `TryFrom` round-trip). `cargo test --features clob` passes, including `price_valid_all_tick_sizes`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes limit-order rejection rules and market-order price snapping on the order path; behavior is stricter for some prices but aligns with server tick grids and fixes quarter-cent market support.
> 
> **Overview**
> Adds **`TickSize::QuarterCent` (`0.0025`)** so `/tick-size` responses for quarter-cent markets (e.g. sports spreads) deserialize and map correctly through `Display`, `as_decimal`, and `TryFrom<Decimal>`.
> 
> **Order builder** no longer treats “decimal places ≤ tick scale” as sufficient for valid prices. Limit orders must be an **exact multiple of the minimum tick** via `price_on_tick_grid`; validation errors now say the price must be a multiple of the tick, not a scale mismatch. Market orders snap the computed price **down to the tick grid** with `snap_price_to_tick` instead of `trunc_with_scale`, so off-grid values like `0.5001` on a `0.0025` market are not sent to the server.
> 
> Unit tests cover quarter-cent and power-of-ten grids for both helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e743af9536d12a8f80332347328a457b00eff832. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->