### PR TITLE
chore: release v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "polymarket_client_sdk_v2"
-version = "0.6.0-canary.1"
+version = "0.6.0"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "polymarket_client_sdk_v2"
 description = "Polymarket CLOB (Central Limit Order Book) API client SDK"
-version = "0.6.0-canary.1"
+version = "0.6.0"
 authors = [
     "Polymarket Engineering <engineering@polymarket.com>",
     "Chaz Byrnes <chaz@polymarket.com>",

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Add the crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-polymarket_client_sdk_v2 = "=0.6.0-canary.1"
+polymarket_client_sdk_v2 = "0.6"
 ```
 
 or
@@ -83,7 +83,7 @@ Enable features in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-polymarket_client_sdk_v2 = { version = "=0.6.0-canary.1", features = ["ws", "data"] }
+polymarket_client_sdk_v2 = { version = "0.6", features = ["ws", "data"] }
 ```
 
 ## Re-exported Types
@@ -410,7 +410,7 @@ async fn main() -> anyhow::Result<()> {
 Real-time orderbook and user event streaming. Requires the `ws` feature.
 
 ```toml
-polymarket_client_sdk_v2 = { version = "=0.6.0-canary.1", features = ["ws"] }
+polymarket_client_sdk_v2 = { version = "0.6", features = ["ws"] }
 ```
 
 ```rust,ignore


### PR DESCRIPTION
## Summary
- bump polymarket_client_sdk_v2 to 0.6.0
- update README install snippets from the canary pin back to stable 0.6

## Verification
- git diff --check
- cargo metadata --no-deps --format-version 1
- cargo package --allow-dirty --no-verify

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only changes with no runtime or API code modifications.
> 
> **Overview**
> **Release v0.6.0** — bumps `polymarket_client_sdk_v2` from `0.6.0-canary.1` to **`0.6.0`** in `Cargo.toml` and the matching entry in `Cargo.lock`.
> 
> README **Getting started** and feature-flag snippets now recommend `polymarket_client_sdk_v2 = "0.6"` (and the same for `ws` / `data` examples) instead of pinning `=0.6.0-canary.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e78d25c22c61986b5f7aa2a3f9947c2eb01700ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->