### PR TITLE
fix(clob): keep heartbeats alive across client clones

### DIFF
--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -378,7 +378,8 @@ pub struct Client<S: State = Unauthenticated> {
 ///  2. Replace the (currently non-existent) ability of specialized implementations of [`Drop`]
 ///     <https://github.com/rust-lang/rust/issues/46893>
 ///
-/// This way, the inner token is expressly cancelled when [`DroppingCancellationToken`] is dropped.
+/// This way, the inner token is expressly cancelled when the final
+/// [`DroppingCancellationToken`] is dropped.
 /// We also have a [`Receiver<()>`] to notify when the inner [`Client`] has been dropped so that
 /// we can avoid a race condition when calling [`Arc::into_inner`] on promotion and demotion methods.
 #[derive(Clone, Debug, Default)]
@@ -414,7 +415,9 @@ impl DroppingCancellationToken {
 #[cfg(feature = "heartbeats")]
 impl Drop for DroppingCancellationToken {
     fn drop(&mut self) {
-        if let Some((token, _)) = self.0.take() {
+        if let Some((token, rx)) = self.0.take()
+            && Arc::into_inner(rx).is_some()
+        {
             token.cancel();
         }
     }

--- a/tests/clob.rs
+++ b/tests/clob.rs
@@ -3223,6 +3223,61 @@ mod authenticated {
 
     #[cfg(feature = "heartbeats")]
     #[tokio::test]
+    async fn dropping_order_builder_should_keep_heartbeats_active() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let id = Uuid::new_v4();
+        let heartbeat = server.mock(|when, then| {
+            when.method(POST).path("/v1/heartbeats");
+            then.status(StatusCode::OK).json_body(json!({
+                "heartbeat_id": id,
+                "error": null
+            }));
+        });
+        server.mock(|when, then| {
+            when.method(GET).path("/auth/derive-api-key");
+            then.status(StatusCode::OK).json_body(json!({
+                "apiKey": API_KEY.to_string(),
+                "passphrase": PASSPHRASE,
+                "secret": SECRET
+            }));
+        });
+
+        let signer = LocalSigner::from_str(PRIVATE_KEY)?.with_chain_id(Some(POLYGON));
+        let config = Config::builder()
+            .heartbeat_interval(Duration::from_millis(20))
+            .build();
+        let mut client = Client::new(&server.base_url(), config)?
+            .authentication_builder(&signer)
+            .authenticate()
+            .await?;
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while heartbeat.calls() < 2 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await?;
+
+        let before_builder_drop = heartbeat.calls();
+        drop(client.limit_order());
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while heartbeat.calls() <= before_builder_drop {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await?;
+
+        assert!(client.heartbeats_active());
+
+        client.stop_heartbeats().await?;
+
+        assert!(!client.heartbeats_active());
+
+        Ok(())
+    }
+
+    #[cfg(feature = "heartbeats")]
+    #[tokio::test]
     async fn stop_heartbeats_from_two_clones_should_fail_and_then_succeed_on_drop()
     -> anyhow::Result<()> {
         let server = MockServer::start();


### PR DESCRIPTION
## Summary

- cancel the automatic heartbeat task only when the final `DroppingCancellationToken` owner is dropped
- keep heartbeats running when temporary `Client` clones, including order-builder clones, are consumed or dropped
- add a bounded-polling integration regression that verifies heartbeats continue after dropping a limit-order builder and can still be stopped explicitly

## Root cause

`Client` and `DroppingCancellationToken` both derive `Clone`, but every cloned wrapper previously called `CancellationToken::cancel()` from `Drop`. `OrderBuilder` embeds a cloned client, so completing or dropping a normal order builder silently terminated the shared heartbeat task while the original client continued reporting `heartbeats_active() == true`.

The fix uses `Arc::into_inner` to atomically identify the final receiver owner. This preserves existing explicit-stop and multiple-owner synchronization behavior while ensuring exactly one final drop performs cancellation, including under concurrent drops.

## Impact

Heartbeat-enabled clients can build orders without silently stopping the dead-man heartbeat mechanism and risking order-priority loss or cancellation of open orders.

## Validation

- `cargo build --all-targets --all-features`
- `cargo test` — 15 unit tests and 4 doctests passed; feature-gated integrations correctly skipped
- `cargo +nightly-2025-11-24 fmt --all -- --check`
- `cargo +1.88 clippy --all-targets --all-features -- -D warnings`
- `cargo +1.88 clippy --all-targets -- -D warnings`
- `cargo sort --check` with cargo-sort 2.0.2
- `cargo +1.88 llvm-cov --all-features --workspace --lcov --output-path lcov.info` — 559 all-feature tests passed
- `PRE_COMMIT_HOME=/tmp/pre-commit pre-commit run --files src/clob/client.rs tests/clob.rs`
- focused heartbeat regression passed 20 consecutive runs

Fixes #91

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared heartbeat teardown for all authenticated client clones; wrong refcount logic could leave heartbeats running or stop them too early, but scope is narrow and covered by a new regression test.
> 
> **Overview**
> Fixes a bug where **dropping any cloned `Client` (including a temporary limit-order builder) cancelled the shared heartbeat task** while the main client still reported heartbeats as active.
> 
> `DroppingCancellationToken`’s `Drop` now calls `CancellationToken::cancel()` only when the dropped instance holds the **last** `Arc` to the cleanup receiver (`Arc::into_inner`), so intermediate clones from `limit_order()` / `market_order()` no longer stop the background heartbeat loop. Explicit `stop_heartbeats` / `cancel_and_wait` behavior is unchanged.
> 
> Adds a **heartbeats** integration test that drops a limit-order builder, asserts heartbeats keep posting, then verifies `stop_heartbeats` still shuts them down.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03fa66aae06473816bd2731e324edf7462d9b5ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->