### PR TITLE
feat(gamma): add feeSchedule and feeType to Market

### DIFF
--- a/src/gamma/types/response.rs
+++ b/src/gamma/types/response.rs
@@ -515,6 +515,19 @@ pub struct Market {
     pub clob_rewards: Option<Vec<ClobReward>>,
     pub category_mailchimp_tag: Option<String>,
     pub subcategory: Option<String>,
+    pub fee_schedule: Option<FeeSchedule>,
+    pub fee_type: Option<String>,
+}
+
+/// Fee schedule applied to a market.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Builder)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct FeeSchedule {
+    pub exponent: Option<i32>,
+    pub rate: Option<Decimal>,
+    pub rebate_rate: Option<Decimal>,
+    pub taker_only: Option<bool>,
 }
 
 /// CLOB rewards configuration for a market.

--- a/tests/gamma.rs
+++ b/tests/gamma.rs
@@ -451,6 +451,7 @@ mod markets {
         types::request::{MarketByIdRequest, MarketBySlugRequest, MarketsRequest},
     };
     use reqwest::StatusCode;
+    use rust_decimal_macros::dec;
     use serde_json::json;
 
     use crate::common::{token_1, token_2};
@@ -525,6 +526,66 @@ mod markets {
 
         assert_eq!(response.id, "99");
         assert_eq!(response.slug, Some("my-market".to_owned()));
+        mock.assert();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn market_fee_schedule_should_deserialize() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = Client::new(&server.base_url())?;
+
+        let mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/markets/slug/btc-updown-5m-1778794800");
+            then.status(StatusCode::OK).json_body(json!({
+                "id": "1",
+                "slug": "btc-updown-5m-1778794800",
+                "feeSchedule": {
+                    "exponent": 1,
+                    "rate": 0.07,
+                    "rebateRate": 0.2,
+                    "takerOnly": true
+                },
+                "feeType": "crypto_fees_v2"
+            }));
+        });
+
+        let request = MarketBySlugRequest::builder()
+            .slug("btc-updown-5m-1778794800")
+            .build();
+        let response = client.market_by_slug(&request).await?;
+
+        let fee_schedule = response.fee_schedule.unwrap();
+        assert_eq!(fee_schedule.exponent, Some(1));
+        assert_eq!(fee_schedule.rate, Some(dec!(0.07)));
+        assert_eq!(fee_schedule.rebate_rate, Some(dec!(0.2)));
+        assert_eq!(fee_schedule.taker_only, Some(true));
+        assert_eq!(response.fee_type, Some("crypto_fees_v2".to_owned()));
+        mock.assert();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn market_without_fee_schedule_should_deserialize() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = Client::new(&server.base_url())?;
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/markets/slug/no-fees");
+            then.status(StatusCode::OK).json_body(json!({
+                "id": "2",
+                "slug": "no-fees"
+            }));
+        });
+
+        let request = MarketBySlugRequest::builder().slug("no-fees").build();
+        let response = client.market_by_slug(&request).await?;
+
+        assert_eq!(response.fee_schedule, None);
+        assert_eq!(response.fee_type, None);
         mock.assert();
 
         Ok(())


### PR DESCRIPTION
Closes #55.

## Problem

The gamma API returns `feeSchedule` and `feeType` on every market, but `gamma::types::response::Market` does not model them. With the `tracing` feature enabled, `serde_helpers` logs a WARN per unknown field per market fetched:

```
WARN polymarket_client_sdk_v2::serde_helpers: unknown field in API response
  field=?.feeSchedule value={"exponent":1,"rate":0.07,"rebateRate":0.2,"takerOnly":true}
WARN polymarket_client_sdk_v2::serde_helpers: unknown field in API response
  field=?.feeType value="crypto_fees_v2"
```

For consumers that treat these WARNs as schema-drift signals, every gamma fetch produces noise that hides real drift.

## Change

Adds a `FeeSchedule` struct and two fields to `Market`:

```rust
pub fee_schedule: Option<FeeSchedule>,
pub fee_type: Option<String>,
```

`FeeSchedule` follows the existing nested-type convention in this file (`ClobReward`, `ImageOptimization`): all-`Option` fields, `#[non_exhaustive]`, and `rename_all = "camelCase"` — so no explicit `#[serde(rename)]` attributes are needed for `feeSchedule`/`feeType`/`rebateRate`/`takerOnly`.

Purely additive. Both fields are `Option`, so markets that omit them continue to deserialize unchanged, and `Market` is already `#[non_exhaustive]` so no downstream construction breaks.

## Tests

Two tests added to `tests/gamma.rs` (httpmock, no network):

- `market_fee_schedule_should_deserialize` — asserts the field values from the issue's payload deserialize into typed values.
- `market_without_fee_schedule_should_deserialize` — asserts a market with neither field still deserializes, with both as `None`.

## Verification

```
cargo test --all-features       554 passed, 0 failed
cargo clippy --all-targets --all-features -- -D warnings    clean
cargo fmt --check               clean
```

## Note

The subfield types (`exponent: i32`, `rate`/`rebateRate`: `Decimal`, `takerOnly: bool`) are taken from the payload in #55. I could not reach `gamma-api.polymarket.com` from my network to sample a wider set of live markets, so if `feeType` is better modeled as an enum, or `exponent` is ever fractional, happy to adjust.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive serde-only response modeling with optional fields; no API client or runtime behavior changes beyond deserialization.
> 
> **Overview**
> Models Gamma API **`feeSchedule`** and **`feeType`** on **`Market`** so responses deserialize without unknown-field noise (notably with the **`tracing`** feature).
> 
> Adds a nested **`FeeSchedule`** type (`exponent`, `rate`, `rebate_rate`, `taker_only`) and optional **`fee_schedule`** / **`fee_type`** on **`Market`**, using the same camelCase / all-optional / **`#[non_exhaustive]`** pattern as other nested response types.
> 
> **Tests:** two httpmock **`market_by_slug`** cases—full fee payload typed as **`Decimal`** where expected, and a market with neither field leaving both **`None`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f9e67e4d38ca529043de2d5d2de0c5800a77777. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->