### PR TITLE
fix: tolerate empty-string decimal fields in trade responses

### DIFF
--- a/src/clob/types/response.rs
+++ b/src/clob/types/response.rs
@@ -403,8 +403,11 @@ pub struct TradeResponse {
     pub market: B256,
     pub asset_id: U256,
     pub side: Side,
+    #[serde(deserialize_with = "empty_string_as_zero")]
     pub size: Decimal,
+    #[serde(deserialize_with = "empty_string_as_zero")]
     pub fee_rate_bps: Decimal,
+    #[serde(deserialize_with = "empty_string_as_zero")]
     pub price: Decimal,
     pub status: TradeStatusType,
     #[serde_as(as = "TimestampSeconds<String>")]
@@ -535,8 +538,11 @@ pub struct MakerOrder {
     pub order_id: String,
     pub owner: ApiKey,
     pub maker_address: Address,
+    #[serde(deserialize_with = "empty_string_as_zero")]
     pub matched_amount: Decimal,
+    #[serde(deserialize_with = "empty_string_as_zero")]
     pub price: Decimal,
+    #[serde(deserialize_with = "empty_string_as_zero")]
     pub fee_rate_bps: Decimal,
     pub asset_id: U256,
     pub outcome: String,

--- a/tests/clob.rs
+++ b/tests/clob.rs
@@ -2030,6 +2030,51 @@ mod authenticated {
     }
 
     #[tokio::test]
+    async fn trades_should_tolerate_empty_decimal_fields() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = create_authenticated(&server).await?;
+
+        let mut trade = trade_json("trade-1", "MATCHED", "");
+        trade["size"] = json!("");
+        trade["fee_rate_bps"] = json!("");
+        trade["price"] = json!("");
+        trade["maker_orders"] = json!([{
+            "order_id": "maker_001",
+            "owner": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            "maker_address": "0x4444444444444444444444444444444444444444",
+            "matched_amount": "",
+            "price": "",
+            "fee_rate_bps": "",
+            "asset_id": token_1(),
+            "outcome": "YES",
+            "side": "SELL"
+        }]);
+
+        let mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/data/trades")
+                .query_param("id", "trade-1");
+            then.status(StatusCode::OK).json_body(trades_page(&[trade]));
+        });
+
+        let request = TradesRequest::builder().id("trade-1").build();
+        let response = client.trades(&request, None).await?;
+
+        assert_eq!(response.data.len(), 1);
+        let trade = &response.data[0];
+        assert_eq!(trade.size, Decimal::ZERO);
+        assert_eq!(trade.fee_rate_bps, Decimal::ZERO);
+        assert_eq!(trade.price, Decimal::ZERO);
+        let maker = &trade.maker_orders[0];
+        assert_eq!(maker.matched_amount, Decimal::ZERO);
+        assert_eq!(maker.price, Decimal::ZERO);
+        assert_eq!(maker.fee_rate_bps, Decimal::ZERO);
+        mock.assert();
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn order_should_succeed() -> anyhow::Result<()> {
         let server = MockServer::start();
         let client = create_authenticated(&server).await?;


### PR DESCRIPTION
## Problem

`GET /data/trades` responses can carry `""` in `Decimal`-typed fields, which makes the whole trades fetch fail to deserialize:

```
invalid value: string "", expected a Decimal type representing a fixed-point number
```

We hit this in production while paging a user's trades through `Client::trades` — one trade with an empty decimal field poisons the entire page.

This is the same venue behavior already handled for `TradeResponse.transaction_hash` (empty until the async execution pipeline broadcasts the trade's transaction, tolerated via `empty_string_as_zero_hash`) and for `PostOrderResponse.making_amount`/`taking_amount` (`empty_string_as_zero`) — but the `Decimal` fields of `TradeResponse` and its `MakerOrder`s still hard-fail on `""`.

## Fix

Apply the existing `empty_string_as_zero` deserializer to:

- `TradeResponse`: `size`, `fee_rate_bps`, `price`
- `MakerOrder`: `matched_amount`, `price`, `fee_rate_bps`

No API change — only widens accepted wire input, mirroring the established pattern.

## Testing

Added `trades_should_tolerate_empty_decimal_fields` (mirrors `trades_should_tolerate_empty_transaction_hash`), asserting all six fields deserialize to `Decimal::ZERO` when the venue sends `""`.

```
cargo test --features clob --test clob trades_should_
running 4 tests ... 4 passed
```

*(Note: couldn't apply the `wip` label from a fork — maintainers, feel free to add if desired.)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deserialization-only widening with an established helper; no API or trading logic changes, though callers may see zero instead of a hard error for malformed venue data.
> 
> **Overview**
> **Trade list deserialization** no longer fails when the venue sends `""` for numeric trade fields on `GET /data/trades`.
> 
> `TradeResponse` (`size`, `fee_rate_bps`, `price`) and nested `MakerOrder` (`matched_amount`, `price`, `fee_rate_bps`) now use the existing `empty_string_as_zero` deserializer, matching `PostOrderResponse` and the empty `transaction_hash` handling. Empty strings map to `Decimal::ZERO`; valid numeric strings behave as before.
> 
> A CLOB integration test asserts a full trades page still parses when those six fields are empty on the trade and its maker order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e59efc5e6555d16ed2c40ba1c6ab6b0f9909e27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->