### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/Polymarket/rs-clob-client-v2/compare/v0.6.0...v0.7.0) - 2026-07-17
+
+### Added
+
+- *(clob)* resolve transaction hashes internally for matched orders ([#83](https://github.com/Polymarket/rs-clob-client-v2/pull/83)). The CLOB is rolling out an async execution pipeline where post order responses no longer include `transactionsHashes` and matched orders carry `tradeIDs` instead; `post_order` and `post_orders` now backfill `transaction_hashes` transparently by polling trades (best-effort, 30s ceiling shared across a batch, never errors after a successful placement). Upgrade before the server rollout; no code changes are required.
+
+### Fixed
+
+- *(clob::types)* `PostOrderResponse::trade_ids` never deserialized: the server emits `tradeIDs`, which the camelCase rename did not match ([#83](https://github.com/Polymarket/rs-clob-client-v2/pull/83))
+- *(clob::types)* `GET /trades` responses failed to deserialize when a trade had no transaction hash yet (pending execution); an empty hash now deserializes as `B256::ZERO` ([#83](https://github.com/Polymarket/rs-clob-client-v2/pull/83))
+
+### Other
+
+- *(cargo)* `tokio` is now a regular dependency with the `time` feature (previously optional); the `ws`, `rtds`, and `heartbeats` features enable the additional tokio features they need ([#83](https://github.com/Polymarket/rs-clob-client-v2/pull/83))
+
 ## [0.4.4](https://github.com/Polymarket/rs-clob-client/compare/v0.4.3...v0.4.4) - 2026-03-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "polymarket_client_sdk_v2"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "polymarket_client_sdk_v2"
 description = "Polymarket CLOB (Central Limit Order Book) API client SDK"
-version = "0.6.0"
+version = "0.7.0"
 authors = [
     "Polymarket Engineering <engineering@polymarket.com>",
     "Chaz Byrnes <chaz@polymarket.com>",


### PR DESCRIPTION
Release 0.7.0: async execution pipeline support (#83).

- Bumps the crate version to 0.7.0
- Adds the 0.7.0 changelog entry (note: the changelog had not been updated since 0.4.4; the 0.5.x/0.6.0 entries are still missing and can be backfilled separately)

After merge: manual `cargo publish` (release-plz is not wired; its workflow fails on every push because the `GH_ACCESS_TOKEN` secret is not configured).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only diff; behavioral risk is in the already-merged #83 code consumers pick up when they upgrade.
> 
> **Overview**
> **Release packaging for v0.7.0** — bumps `polymarket_client_sdk_v2` from **0.6.0** to **0.7.0** in `Cargo.toml` and `Cargo.lock`, and adds a **[0.7.0]** section under `[Unreleased]` in `CHANGELOG.md` (0.5.x/0.6.0 entries are still not backfilled).
> 
> The new changelog entry documents what shipped in #83: **`post_order` / `post_orders`** best-effort backfill of **`transaction_hashes`** via trade polling for the async execution pipeline; fixes for **`tradeIDs`** deserialization and pending **`GET /trades`** hashes; and **`tokio`** becoming a non-optional dependency with the `time` feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7544c58483b9837f70c224c81a99e405cfdee731. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->