### PR TITLE
fix(ws): install a rustls crypto provider so the TLS connect does not panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3654,6 +3654,7 @@ dependencies = [
  "reqwest 0.13.2",
  "rust_decimal",
  "rust_decimal_macros",
+ "rustls 0.23.38",
  "secrecy",
  "serde",
  "serde_html_form",
@@ -4342,6 +4343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,12 +34,14 @@ tracing = ["dep:tracing", "dep:serde_ignored", "dep:serde_path_to_error"]
 ws = [
     "dep:backoff",
     "dep:bitflags",
+    "dep:rustls",
     "dep:tokio-tungstenite",
     "tokio/macros",
     "tokio/rt-multi-thread",
 ]
 rtds = [
     "dep:backoff",
+    "dep:rustls",
     "dep:tokio-tungstenite",
     "tokio/macros",
     "tokio/rt-multi-thread",
@@ -83,6 +85,7 @@ sha1 = "0.10.6"
 sha2 = "0.10.9"
 strum_macros = "0.28.0"
 tokio = { version = "1.50.0", features = ["time"] }
+rustls = { version = "0.23.38", optional = true }
 tokio-tungstenite = { version = "0.29.0", features = ["rustls-tls-native-roots"], optional = true }
 tokio-util = { version = "0.7.18", optional = true }
 tracing = { version = "0.1", optional = true }
@@ -397,3 +400,8 @@ unwrap_used = "warn"
 [profile.bench]
 lto = "thin"        # Link-Time Optimization: enables cross-crate inlining
 codegen-units = 1   # Single codegen unit allows more aggressive optimizations
+
+
+
+
+

--- a/src/ws/connection.rs
+++ b/src/ws/connection.rs
@@ -8,7 +8,7 @@ use std::marker::PhantomData;
 use std::time::Instant;
 
 use backoff::backoff::Backoff as _;
-use futures::{SinkExt as _, StreamExt as _};
+use futures::{FutureExt as _, SinkExt as _, StreamExt as _};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tokio::net::TcpStream;
@@ -28,6 +28,23 @@ type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
 /// Broadcast channel capacity for incoming messages.
 const BROADCAST_CAPACITY: usize = 1024;
+
+/// Install a default rustls crypto provider if the process does not already have one.
+///
+/// Establishing the TLS connection resolves the process-level rustls `CryptoProvider`
+/// from crate features, which panics when more than one provider is present in the
+/// dependency graph. That happens readily in practice, because an application only has
+/// to pull in `ring` alongside the `aws-lc-rs` that rustls enables by default. Installing
+/// a provider explicitly avoids the panic, and an application that has already installed
+/// its own provider is left untouched.
+fn ensure_crypto_provider() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        if rustls::crypto::CryptoProvider::get_default().is_none() {
+            _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        }
+    });
+}
 
 /// Connection state tracking.
 #[non_exhaustive]
