### PR TITLE
fix: give every default HTTP client a connect/total timeout

### DIFF
--- a/src/bridge/client.rs
+++ b/src/bridge/client.rs
@@ -61,7 +61,15 @@ impl Client {
         headers.insert("Accept", HeaderValue::from_static("*/*"));
         headers.insert("Connection", HeaderValue::from_static("keep-alive"));
         headers.insert("Content-Type", HeaderValue::from_static("application/json"));
-        let client = ReqwestClient::builder().default_headers(headers).build()?;
+        // reqwest ships with no default timeout, so a single hung TCP
+        // connection blocks the caller indefinitely. 30s total / 10s connect
+        // is far above any healthy response from these APIs while still
+        // guaranteeing the caller gets control back.
+        let client = ReqwestClient::builder()
+            .default_headers(headers)
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
+            .build()?;
 
         Ok(Self {
             host: Url::parse(host)?,

--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -1491,7 +1491,15 @@ impl Client<Unauthenticated> {
         headers.insert("Connection", HeaderValue::from_static("keep-alive"));
         headers.insert("Content-Type", HeaderValue::from_static("application/json"));
 
-        let client = ReqwestClient::builder().default_headers(headers).build()?;
+        // reqwest ships with no default timeout, so a single hung TCP
+        // connection blocks the caller indefinitely. 30s total / 10s connect
+        // is far above any healthy response from these APIs while still
+        // guaranteeing the caller gets control back.
+        let client = ReqwestClient::builder()
+            .default_headers(headers)
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
+            .build()?;
 
         let geoblock_host = Url::parse(
             config

--- a/src/data/client.rs
+++ b/src/data/client.rs
@@ -93,7 +93,15 @@ impl Client {
         headers.insert("Accept", HeaderValue::from_static("*/*"));
         headers.insert("Connection", HeaderValue::from_static("keep-alive"));
         headers.insert("Content-Type", HeaderValue::from_static("application/json"));
-        let client = ReqwestClient::builder().default_headers(headers).build()?;
+        // reqwest ships with no default timeout, so a single hung TCP
+        // connection blocks the caller indefinitely. 30s total / 10s connect
+        // is far above any healthy response from these APIs while still
+        // guaranteeing the caller gets control back.
+        let client = ReqwestClient::builder()
+            .default_headers(headers)
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
+            .build()?;
 
         Ok(Self {
             host: Url::parse(host)?,

--- a/src/gamma/client.rs
+++ b/src/gamma/client.rs
@@ -105,7 +105,15 @@ impl Client {
         headers.insert("Accept", HeaderValue::from_static("*/*"));
         headers.insert("Connection", HeaderValue::from_static("keep-alive"));
         headers.insert("Content-Type", HeaderValue::from_static("application/json"));
-        let client = ReqwestClient::builder().default_headers(headers).build()?;
+        // reqwest ships with no default timeout, so a single hung TCP
+        // connection blocks the caller indefinitely. 30s total / 10s connect
+        // is far above any healthy response from these APIs while still
+        // guaranteeing the caller gets control back.
+        let client = ReqwestClient::builder()
+            .default_headers(headers)
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
+            .build()?;
 
         Ok(Self {
             host: Url::parse(host)?,


### PR DESCRIPTION
## Problem

`reqwest::Client` ships with **no timeout by default**, and all four sub-clients (clob / gamma / data / bridge) build their default client without setting one. A single hung TCP connection — a dropped SYN-ACK, a stalled middlebox — wedges the calling task forever: no error, no return. We measured exactly this failure class live (a task hung 17+ minutes on a network blip until externally killed).

## Fix

`connect_timeout(10s)` + `timeout(30s)` on the default builders. Both are far above any healthy response from these APIs, while guaranteeing the caller always gets control back. Callers with different budgets can keep constructing and injecting their own client, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRy5VdMgLHQ1EB9WgqxP3p

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default timeouts apply to all four API surfaces, including CLOB; legitimately slow calls may now surface timeout errors instead of hanging, which can affect trading and automation that relied on unbounded waits.
> 
> **Overview**
> Adds **10s connect** and **30s total** request timeouts on the built-in `reqwest` clients in **bridge**, **clob**, **data**, and **gamma** `Client::new`, so hung connections fail instead of blocking forever.
> 
> Each builder gets a short comment explaining why `reqwest` has no default timeout. Callers who need different limits can still supply their own HTTP client where the API allows it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91c9257873757fe14e31dcb8922108c57b627af3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->