### PR TITLE
fix(clob::types): tolerate empty-string numerics on pending-execution trades

### DIFF
--- a/src/clob/types/response.rs
+++ b/src/clob/types/response.rs
@@ -403,8 +403,15 @@ pub struct TradeResponse {
     pub market: B256,
     pub asset_id: U256,
     pub side: Side,
+    /// Numeric fields tolerate the empty strings the async execution
+    /// pipeline emits for trades whose settlement is still pending (observed
+    /// live 2026-07-29 on `GET /data/trades`); a strict `Decimal` failed the
+    /// whole page. Same lenient policy as `transaction_hash` below.
+    #[serde_as(deserialize_as = "DefaultOnError")]
     pub size: Decimal,
+    #[serde_as(deserialize_as = "DefaultOnError")]
     pub fee_rate_bps: Decimal,
+    #[serde_as(deserialize_as = "DefaultOnError")]
     pub price: Decimal,
     pub status: TradeStatusType,
     #[serde_as(as = "TimestampSeconds<String>")]
@@ -529,14 +536,19 @@ pub struct UserInfo {
 }
 
 #[non_exhaustive]
+#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, Builder, PartialEq)]
 #[builder(on(String, into))]
 pub struct MakerOrder {
     pub order_id: String,
     pub owner: ApiKey,
     pub maker_address: Address,
+    /// See [`TradeResponse`]: pending-execution rows may carry "" numerics.
+    #[serde_as(deserialize_as = "DefaultOnError")]
     pub matched_amount: Decimal,
+    #[serde_as(deserialize_as = "DefaultOnError")]
     pub price: Decimal,
+    #[serde_as(deserialize_as = "DefaultOnError")]
     pub fee_rate_bps: Decimal,
     pub asset_id: U256,
     pub outcome: String,


### PR DESCRIPTION
## Problem

The async execution pipeline can return `""` for numeric fields (`size` / `price` / `fee_rate_bps` on `TradeResponse` and `MakerOrder`) on `GET /data/trades` rows whose settlement is still pending — observed live 2026-07-29. A strict `Decimal` fails deserialization of the **whole page**, so one pending trade blacks out the entire tape for consumers polling it. In our case a market maker's fill reconciliation went dark for 24h+ before the root cause was found.

## Fix

Deserialize those fields with `DefaultOnError` — the same lenient policy v0.7.0 already applies to `transaction_hash` for exactly this pipeline (#83). A pending row parses with zeroed numerics instead of poisoning the page; consumers that need exact figures can re-poll once the trade confirms, and every other row on the page survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRy5VdMgLHQ1EB9WgqxP3p

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow serde-only change to trade response types; no auth, settlement, or client logic changes, with the main behavioral caveat that pending rows may show zero numerics until confirmed.
> 
> **Overview**
> **`GET /data/trades` pages no longer fail** when the async execution pipeline returns `""` for numeric fields on trades that are still settling.
> 
> `TradeResponse` (`size`, `price`, `fee_rate_bps`) and nested `MakerOrder` (`matched_amount`, `price`, `fee_rate_bps`) now deserialize those values with `serde_as(deserialize_as = "DefaultOnError")`, matching the existing lenient handling for `transaction_hash`. Pending rows parse with default/zero decimals instead of breaking deserialization for the entire page; callers can treat unsettled rows via status/hash and re-fetch after confirmation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f4c485f2576d82bf7ad5d6193880ab130f4e62b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->