### PR TITLE
fix: support new tick sizes

### DIFF
--- a/src/clob/order_builder.rs
+++ b/src/clob/order_builder.rs
@@ -296,6 +296,12 @@ impl<K: AuthKind> OrderBuilder<Limit, K> {
             )));
         }
 
+        if !price_aligned_to_tick_size(price, minimum_tick_size) {
+            return Err(Error::validation(format!(
+                "Price {price} is not aligned to the minimum tick size {minimum_tick_size}"
+            )));
+        }
+
         let Some(size) = self.size else {
             return Err(Error::validation(
                 "Unable to build Order due to missing size",
@@ -550,6 +556,12 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
             )));
         }
 
+        if !price_aligned_to_tick_size(price, minimum_tick_size) {
+            return Err(Error::validation(format!(
+                "Price {price} is not aligned to the minimum tick size {minimum_tick_size}"
+            )));
+        }
+
         let amount = match (side, amount.0, self.user_usdc_balance) {
             (Side::Buy, AmountInner::Usdc(raw), Some(balance)) => {
                 // V2 uses `/clob-markets/{id}` `fd` (rate + exponent); `/fee-rate`
@@ -674,6 +686,10 @@ const JS_SAFE_INTEGER_MAX: u64 = (1 << 53) - 1;
 
 fn to_ieee_754_int(value: u64) -> u64 {
     value & JS_SAFE_INTEGER_MAX
+}
+
+fn price_aligned_to_tick_size(price: Decimal, tick_size: Decimal) -> bool {
+    (price % tick_size).is_zero()
 }
 
 #[must_use]

--- a/src/clob/types/mod.rs
+++ b/src/clob/types/mod.rs
@@ -357,6 +357,8 @@ pub enum TraderSide {
 pub enum TickSize {
     Tenth,
     Hundredth,
+    HalfCent,
+    QuarterCent,
     Thousandth,
     TenThousandth,
 }
@@ -366,6 +368,8 @@ impl fmt::Display for TickSize {
         let name = match self {
             TickSize::Tenth => "Tenth",
             TickSize::Hundredth => "Hundredth",
+            TickSize::HalfCent => "HalfCent",
+            TickSize::QuarterCent => "QuarterCent",
             TickSize::Thousandth => "Thousandth",
             TickSize::TenThousandth => "TenThousandth",
         };
@@ -380,6 +384,8 @@ impl TickSize {
         match self {
             TickSize::Tenth => dec!(0.1),
             TickSize::Hundredth => dec!(0.01),
+            TickSize::HalfCent => dec!(0.005),
+            TickSize::QuarterCent => dec!(0.0025),
             TickSize::Thousandth => dec!(0.001),
             TickSize::TenThousandth => dec!(0.0001),
         }
@@ -399,10 +405,12 @@ impl TryFrom<Decimal> for TickSize {
         match value {
             v if v == dec!(0.1) => Ok(TickSize::Tenth),
             v if v == dec!(0.01) => Ok(TickSize::Hundredth),
+            v if v == dec!(0.005) => Ok(TickSize::HalfCent),
+            v if v == dec!(0.0025) => Ok(TickSize::QuarterCent),
             v if v == dec!(0.001) => Ok(TickSize::Thousandth),
             v if v == dec!(0.0001) => Ok(TickSize::TenThousandth),
             other => Err(Error::validation(format!(
-                "Unknown tick size: {other}. Expected one of: 0.1, 0.01, 0.001, 0.0001"
+                "Unknown tick size: {other}. Expected one of: 0.1, 0.01, 0.005, 0.0025, 0.001, 0.0001"
             ))),
         }
     }
@@ -878,6 +886,8 @@ mod tests {
     fn tick_size_decimals_should_succeed() {
         assert_eq!(TickSize::Tenth.as_decimal().scale(), 1);
         assert_eq!(TickSize::Hundredth.as_decimal().scale(), 2);
+        assert_eq!(TickSize::HalfCent.as_decimal().scale(), 3);
+        assert_eq!(TickSize::QuarterCent.as_decimal().scale(), 4);
         assert_eq!(TickSize::Thousandth.as_decimal().scale(), 3);
         assert_eq!(TickSize::TenThousandth.as_decimal().scale(), 4);
     }
@@ -886,6 +896,8 @@ mod tests {
     fn tick_size_should_display() {
         assert_eq!(format!("{}", TickSize::Tenth), "Tenth(0.1)");
         assert_eq!(format!("{}", TickSize::Hundredth), "Hundredth(0.01)");
+        assert_eq!(format!("{}", TickSize::HalfCent), "HalfCent(0.005)");
+        assert_eq!(format!("{}", TickSize::QuarterCent), "QuarterCent(0.0025)");
         assert_eq!(format!("{}", TickSize::Thousandth), "Thousandth(0.001)");
         assert_eq!(
             format!("{}", TickSize::TenThousandth),
@@ -902,6 +914,11 @@ mod tests {
         assert_eq!(
             TickSize::try_from(dec!(0.001)).unwrap(),
             TickSize::Thousandth
+        );
+        assert_eq!(TickSize::try_from(dec!(0.005)).unwrap(), TickSize::HalfCent);
+        assert_eq!(
+            TickSize::try_from(dec!(0.0025)).unwrap(),
+            TickSize::QuarterCent
         );
         assert_eq!(TickSize::try_from(dec!(0.01)).unwrap(), TickSize::Hundredth);
         assert_eq!(TickSize::try_from(dec!(0.1)).unwrap(), TickSize::Tenth);

--- a/src/clob/utilities.rs
+++ b/src/clob/utilities.rs
@@ -380,6 +380,8 @@ mod tests {
     fn price_valid_all_tick_sizes() {
         assert!(price_valid(dec!(0.5), TickSize::Tenth));
         assert!(price_valid(dec!(0.5), TickSize::Hundredth));
+        assert!(price_valid(dec!(0.5), TickSize::HalfCent));
+        assert!(price_valid(dec!(0.5), TickSize::QuarterCent));
         assert!(price_valid(dec!(0.5), TickSize::Thousandth));
         assert!(price_valid(dec!(0.5), TickSize::TenThousandth));
     }

--- a/tests/order.rs
+++ b/tests/order.rs
@@ -675,6 +675,50 @@ mod limit {
     }
 
     #[tokio::test]
+    async fn should_fail_on_off_grid_price() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = create_authenticated(&server).await?;
+
+        ensure_requirements(&server, token_1(), TickSize::HalfCent);
+
+        let err = client
+            .limit_order()
+            .token_id(token_1())
+            .price(dec!(0.051))
+            .size(dec!(21.04))
+            .side(Side::Buy)
+            .build()
+            .await
+            .unwrap_err();
+        let msg = &err.downcast_ref::<Validation>().unwrap().reason;
+
+        assert_eq!(
+            msg,
+            "Price 0.051 is not aligned to the minimum tick size 0.005"
+        );
+
+        ensure_requirements(&server, token_2(), TickSize::QuarterCent);
+
+        let err = client
+            .limit_order()
+            .token_id(token_2())
+            .price(dec!(0.0526))
+            .size(dec!(21.04))
+            .side(Side::Buy)
+            .build()
+            .await
+            .unwrap_err();
+        let msg = &err.downcast_ref::<Validation>().unwrap().reason;
+
+        assert_eq!(
+            msg,
+            "Price 0.0526 is not aligned to the minimum tick size 0.0025"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn should_fail_on_negative_price_and_size() -> anyhow::Result<()> {
         let server = MockServer::start();
         let client = create_authenticated(&server).await?;

--- a/tests/order.rs
+++ b/tests/order.rs
@@ -798,6 +798,88 @@ mod limit {
         }
 
         #[tokio::test]
+        async fn should_succeed_0_005() -> anyhow::Result<()> {
+            let server = MockServer::start();
+            let client = create_authenticated(&server).await?;
+
+            ensure_requirements(&server, token_1(), TickSize::HalfCent);
+
+            let signable_order = client
+                .limit_order()
+                .token_id(token_1())
+                .price(dec!(0.055))
+                .size(dec!(21.04))
+                .side(Side::Buy)
+                .order_type(OrderType::GTD)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
+                .build()
+                .await?;
+
+            let maker_amount = signable_order.order().makerAmount;
+            let taker_amount = signable_order.order().takerAmount;
+
+            let price = to_decimal(maker_amount) / to_decimal(taker_amount);
+            assert_eq!(price, dec!(0.055));
+
+            assert_eq!(signable_order.order().maker, client.address());
+            assert_eq!(signable_order.order().signer, client.address());
+
+            assert_eq!(signable_order.order().tokenId, token_1());
+            assert_eq!(signable_order.order().makerAmount, U256::from(1_157_200));
+            assert_eq!(signable_order.order().takerAmount, U256::from(21_040_000));
+            assert_eq!(signable_order.v2().expiration, U256::from(50000));
+
+            assert_eq!(signable_order.order().side, Side::Buy as u8);
+            assert_eq!(
+                signable_order.order().signatureType,
+                SignatureType::Eoa as u8
+            );
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn should_succeed_0_0025() -> anyhow::Result<()> {
+            let server = MockServer::start();
+            let client = create_authenticated(&server).await?;
+
+            ensure_requirements(&server, token_1(), TickSize::QuarterCent);
+
+            let signable_order = client
+                .limit_order()
+                .token_id(token_1())
+                .price(dec!(0.0525))
+                .size(dec!(21.04))
+                .side(Side::Buy)
+                .order_type(OrderType::GTD)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
+                .build()
+                .await?;
+
+            let maker_amount = signable_order.order().makerAmount;
+            let taker_amount = signable_order.order().takerAmount;
+
+            let price = to_decimal(maker_amount) / to_decimal(taker_amount);
+            assert_eq!(price, dec!(0.0525));
+
+            assert_eq!(signable_order.order().maker, client.address());
+            assert_eq!(signable_order.order().signer, client.address());
+
+            assert_eq!(signable_order.order().tokenId, token_1());
+            assert_eq!(signable_order.order().makerAmount, U256::from(1_104_600));
+            assert_eq!(signable_order.order().takerAmount, U256::from(21_040_000));
+            assert_eq!(signable_order.v2().expiration, U256::from(50000));
+
+            assert_eq!(signable_order.order().side, Side::Buy as u8);
+            assert_eq!(
+                signable_order.order().signatureType,
+                SignatureType::Eoa as u8
+            );
+
+            Ok(())
+        }
+
+        #[tokio::test]
         async fn should_succeed_0_001() -> anyhow::Result<()> {
             let server = MockServer::start();
             let client = create_authenticated(&server).await?;
@@ -1052,6 +1134,88 @@ mod limit {
             assert_eq!(signable_order.order().tokenId, token_1());
             assert_eq!(signable_order.order().makerAmount, U256::from(21_040_000));
             assert_eq!(signable_order.order().takerAmount, U256::from(11_782_400));
+            assert_eq!(signable_order.v2().expiration, U256::from(50000));
+
+            assert_eq!(signable_order.order().side, Side::Sell as u8);
+            assert_eq!(
+                signable_order.order().signatureType,
+                SignatureType::Eoa as u8
+            );
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn should_succeed_0_005() -> anyhow::Result<()> {
+            let server = MockServer::start();
+            let client = create_authenticated(&server).await?;
+
+            ensure_requirements(&server, token_1(), TickSize::HalfCent);
+
+            let signable_order = client
+                .limit_order()
+                .token_id(token_1())
+                .price(dec!(0.055))
+                .size(dec!(21.04))
+                .side(Side::Sell)
+                .order_type(OrderType::GTD)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
+                .build()
+                .await?;
+
+            let maker_amount = signable_order.order().makerAmount;
+            let taker_amount = signable_order.order().takerAmount;
+
+            let price = to_decimal(taker_amount) / to_decimal(maker_amount);
+            assert_eq!(price, dec!(0.055));
+
+            assert_eq!(signable_order.order().maker, client.address());
+            assert_eq!(signable_order.order().signer, client.address());
+
+            assert_eq!(signable_order.order().tokenId, token_1());
+            assert_eq!(signable_order.order().makerAmount, U256::from(21_040_000));
+            assert_eq!(signable_order.order().takerAmount, U256::from(1_157_200));
+            assert_eq!(signable_order.v2().expiration, U256::from(50000));
+
+            assert_eq!(signable_order.order().side, Side::Sell as u8);
+            assert_eq!(
+                signable_order.order().signatureType,
+                SignatureType::Eoa as u8
+            );
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn should_succeed_0_0025() -> anyhow::Result<()> {
+            let server = MockServer::start();
+            let client = create_authenticated(&server).await?;
+
+            ensure_requirements(&server, token_1(), TickSize::QuarterCent);
+
+            let signable_order = client
+                .limit_order()
+                .token_id(token_1())
+                .price(dec!(0.0525))
+                .size(dec!(21.04))
+                .side(Side::Sell)
+                .order_type(OrderType::GTD)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
+                .build()
+                .await?;
+
+            let maker_amount = signable_order.order().makerAmount;
+            let taker_amount = signable_order.order().takerAmount;
+
+            let price = to_decimal(taker_amount) / to_decimal(maker_amount);
+            assert_eq!(price, dec!(0.0525));
+
+            assert_eq!(signable_order.order().maker, client.address());
+            assert_eq!(signable_order.order().signer, client.address());
+
+            assert_eq!(signable_order.order().tokenId, token_1());
+            assert_eq!(signable_order.order().makerAmount, U256::from(21_040_000));
+            assert_eq!(signable_order.order().takerAmount, U256::from(1_104_600));
             assert_eq!(signable_order.v2().expiration, U256::from(50000));
 
             assert_eq!(signable_order.order().side, Side::Sell as u8);


### PR DESCRIPTION
## Summary
- Add `TickSize::HalfCent` for `0.005` markets.
- Add `TickSize::QuarterCent` for `0.0025` markets.
- Cover parsing/display, price validation, and limit order amount rounding for both new tick sizes.

## Verification
- cargo fmt -- --check
- cargo test --features clob tick_size
- cargo test --features clob --test order should_succeed_0_005
- cargo test --features clob --test order should_succeed_0_0025
- cargo test --features clob --test order
- cargo test --features "clob tracing"
- cargo test
- cargo build --all-targets --all-features
- cargo test --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches order price validation and amount rounding on the CLOB build path; misalignment checks could reject orders that previously passed decimal-scale checks only.
> 
> **Overview**
> Adds **`TickSize::HalfCent` (`0.005`)** and **`TickSize::QuarterCent` (`0.0025`)** so markets with finer price grids parse, display, and round like existing tick sizes.
> 
> **Limit and market order builds** now reject prices that are in range but not on the tick grid via **`price_aligned_to_tick_size`** (`price % tick_size == 0`), with a clear validation error—important for the new ticks where extra decimal places alone are not enough (e.g. `0.051` on a `0.005` grid).
> 
> Tests cover off-grid failures and buy/sell limit orders at **`0.055`** and **`0.0525`** with expected maker/taker amounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 400a0c9712b9c31b86d53547925be3ad8e5cfdc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->