### PR TITLE
feat: resolve transaction hashes internally for matched orders

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,19 @@ bridge = []
 ctf = ["alloy/contract", "alloy/providers"]
 rfq = []
 tracing = ["dep:tracing", "dep:serde_ignored", "dep:serde_path_to_error"]
-ws = ["dep:backoff", "dep:bitflags", "dep:tokio-tungstenite", "tokio/macros", "tokio/rt-multi-thread"]
-rtds = ["dep:backoff", "dep:tokio-tungstenite", "tokio/macros", "tokio/rt-multi-thread"]
+ws = [
+    "dep:backoff",
+    "dep:bitflags",
+    "dep:tokio-tungstenite",
+    "tokio/macros",
+    "tokio/rt-multi-thread",
+]
+rtds = [
+    "dep:backoff",
+    "dep:tokio-tungstenite",
+    "tokio/macros",
+    "tokio/rt-multi-thread",
+]
 heartbeats = ["dep:tokio-util", "tokio/macros", "tokio/rt-multi-thread"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,9 @@ bridge = []
 ctf = ["alloy/contract", "alloy/providers"]
 rfq = []
 tracing = ["dep:tracing", "dep:serde_ignored", "dep:serde_path_to_error"]
-ws = ["dep:backoff", "dep:bitflags", "dep:tokio", "dep:tokio-tungstenite"]
-rtds = ["dep:backoff", "dep:tokio", "dep:tokio-tungstenite"]
-heartbeats = ["dep:tokio", "dep:tokio-util"]
+ws = ["dep:backoff", "dep:bitflags", "dep:tokio-tungstenite", "tokio/macros", "tokio/rt-multi-thread"]
+rtds = ["dep:backoff", "dep:tokio-tungstenite", "tokio/macros", "tokio/rt-multi-thread"]
+heartbeats = ["dep:tokio-util", "tokio/macros", "tokio/rt-multi-thread"]
 
 [dependencies]
 alloy = { version = "1.6.3", default-features = false, features = [
@@ -71,7 +71,7 @@ serde_with = { version = "3.18.0", features = ["chrono_0_4", "json"] }
 sha1 = "0.10.6"
 sha2 = "0.10.9"
 strum_macros = "0.28.0"
-tokio = { version = "1.50.0", features = ["rt-multi-thread", "macros"], optional = true }
+tokio = { version = "1.50.0", features = ["time"] }
 tokio-tungstenite = { version = "0.29.0", features = ["rustls-tls-native-roots"], optional = true }
 tokio-util = { version = "0.7.18", optional = true }
 tracing = { version = "0.1", optional = true }

--- a/benches/deserialize_clob.rs
+++ b/benches/deserialize_clob.rs
@@ -91,7 +91,7 @@ fn bench_orders(c: &mut Criterion) {
         "status": "LIVE",
         "success": true,
         "transactionsHashes": ["0x0000000000000000000000000000000000000000000000000000000000000001"],
-        "trade_ids": ["trade_123", "trade_456"]
+        "tradeIDs": ["trade_123", "trade_456"]
     }"#;
     group.throughput(Throughput::Bytes(post_order.len() as u64));
     group.bench_function("PostOrderResponse", |b| {

--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -3,8 +3,7 @@ use std::marker::PhantomData;
 use std::mem;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
-#[cfg(feature = "heartbeats")]
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use alloy::dyn_abi::Eip712Domain;
 use alloy::primitives::{Signature, U256, keccak256};
@@ -56,7 +55,7 @@ use crate::clob::types::{
 };
 use crate::clob::types::{
     Amount, OrderPayload, OrderSignature, OrderType, Side, SignableOrder, SignatureType,
-    SignedOrder, TickSize,
+    SignedOrder, TickSize, TradeStatusType,
 };
 use crate::error::{Error, Kind as ErrorKind, Synchronization};
 use crate::types::{Address, B256, Decimal};
@@ -86,6 +85,15 @@ const SOLADY_TYPE_STRING: &str = concat!(
 const TERMINAL_CURSOR: &str = "LTE="; // base64("-1")
 
 pub(crate) const ORDER_VERSION_MISMATCH_ERROR: &str = "order_version_mismatch";
+
+const RESOLVE_TRADES_TIMEOUT: Duration = Duration::from_secs(30);
+const RESOLVE_TRADES_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+// A trade is resolved once execution reached a terminal outcome: it either
+// carries a settlement transaction hash or it failed and never will.
+fn is_trade_resolved(trade: &TradeResponse) -> bool {
+    matches!(trade.status, TradeStatusType::Failed) || !trade.transaction_hash.is_zero()
+}
 
 fn push_hex(out: &mut String, bytes: &[u8]) {
     const LUT: &[u8; 16] = b"0123456789abcdef";
@@ -1849,7 +1857,15 @@ impl<K: Kind> Client<Authenticated<K>> {
     /// - The user has insufficient balance or allowance
     /// - The order price/size violates market rules
     /// - The request fails
+    ///
+    /// When the order matches, the response carries the settlement
+    /// transaction hashes of its fills in
+    /// [`transaction_hashes`](PostOrderResponse::transaction_hashes), resolved
+    /// on a best-effort basis. If a hash is not available yet, the fill's
+    /// trade can be followed via
+    /// [`trade_ids`](PostOrderResponse::trade_ids).
     pub async fn post_order(&self, order: SignedOrder) -> Result<PostOrderResponse> {
+        let defer_exec = order.defer_exec == Some(true);
         let request = self
             .client()
             .request(Method::POST, format!("{}order", self.host()))
@@ -1859,7 +1875,11 @@ impl<K: Kind> Client<Authenticated<K>> {
 
         let result = crate::request(&self.inner.client, request, Some(headers)).await;
         self.invalidate_version_if_mismatch(&result).await;
-        result
+        let response = result?;
+        if defer_exec {
+            return Ok(response);
+        }
+        Ok(self.resolve_transaction_hashes(response).await)
     }
 
     /// Posts multiple signed orders to the orderbook in a single request.
@@ -1872,6 +1892,10 @@ impl<K: Kind> Client<Authenticated<K>> {
     ///
     /// Returns an error if any order fails validation or the request fails.
     pub async fn post_orders(&self, orders: Vec<SignedOrder>) -> Result<Vec<PostOrderResponse>> {
+        let defer_exec: Vec<bool> = orders
+            .iter()
+            .map(|order| order.defer_exec == Some(true))
+            .collect();
         let request = self
             .client()
             .request(Method::POST, format!("{}orders", self.host()))
@@ -1881,7 +1905,85 @@ impl<K: Kind> Client<Authenticated<K>> {
 
         let result = crate::request(&self.inner.client, request, Some(headers)).await;
         self.invalidate_version_if_mismatch(&result).await;
-        result
+        let responses: Vec<PostOrderResponse> = result?;
+
+        let mut resolved = Vec::with_capacity(responses.len());
+        for (index, response) in responses.into_iter().enumerate() {
+            if defer_exec.get(index).copied().unwrap_or(false) {
+                resolved.push(response);
+            } else {
+                resolved.push(self.resolve_transaction_hashes(response).await);
+            }
+        }
+        Ok(resolved)
+    }
+
+    // Polls the given trades until every one reaches a terminal execution
+    // outcome (it carries a settlement transaction hash or its status is
+    // FAILED) or the polling window elapses. Best-effort: returns whatever
+    // trades resolved in time and never fails.
+    async fn wait_for_resolved_trades(&self, trade_ids: &[String]) -> Vec<TradeResponse> {
+        let mut ids: Vec<&String> = Vec::new();
+        for id in trade_ids {
+            if !id.is_empty() && !ids.contains(&id) {
+                ids.push(id);
+            }
+        }
+        if ids.is_empty() {
+            return Vec::new();
+        }
+
+        let mut resolved: Vec<Option<TradeResponse>> = vec![None; ids.len()];
+        let deadline = Instant::now() + RESOLVE_TRADES_TIMEOUT;
+
+        loop {
+            for (index, id) in ids.iter().enumerate() {
+                if resolved[index].is_some() {
+                    continue;
+                }
+                let request = TradesRequest::builder().id((*id).clone()).build();
+                let Ok(page) = self.trades(&request, None).await else {
+                    continue;
+                };
+                resolved[index] = page
+                    .data
+                    .into_iter()
+                    .find(|trade| trade.id == **id && is_trade_resolved(trade));
+            }
+
+            if resolved.iter().all(Option::is_some) || Instant::now() >= deadline {
+                return resolved.into_iter().flatten().collect();
+            }
+            tokio::time::sleep(RESOLVE_TRADES_POLL_INTERVAL).await;
+        }
+    }
+
+    // Fills `transaction_hashes` on an order response whose trades executed
+    // asynchronously (the server returned trade IDs without hashes), by
+    // polling the trades until they resolve. Best-effort: on timeout the
+    // response is returned with whatever hashes resolved, which may be none.
+    // Trades that failed execution never contribute a hash.
+    async fn resolve_transaction_hashes(
+        &self,
+        mut response: PostOrderResponse,
+    ) -> PostOrderResponse {
+        if !response.transaction_hashes.is_empty() || response.trade_ids.is_empty() {
+            return response;
+        }
+
+        let hashes: Vec<B256> = self
+            .wait_for_resolved_trades(&response.trade_ids)
+            .await
+            .into_iter()
+            .filter(|trade| !matches!(trade.status, TradeStatusType::Failed))
+            .map(|trade| trade.transaction_hash)
+            .filter(|hash| !hash.is_zero())
+            .collect();
+
+        if !hashes.is_empty() {
+            response.transaction_hashes = hashes;
+        }
+        response
     }
 
     async fn invalidate_version_if_mismatch<T>(&self, result: &Result<T>) {

--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -95,6 +95,18 @@ fn is_trade_resolved(trade: &TradeResponse) -> bool {
     matches!(trade.status, TradeStatusType::Failed) || !trade.transaction_hash.is_zero()
 }
 
+// Extracts the settlement hashes for the given trade IDs from resolved
+// trades. Trades that failed execution never contribute a hash.
+fn transaction_hashes_for(trade_ids: &[String], resolved_trades: &[TradeResponse]) -> Vec<B256> {
+    trade_ids
+        .iter()
+        .filter_map(|id| resolved_trades.iter().find(|trade| trade.id == *id))
+        .filter(|trade| !matches!(trade.status, TradeStatusType::Failed))
+        .map(|trade| trade.transaction_hash)
+        .filter(|hash| !hash.is_zero())
+        .collect()
+}
+
 fn push_hex(out: &mut String, bytes: &[u8]) {
     const LUT: &[u8; 16] = b"0123456789abcdef";
     out.reserve(bytes.len() * 2);
@@ -1905,17 +1917,37 @@ impl<K: Kind> Client<Authenticated<K>> {
 
         let result = crate::request(&self.inner.client, request, Some(headers)).await;
         self.invalidate_version_if_mismatch(&result).await;
-        let responses: Vec<PostOrderResponse> = result?;
+        let mut responses: Vec<PostOrderResponse> = result?;
 
-        let mut resolved = Vec::with_capacity(responses.len());
-        for (index, response) in responses.into_iter().enumerate() {
-            if defer_exec.get(index).copied().unwrap_or(false) {
-                resolved.push(response);
-            } else {
-                resolved.push(self.resolve_transaction_hashes(response).await);
+        // Resolve all batch entries against a single polling window so a
+        // degraded pipeline delays the batch by at most one timeout, not one
+        // timeout per matched order.
+        let pending_trade_ids: Vec<String> = responses
+            .iter()
+            .enumerate()
+            .filter(|(index, response)| {
+                !defer_exec.get(*index).copied().unwrap_or(false)
+                    && response.transaction_hashes.is_empty()
+            })
+            .flat_map(|(_, response)| response.trade_ids.iter().cloned())
+            .collect();
+        if pending_trade_ids.is_empty() {
+            return Ok(responses);
+        }
+
+        let resolved_trades = self.wait_for_resolved_trades(&pending_trade_ids).await;
+        for (index, response) in responses.iter_mut().enumerate() {
+            if defer_exec.get(index).copied().unwrap_or(false)
+                || !response.transaction_hashes.is_empty()
+            {
+                continue;
+            }
+            let hashes = transaction_hashes_for(&response.trade_ids, &resolved_trades);
+            if !hashes.is_empty() {
+                response.transaction_hashes = hashes;
             }
         }
-        Ok(resolved)
+        Ok(responses)
     }
 
     // Polls the given trades until every one reaches a terminal execution
@@ -1971,15 +2003,8 @@ impl<K: Kind> Client<Authenticated<K>> {
             return response;
         }
 
-        let hashes: Vec<B256> = self
-            .wait_for_resolved_trades(&response.trade_ids)
-            .await
-            .into_iter()
-            .filter(|trade| !matches!(trade.status, TradeStatusType::Failed))
-            .map(|trade| trade.transaction_hash)
-            .filter(|hash| !hash.is_zero())
-            .collect();
-
+        let resolved_trades = self.wait_for_resolved_trades(&response.trade_ids).await;
+        let hashes = transaction_hashes_for(&response.trade_ids, &resolved_trades);
         if !hashes.is_empty() {
             response.transaction_hashes = hashes;
         }

--- a/src/clob/types/response.rs
+++ b/src/clob/types/response.rs
@@ -308,15 +308,18 @@ pub struct PostOrderResponse {
     pub order_id: String,
     pub status: OrderStatusType,
     pub success: bool,
-    /// On-chain transaction hashes for the order execution.
+    /// Settlement transaction hashes for the order's trades, returned on a
+    /// best-effort basis when the order matched.
     #[builder(default)]
     #[serde(default)]
     #[serde_as(deserialize_as = "DefaultOnNull")]
     #[serde(alias = "transactionsHashes")]
     pub transaction_hashes: Vec<B256>,
+    /// IDs of the trades created when the order matched.
     #[builder(default)]
     #[serde(default)]
     #[serde_as(deserialize_as = "DefaultOnNull")]
+    #[serde(alias = "tradeIDs")]
     pub trade_ids: Vec<String>,
 }
 
@@ -330,6 +333,19 @@ where
         Ok(Decimal::ZERO)
     } else {
         s.parse::<Decimal>().map_err(serde::de::Error::custom)
+    }
+}
+
+pub fn empty_string_as_zero_hash<'de, D>(deserializer: D) -> std::result::Result<B256, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+
+    if s.trim().is_empty() {
+        Ok(B256::ZERO)
+    } else {
+        s.parse::<B256>().map_err(serde::de::Error::custom)
     }
 }
 
@@ -402,7 +418,10 @@ pub struct TradeResponse {
     #[serde(default)]
     #[serde_as(deserialize_as = "DefaultOnNull")]
     pub maker_orders: Vec<MakerOrder>,
-    /// On-chain transaction hash.
+    /// On-chain transaction hash. Zero until the trade's transaction has been
+    /// submitted (servers running the async execution pipeline create trades
+    /// before broadcasting).
+    #[serde(default, deserialize_with = "empty_string_as_zero_hash")]
     pub transaction_hash: B256,
     pub trader_side: TraderSide,
     #[serde(default)]

--- a/tests/clob.rs
+++ b/tests/clob.rs
@@ -1929,6 +1929,84 @@ mod authenticated {
     }
 
     #[tokio::test]
+    async fn post_orders_should_distribute_hashes_across_matched_entries() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = create_authenticated(&server).await?;
+
+        ensure_requirements(&server, token_1(), TickSize::Hundredth);
+
+        let orders_mock = server.mock(|when, then| {
+            when.method(POST).path("/orders");
+            then.status(StatusCode::OK).json_body(json!([
+                {
+                    "error_msg": "",
+                    "makingAmount": "50",
+                    "orderID": "0x1111111111111111111111111111111111111111111111111111111111111111",
+                    "status": "matched",
+                    "success": true,
+                    "takingAmount": "100",
+                    "tradeIDs": ["trade-1"]
+                },
+                {
+                    "error_msg": "",
+                    "makingAmount": "25",
+                    "orderID": "0x3333333333333333333333333333333333333333333333333333333333333333",
+                    "status": "matched",
+                    "success": true,
+                    "takingAmount": "50",
+                    "tradeIDs": ["trade-2"]
+                }
+            ]));
+        });
+        let first_trade_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/data/trades")
+                .query_param("id", "trade-1");
+            then.status(StatusCode::OK)
+                .json_body(trades_page(&[trade_json(
+                    "trade-1",
+                    "MINED",
+                    "0x1111111111111111111111111111111111111111111111111111111111111111",
+                )]));
+        });
+        let second_trade_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/data/trades")
+                .query_param("id", "trade-2");
+            then.status(StatusCode::OK)
+                .json_body(trades_page(&[trade_json(
+                    "trade-2",
+                    "MINED",
+                    "0x2222222222222222222222222222222222222222222222222222222222222222",
+                )]));
+        });
+
+        let signer = LocalSigner::from_str(PRIVATE_KEY)?.with_chain_id(Some(POLYGON));
+        let first = client.sign(&signer, SignableOrder::default()).await?;
+        let second = client.sign(&signer, SignableOrder::default()).await?;
+        let responses = client.post_orders(vec![first, second]).await?;
+
+        // Each entry gets its own trades' hashes, resolved in one shared poll.
+        assert_eq!(
+            responses[0].transaction_hashes,
+            vec![b256!(
+                "1111111111111111111111111111111111111111111111111111111111111111"
+            )]
+        );
+        assert_eq!(
+            responses[1].transaction_hashes,
+            vec![b256!(
+                "2222222222222222222222222222222222222222222222222222222222222222"
+            )]
+        );
+        orders_mock.assert();
+        first_trade_mock.assert();
+        second_trade_mock.assert();
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn trades_should_tolerate_empty_transaction_hash() -> anyhow::Result<()> {
         let server = MockServer::start();
         let client = create_authenticated(&server).await?;

--- a/tests/clob.rs
+++ b/tests/clob.rs
@@ -1443,7 +1443,7 @@ mod authenticated {
     };
     #[cfg(feature = "heartbeats")]
     use polymarket_client_sdk_v2::error::Synchronization;
-    use polymarket_client_sdk_v2::types::{Address, address, b256};
+    use polymarket_client_sdk_v2::types::{Address, B256, address, b256};
 
     use super::*;
     use crate::common::{
@@ -1695,6 +1695,257 @@ mod authenticated {
             .build();
 
         assert_eq!(response, expected);
+        mock.assert();
+
+        Ok(())
+    }
+
+    fn trade_json(id: &str, status: &str, transaction_hash: &str) -> serde_json::Value {
+        json!({
+            "id": id,
+            "taker_order_id": "taker_123",
+            "market": "0x000000000000000000000000000000000000000000000000000000006d61726b",
+            "asset_id": token_1(),
+            "side": "BUY",
+            "size": "12.5",
+            "fee_rate_bps": "5",
+            "price": "0.42",
+            "status": status,
+            "match_time": "1705322096",
+            "last_update": "1705322130",
+            "outcome": "YES",
+            "bucket_index": 2,
+            "owner": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            "maker_address": "0x2222222222222222222222222222222222222222",
+            "maker_orders": [],
+            "transaction_hash": transaction_hash,
+            "trader_side": "TAKER"
+        })
+    }
+
+    fn trades_page(trades: &[serde_json::Value]) -> serde_json::Value {
+        json!({
+            "data": trades,
+            "limit": 1,
+            "count": 1,
+            "next_cursor": "LTE="
+        })
+    }
+
+    #[tokio::test]
+    async fn post_order_should_resolve_transaction_hashes_from_trades() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = create_authenticated(&server).await?;
+
+        ensure_requirements(&server, token_1(), TickSize::Hundredth);
+
+        let order_mock = server.mock(|when, then| {
+            when.method(POST).path("/order");
+            then.status(StatusCode::OK).json_body(json!({
+                "error_msg": "",
+                "makingAmount": "50",
+                "orderID": "0x23b457271bce9fa09b4f79125c9ec09e968235a462de82e318ef4eb6fe0ffeb0",
+                "status": "matched",
+                "success": true,
+                "takingAmount": "100",
+                "tradeIDs": ["trade-1"]
+            }));
+        });
+        let trades_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/data/trades")
+                .query_param("id", "trade-1");
+            then.status(StatusCode::OK)
+                .json_body(trades_page(&[trade_json(
+                    "trade-1",
+                    "MINED",
+                    "0x2369f69af45a559ad6e769d3d209d2379af9d412315e27b9283594a6392557b6",
+                )]));
+        });
+
+        let signer = LocalSigner::from_str(PRIVATE_KEY)?.with_chain_id(Some(POLYGON));
+        let signed_order = client.sign(&signer, SignableOrder::default()).await?;
+        let response = client.post_order(signed_order).await?;
+
+        assert_eq!(response.status, OrderStatusType::Matched);
+        assert_eq!(response.trade_ids, vec!["trade-1"]);
+        assert_eq!(
+            response.transaction_hashes,
+            vec![b256!(
+                "2369f69af45a559ad6e769d3d209d2379af9d412315e27b9283594a6392557b6"
+            )]
+        );
+        order_mock.assert();
+        trades_mock.assert();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn post_order_should_not_resolve_for_defer_exec_orders() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = create_authenticated(&server).await?;
+
+        ensure_requirements(&server, token_1(), TickSize::Hundredth);
+
+        let order_mock = server.mock(|when, then| {
+            when.method(POST).path("/order");
+            then.status(StatusCode::OK).json_body(json!({
+                "error_msg": "",
+                "makingAmount": "50",
+                "orderID": "0x23b457271bce9fa09b4f79125c9ec09e968235a462de82e318ef4eb6fe0ffeb0",
+                "status": "matched",
+                "success": true,
+                "takingAmount": "100",
+                "tradeIDs": ["trade-1"]
+            }));
+        });
+        // No /data/trades mock: polling would fail the test with a hang/404s.
+
+        let signer = LocalSigner::from_str(PRIVATE_KEY)?.with_chain_id(Some(POLYGON));
+        let mut signed_order = client.sign(&signer, SignableOrder::default()).await?;
+        signed_order.defer_exec = Some(true);
+        let response = client.post_order(signed_order).await?;
+
+        assert_eq!(response.trade_ids, vec!["trade-1"]);
+        assert!(response.transaction_hashes.is_empty());
+        order_mock.assert();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn post_order_should_exclude_failed_trades_from_resolved_hashes() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = create_authenticated(&server).await?;
+
+        ensure_requirements(&server, token_1(), TickSize::Hundredth);
+
+        let order_mock = server.mock(|when, then| {
+            when.method(POST).path("/order");
+            then.status(StatusCode::OK).json_body(json!({
+                "error_msg": "",
+                "makingAmount": "50",
+                "orderID": "0x23b457271bce9fa09b4f79125c9ec09e968235a462de82e318ef4eb6fe0ffeb0",
+                "status": "matched",
+                "success": true,
+                "takingAmount": "100",
+                "tradeIDs": ["trade-1", "trade-2"]
+            }));
+        });
+        let failed_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/data/trades")
+                .query_param("id", "trade-1");
+            then.status(StatusCode::OK)
+                .json_body(trades_page(&[trade_json("trade-1", "FAILED", "")]));
+        });
+        let executed_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/data/trades")
+                .query_param("id", "trade-2");
+            then.status(StatusCode::OK)
+                .json_body(trades_page(&[trade_json(
+                    "trade-2",
+                    "MINED",
+                    "0x2222222222222222222222222222222222222222222222222222222222222222",
+                )]));
+        });
+
+        let signer = LocalSigner::from_str(PRIVATE_KEY)?.with_chain_id(Some(POLYGON));
+        let signed_order = client.sign(&signer, SignableOrder::default()).await?;
+        let response = client.post_order(signed_order).await?;
+
+        assert_eq!(
+            response.transaction_hashes,
+            vec![b256!(
+                "2222222222222222222222222222222222222222222222222222222222222222"
+            )]
+        );
+        order_mock.assert();
+        failed_mock.assert();
+        executed_mock.assert();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn post_orders_should_resolve_matched_entries() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = create_authenticated(&server).await?;
+
+        ensure_requirements(&server, token_1(), TickSize::Hundredth);
+
+        let orders_mock = server.mock(|when, then| {
+            when.method(POST).path("/orders");
+            then.status(StatusCode::OK).json_body(json!([
+                {
+                    "error_msg": "",
+                    "makingAmount": "50",
+                    "orderID": "0x1111111111111111111111111111111111111111111111111111111111111111",
+                    "status": "matched",
+                    "success": true,
+                    "takingAmount": "100",
+                    "tradeIDs": ["trade-1"]
+                },
+                {
+                    "error_msg": "",
+                    "makingAmount": "",
+                    "orderID": "0x3333333333333333333333333333333333333333333333333333333333333333",
+                    "status": "live",
+                    "success": true,
+                    "takingAmount": ""
+                }
+            ]));
+        });
+        let trades_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/data/trades")
+                .query_param("id", "trade-1");
+            then.status(StatusCode::OK)
+                .json_body(trades_page(&[trade_json(
+                    "trade-1",
+                    "CONFIRMED",
+                    "0x1111111111111111111111111111111111111111111111111111111111111111",
+                )]));
+        });
+
+        let signer = LocalSigner::from_str(PRIVATE_KEY)?.with_chain_id(Some(POLYGON));
+        let first = client.sign(&signer, SignableOrder::default()).await?;
+        let second = client.sign(&signer, SignableOrder::default()).await?;
+        let responses = client.post_orders(vec![first, second]).await?;
+
+        assert_eq!(
+            responses[0].transaction_hashes,
+            vec![b256!(
+                "1111111111111111111111111111111111111111111111111111111111111111"
+            )]
+        );
+        assert!(responses[1].transaction_hashes.is_empty());
+        orders_mock.assert();
+        trades_mock.assert();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn trades_should_tolerate_empty_transaction_hash() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = create_authenticated(&server).await?;
+
+        let mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/data/trades")
+                .query_param("id", "trade-1");
+            then.status(StatusCode::OK)
+                .json_body(trades_page(&[trade_json("trade-1", "MATCHED", "")]));
+        });
+
+        let request = TradesRequest::builder().id("trade-1").build();
+        let response = client.trades(&request, None).await?;
+
+        assert_eq!(response.data.len(), 1);
+        assert_eq!(response.data[0].transaction_hash, B256::ZERO);
         mock.assert();
 
         Ok(())


### PR DESCRIPTION
Rust port of Polymarket/clob-client-v2#90 and Polymarket/py-clob-client-v2#101, supporting the async DB pipeline (Polymarket/clob-v2#299) where post /order responses omit `transactionsHashes` and matched orders carry `tradeIDs` instead.

## Approach

No new integration surface. Existing code reading `PostOrderResponse::transaction_hashes` keeps working across the server change with zero code changes.

- `post_order` / `post_orders`: when a response carries `trade_ids` without hashes, the client resolves `transaction_hashes` internally by polling `trades()` before returning. Sync responses short-circuit; unmatched orders and `defer_exec` orders are returned as-is (the flag is read per order, so batch entries are handled individually).
- Applies to every matched order, not just FAK/FOK. Per the server-side ADP change, `tradeIDs` only ever covers fills that already happened at match time, so resolution never waits on a resting remainder — a partially matched limit order resolves in the same bounded window as a market order, which is parity with today's synchronous execution.
- Resolution is best-effort: 30s ceiling, 250ms poll interval, and it never errors after a successful placement (avoids double-submission on resolution timeout). Poll failures are treated as "not resolved yet" and retried. Failed trades never contribute hashes.
- Polling is a private implementation detail, so it can be swapped for websocket-based resolution later without a breaking change.

## Bug fixes required by (but independent of) the feature

- `PostOrderResponse.trade_ids` never actually deserialized: the struct's camelCase rename expects `tradeIds`, but the server emits `tradeIDs`. Added `#[serde(alias = "tradeIDs")]` and corrected the bench fixture that encoded the same wrong casing.
- `TradeResponse.transaction_hash` was a required `B256`, but trades exist with an empty hash before broadcast (deferExec today, all matched orders under ADP), which made any `GET /trades` page containing one fail to deserialize. Added an `empty_string_as_zero_hash` deserializer following the existing `empty_string_as_zero` pattern; a zero hash now means "not yet submitted".

## Dependency note

`tokio` moves from optional to a regular dependency with only the `time` feature (needed for `sleep` in the base `clob` feature). This adds nothing to the dependency tree — reqwest already pulls tokio with time — and the `ws`/`rtds`/`heartbeats` features now enable the richer tokio features (`rt-multi-thread`, `macros`) instead of `dep:tokio`.

## Verification

- `cargo +nightly-2025-11-24 fmt --all -- --check` clean
- `cargo clippy --all-targets --all-features -- -D warnings` and `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --all-features`: full suite passes, including 6 new tests (polling resolution, defer_exec skip, failed-trade exclusion including empty-hash FAILED trades, batch mixed entries, empty transaction_hash tolerance); the pre-existing `post_order` tests double as no-tradeIDs and sync short-circuit regression guards since they would hang if resolution misfired

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes order-post return timing (up to 30s extra latency) and core trading response handling, though it preserves successful placement on resolution timeout and skips defer_exec.
> 
> **Overview**
> **Matched orders** that return `tradeIDs` without `transactionsHashes` (async execution pipeline) now get **`transaction_hashes` filled in** before `post_order` / `post_orders` return, by **best-effort polling** `GET /data/trades` (30s cap, 250ms interval). **`defer_exec`** orders skip polling; batch posts **dedupe trade IDs** and share **one** poll window. Resolution never fails a successful placement; **failed** trades are omitted from hashes.
> 
> **Serde fixes:** `PostOrderResponse.trade_ids` accepts server **`tradeIDs`**; `TradeResponse.transaction_hash` treats **empty strings as zero** so in-flight trades deserialize.
> 
> **Deps:** `tokio` is a **non-optional** dependency with **`time`** only for `sleep`; `ws` / `rtds` / `heartbeats` enable richer tokio via feature flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06a20ed9a92f5541138642446246e2433143decf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->