### PR TITLE
fix(clob): force version refresh in build_sign_and_post retry (#100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- *(clob)* `build_sign_and_post` (Limit and Market) now forces a version-cache refresh (`resolve_version(true)`) when checking whether the server version changed after an `order_version_mismatch`, instead of re-reading the value cached before the post. The retry previously worked only as an implicit side-effect of `post_order` invalidating the cache; it is now self-contained and no longer silently breaks if that invalidation changes. Adds regression tests covering both order paths ([#100](https://github.com/Polymarket/rs-clob-client-v2/issues/100)).
+
 ## [0.7.0](https://github.com/Polymarket/rs-clob-client-v2/compare/v0.6.0...v0.7.0) - 2026-07-17
 
 ### Added

--- a/src/clob/order_builder.rs
+++ b/src/clob/order_builder.rs
@@ -399,7 +399,9 @@ impl<K: AuthKind> OrderBuilder<Limit, K> {
                 .message
                 .contains(crate::clob::client::ORDER_VERSION_MISMATCH_ERROR)
         {
-            let after_version = client.resolve_version(false).await.unwrap_or(0);
+            // Force a cache refresh: `resolve_version(false)` would return the value
+            // cached before the post, so the comparison below could never detect a bump.
+            let after_version = client.resolve_version(true).await.unwrap_or(0);
             if after_version != before_version {
                 let order = retry.build().await?;
                 let signed = client.sign(signer, order).await?;
@@ -658,7 +660,9 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
                 .message
                 .contains(crate::clob::client::ORDER_VERSION_MISMATCH_ERROR)
         {
-            let after_version = client.resolve_version(false).await.unwrap_or(0);
+            // Force a cache refresh: `resolve_version(false)` would return the value
+            // cached before the post, so the comparison below could never detect a bump.
+            let after_version = client.resolve_version(true).await.unwrap_or(0);
             if after_version != before_version {
                 let order = retry.build().await?;
                 let signed = client.sign(signer, order).await?;

--- a/tests/version_retry.rs
+++ b/tests/version_retry.rs
@@ -1,0 +1,164 @@
+#![cfg(feature = "clob")]
+#![allow(
+    clippy::unwrap_used,
+    reason = "Do not need additional syntax for setting up tests"
+)]
+
+mod common;
+
+use std::str::FromStr as _;
+
+use alloy::signers::Signer as _;
+use alloy::signers::local::LocalSigner;
+use httpmock::{Method, MockServer};
+use polymarket_client_sdk_v2::POLYGON;
+use polymarket_client_sdk_v2::clob::types::response::OrderSummary;
+use polymarket_client_sdk_v2::clob::types::{Amount, OrderType, Side, TickSize};
+use polymarket_client_sdk_v2::types::Decimal;
+use reqwest::StatusCode;
+use rust_decimal_macros::dec;
+use serde_json::json;
+
+use crate::common::{
+    PRIVATE_KEY, create_authenticated, ensure_requirements, ensure_version, token_1,
+};
+
+/// Reproduces rs-clob-client-v2#100: on `order_version_mismatch`, `build_sign_and_post`
+/// must refresh the cached version and retry once. We seed the cache with the stale
+/// version (1), then have the server report version 2 and reject every post with a
+/// version-mismatch error. The retry firing means `/order` is hit twice.
+#[tokio::test]
+async fn limit_build_sign_and_post_retries_on_version_mismatch() -> anyhow::Result<()> {
+    let server = MockServer::start();
+    let client = create_authenticated(&server).await?;
+    let signer = LocalSigner::from_str(PRIVATE_KEY)?.with_chain_id(Some(POLYGON));
+
+    // Seed the version cache with the OLD version (1).
+    let mut version_v1 = server.mock(|when, then| {
+        when.method(httpmock::Method::GET).path("/version");
+        then.status(StatusCode::OK)
+            .json_body(json!({ "version": 1 }));
+    });
+    assert_eq!(client.version().await?, 1);
+    version_v1.delete();
+
+    // Server has since upgraded to version 2 (ensure_requirements mocks /version -> 2)
+    // and rejects the stale-version order.
+    ensure_requirements(&server, token_1(), TickSize::Tenth);
+
+    let order_mock = server.mock(|when, then| {
+        when.method(httpmock::Method::POST).path("/order");
+        then.status(StatusCode::BAD_REQUEST)
+            .json_body(json!({ "error": "order_version_mismatch" }));
+    });
+
+    let result = client
+        .limit_order()
+        .token_id(token_1())
+        .size(Decimal::ONE_HUNDRED)
+        .price(dec!(0.1))
+        .side(Side::Buy)
+        .build_sign_and_post(&signer)
+        .await;
+
+    assert!(
+        result.is_err(),
+        "expected the version-mismatch error to propagate after the retry"
+    );
+    assert_eq!(
+        order_mock.calls(),
+        2,
+        "version-mismatch retry did not fire: /order should be posted twice (initial + retry)"
+    );
+
+    Ok(())
+}
+
+/// Same as above, but for the market-order path (rs-clob-client-v2#100 notes both paths).
+#[tokio::test]
+async fn market_build_sign_and_post_retries_on_version_mismatch() -> anyhow::Result<()> {
+    let server = MockServer::start();
+    let client = create_authenticated(&server).await?;
+    let signer = LocalSigner::from_str(PRIVATE_KEY)?.with_chain_id(Some(POLYGON));
+
+    // Seed the version cache with the OLD version (1).
+    let mut version_v1 = server.mock(|when, then| {
+        when.method(Method::GET).path("/version");
+        then.status(StatusCode::OK)
+            .json_body(json!({ "version": 1 }));
+    });
+    assert_eq!(client.version().await?, 1);
+    version_v1.delete();
+
+    // Server has since upgraded to version 2.
+    ensure_version(&server, 2);
+
+    // Book / tick-size / fee-rate needed to compute the market price and build the order.
+    let asks = vec![
+        OrderSummary::builder()
+            .price(dec!(0.5))
+            .size(dec!(1000))
+            .build(),
+    ];
+    server.mock(|when, then| {
+        when.method(Method::GET)
+            .path("/book")
+            .query_param("token_id", token_1().to_string());
+        then.status(StatusCode::OK).json_body(json!({
+            "market": "0xbd31dc8a20211944f6b70f31557f1001557b59905b7738480ca09bd4532f84af",
+            "asset_id": token_1(),
+            "timestamp": "1000",
+            "bids": [],
+            "asks": asks,
+            "min_order_size": "5",
+            "neg_risk": false,
+            "tick_size": "0.1",
+        }));
+    });
+    server.mock(|when, then| {
+        when.method(Method::GET)
+            .path("/tick-size")
+            .query_param("token_id", token_1().to_string());
+        then.status(StatusCode::OK)
+            .json_body(json!({ "minimum_tick_size": "0.1" }));
+    });
+    server.mock(|when, then| {
+        when.method(Method::GET)
+            .path("/fee-rate")
+            .query_param("token_id", token_1().to_string());
+        then.status(StatusCode::OK)
+            .json_body(json!({ "base_fee": 0 }));
+    });
+    server.mock(|when, then| {
+        when.method(Method::GET).path("/neg-risk");
+        then.status(StatusCode::OK)
+            .json_body(json!({ "neg_risk": false }));
+    });
+
+    let order_mock = server.mock(|when, then| {
+        when.method(Method::POST).path("/order");
+        then.status(StatusCode::BAD_REQUEST)
+            .json_body(json!({ "error": "order_version_mismatch" }));
+    });
+
+    let result = client
+        .market_order()
+        .token_id(token_1())
+        .amount(Amount::usdc(Decimal::ONE_HUNDRED)?)
+        .side(Side::Buy)
+        .order_type(OrderType::FOK)
+        .build_sign_and_post(&signer)
+        .await;
+
+    assert!(
+        result.is_err(),
+        "expected the version-mismatch error to propagate after the retry"
+    );
+    assert_eq!(
+        order_mock.calls(),
+        2,
+        "version-mismatch retry did not fire: /order should be posted twice (initial + retry)"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #100.

## What

`build_sign_and_post` (both `Limit` and `Market`) retries once on `order_version_mismatch` by comparing `resolve_version()` before and after the failed post. The post-error check called `resolve_version(false)`, which returns the value cached **before** the post — so `after_version != before_version` was being satisfied only as an implicit side-effect of `post_order` invalidating the cache (`invalidate_version_if_mismatch` → `resolve_version(true)`).

This changes the post-error check to `resolve_version(true)` so the retry forces a fresh version fetch and is self-contained.

## Investigation note (important)

The issue reports that the retry *never* fires. That is **not** what current `main` does: `post_order` already force-refreshes the version cache on a mismatch (`client.rs`, `invalidate_version_if_mismatch`) *before* the retry block reads `after_version`, so the retry **does** fire today in the realistic stale-cache → server-bump scenario. I verified this empirically:

- Unmodified code + new regression test → `/order` is posted **twice** (retry fires). ✅
- Temporarily disabling `invalidate_version_if_mismatch` → `/order` posted **once** (exactly the "never fires" behavior the issue describes).

So the real defect is a **hidden dependency**: the retry's correctness relies on an unrelated cache-invalidation side-effect in `post_order`. `resolve_version(true)` removes that coupling and makes the intent explicit, matching the documented behavior of the function. Net cost is one extra `GET /version` on the (rare) mismatch path.

## Testing

- New `tests/version_retry.rs`: seeds the cache with a stale version, has the server report a bumped version and reject the stale order, and asserts `/order` is posted twice (initial + retry) — one test each for the limit and market paths.
- Full test suite passes (`cargo test --features clob --tests --lib`), no regressions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to the rare version-mismatch retry path plus tests; adds one extra version fetch on that error path only.
> 
> **Overview**
> **Fixes `order_version_mismatch` retry logic** in limit and market `build_sign_and_post` so it no longer depends on `post_order` side-effect cache invalidation.
> 
> After a failed post, the retry path now calls `resolve_version(true)` instead of `resolve_version(false)` when comparing server version before vs. after. That forces a fresh `GET /version` so a bumped version is detected even if the pre-post cached value would still be returned.
> 
> Regression tests in `tests/version_retry.rs` seed a stale cached version, mock a server upgrade and repeated mismatch errors, and assert `/order` is posted twice for both limit and market flows. **CHANGELOG** documents the fix under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 852af728ecad6f9c8a0e3c60ad5b42f5973e3cca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->