@@ -119,22 +136,36 @@ where
         let (broadcast_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
         let (state_tx, state_rx) = watch::channel(ConnectionState::Disconnected);
 
+        ensure_crypto_provider();
+
         // Spawn connection task
         let connection_config = config;
         let connection_endpoint = endpoint;
         let broadcast_tx_clone = broadcast_tx.clone();
         let state_tx_clone = state_tx.clone();
+        let panic_state_tx = state_tx.clone();
 
         tokio::spawn(async move {
-            Self::connection_loop(
+            let connection_loop = std::panic::AssertUnwindSafe(Self::connection_loop(
                 connection_endpoint,
                 connection_config,
                 sender_rx,
                 broadcast_tx_clone,
                 parser,
                 state_tx_clone,
-            )
-            .await;
+            ));
+
+            if connection_loop.catch_unwind().await.is_err() {
+                // This task is detached, so a panic in the connection loop is otherwise
+                // swallowed: the manager would keep reporting whatever state it reached
+                // last (typically `Connecting`) and every subscription stream would hang
+                // with no error and no data. Report the connection as disconnected so the
+                // failure is at least observable.
+                _ = panic_state_tx.send(ConnectionState::Disconnected);
+
+                #[cfg(feature = "tracing")]
+                tracing::error!("websocket connection task panicked; reporting disconnected");
+            }
         });
 
         Ok(Self {
@@ -422,5 +453,19 @@ where
     #[must_use]
     pub fn state_receiver(&self) -> watch::Receiver<ConnectionState> {
         self.state_tx.subscribe()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_crypto_provider;
+
+    #[test]
+    fn ensure_crypto_provider_installs_a_default() {
+        // More than one rustls crypto provider is present in the dependency graph, so
+        // the process-level default cannot be resolved from crate features and setting
+        // up TLS panics. Installing one keeps that from happening.
+        ensure_crypto_provider();
+        assert!(rustls::crypto::CryptoProvider::get_default().is_some());
     }
 }


### PR DESCRIPTION
Fixes #57.

`connect_async` resolves the process-level rustls `CryptoProvider` from crate features, which panics when more than one provider is present in the dependency graph. That is the default situation here, `aws-lc-rs` and `ring` are both in Cargo.lock already, so the first TLS connect panics.

The panic happens inside the detached `tokio::spawn` in `ConnectionManager::new`, and its `JoinHandle` is dropped, so nothing surfaces. The manager keeps reporting the last state it reached, `Connecting`, and every subscription stream hangs with no error and no data.

Two changes:

`ensure_crypto_provider` installs a default provider if the process does not already have one, so the ambiguity never comes up. An application that has installed its own provider is left alone, I checked that by installing `ring` from the test app first and confirming the guard steps aside.

The connection loop is wrapped in `catch_unwind` and the connection is reported as `Disconnected` if it panics. Without that, any panic in that loop is swallowed and becomes a silent hang, which is what made this one hard to see.

Against a live market, before:

```
thread 'tokio-rt-worker' panicked at rustls-0.23.38/src/crypto/mod.rs:249
state = Connecting
NO DATA in 12s
```

and after:

```
state = Connected { .. }
GOT BOOK SNAPSHOT: bids=56 asks=82
```

REST is not affected. reqwest uses the same rustls version but selects a provider explicitly, and I confirmed it completes the handshake in the same process where tungstenite panics. So this only needs fixing on the websocket path. `ConnectionManager` is the only place the SDK opens a TLS connection, so the one fix covers both the clob ws client and rtds.

`cargo test --features clob,ws,tracing` passes, 388 tests, no failures. `cargo fmt --check` is clean and clippy reports the same findings as on main.

Two things I ran into while reproducing this, both separate from the fix and not in this PR:

`cargo test --features clob,ws` does not run any tests at all. It fails to build nine of the examples, because they import `tracing` but their `required-features` does not include it (`error[E0432]: unresolved import tracing`). It fails the same way on main, so it is not from this change, but it does mean that feature combination has no working test command right now. The affected examples are async, authenticated, aws_authenticated, builder_authenticated, websocket_orderbook, websocket_user, websocket_unsubscribe, rfq_quotes and rfq_requests.

That is also why the repro command quoted in the issue, `cargo run --example websocket_orderbook --features clob,ws`, does not compile. Adding `tracing` to the feature list is the workaround.

Happy to send a follow-up for the `required-features` gap if you want it.

I used an AI assistant while working on this. I built and ran everything myself, including the live-market check above, and I understand the change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches TLS/crypto initialization for all WebSocket and RTDS connections; behavior is narrowly scoped but incorrect provider choice could affect handshake compatibility in edge deployments.
> 
> **Overview**
> Fixes WebSocket TLS setup when the process has **multiple rustls crypto providers** in the dependency graph (e.g. `aws-lc-rs` and `ring`), which previously caused `connect_async` to panic on first connect.
> 
> Adds **`ensure_crypto_provider`**, called when creating a `ConnectionManager`, to install `aws-lc-rs` as the default only if none is set yet—apps that already chose a provider are unchanged. **`rustls`** is wired in as an optional dependency for the `ws` and `rtds` features.
> 
> Wraps the spawned **connection loop** in **`catch_unwind`** so a panic in that detached task sets state to **`Disconnected`** (and logs with `tracing` when enabled) instead of leaving clients stuck in **`Connecting`** with no data or error.
> 
> Includes a unit test that **`ensure_crypto_provider`** leaves a default provider installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67e8a4c54f5cc3ae7794cb98a683df343cb001cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->