### PR TITLE
fix(ws): surface recoverable subscription lag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+### Changed
 
-- *(ws)* surface recoverable broadcast lag to CLOB and RTDS subscription consumers without terminating the stream
+- *(ws)* [**breaking**] CLOB and RTDS subscription streams now yield a recoverable `Err` (`WsError::Lagged` / `RtdsError::Lagged`) when the receiver falls behind the shared broadcast channel, instead of only logging under the `tracing` feature. The stream stays alive after the item. Consumers that propagate every stream error (`let msg = item?;`) will now stop consuming on lag: match on `Lagged`, resnapshot or reconcile if needed, then continue polling; propagate other errors.
 
 ## [0.7.0](https://github.com/Polymarket/rs-clob-client-v2/compare/v0.6.0...v0.7.0) - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- *(ws)* surface recoverable broadcast lag to CLOB and RTDS subscription consumers without terminating the stream
+
 ## [0.7.0](https://github.com/Polymarket/rs-clob-client-v2/compare/v0.6.0...v0.7.0) - 2026-07-17
 
 ### Added

--- a/src/clob/ws/client.rs
+++ b/src/clob/ws/client.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use async_stream::try_stream;
+use async_stream::stream;
 use dashmap::mapref::one::{Ref, RefMut};
 use dashmap::{DashMap, Entry};
 use futures::Stream;
@@ -21,6 +21,33 @@ use crate::ws::ConnectionManager;
 use crate::ws::config::Config;
 use crate::ws::connection::ConnectionState;
 
+fn midpoint_stream<S>(books: S) -> impl Stream<Item = Result<MidpointUpdate>>
+where
+    S: Stream<Item = Result<BookUpdate>>,
+{
+    stream! {
+        for await book_result in books {
+            match book_result {
+                Ok(book) => {
+                    // Calculate midpoint from best bid/ask
+                    if let (Some(bid), Some(ask)) = (book.bids.first(), book.asks.first()) {
+                        let midpoint = (bid.price + ask.price) / Decimal::TWO;
+                        yield Ok(MidpointUpdate {
+                            asset_id: book.asset_id,
+                            market: book.market,
+                            midpoint,
+                            timestamp: book.timestamp,
+                        });
+                    }
+                }
+                // Lag is a recoverable stream item. Forward it without ending
+                // this derived stream so later order books still produce midpoints.
+                Err(error) => yield Err(error),
+            }
+        }
+    }
+}
+
 /// WebSocket client for real-time market data and user updates.
 ///
 /// This client uses a type-state pattern to enforce authentication requirements at compile time:
@@ -32,7 +59,7 @@ use crate::ws::connection::ConnectionState;
 /// ```rust, no_run
 /// use std::str::FromStr as _;
 ///
-/// use polymarket_client_sdk_v2::clob::ws::Client;
+/// use polymarket_client_sdk_v2::clob::ws::{Client, WsError};
 /// use polymarket_client_sdk_v2::types::U256;
 /// use futures::StreamExt;
 ///
@@ -44,8 +71,18 @@ use crate::ws::connection::ConnectionState;
 ///     let stream = client.subscribe_orderbook(vec![U256::from_str("106585164761922456203746651621390029417453862034640469075081961934906147433548")?])?;
 ///     let mut stream = Box::pin(stream);
 ///
-///     while let Some(book) = stream.next().await {
-///         println!("Orderbook: {:?}", book?);
+///     while let Some(book_result) = stream.next().await {
+///         match book_result {
+///             Ok(book) => println!("Orderbook: {book:?}"),
+///             Err(error) if matches!(
+///                 error.downcast_ref::<WsError>(),
+///                 Some(WsError::Lagged { .. })
+///             ) => {
+///                 // Re-fetch the book snapshot, then continue consuming updates.
+///                 continue;
+///             }
+///             Err(error) => return Err(error.into()),
+///         }
 ///     }
 ///
 ///     Ok(())
@@ -274,22 +311,7 @@ impl<S: State> Client<S> {
     ) -> Result<impl Stream<Item = Result<MidpointUpdate>> + use<S>> {
         let stream = self.subscribe_orderbook(asset_ids)?;
 
-        Ok(try_stream! {
-            for await book_result in stream {
-                let book = book_result?;
-
-                // Calculate midpoint from best bid/ask
-                if let (Some(bid), Some(ask)) = (book.bids.first(), book.asks.first()) {
-                    let midpoint = (bid.price + ask.price) / Decimal::TWO;
-                    yield MidpointUpdate {
-                        asset_id: book.asset_id,
-                        market: book.market,
-                        midpoint,
-                        timestamp: book.timestamp,
-                    };
-                }
-            }
-        })
+        Ok(midpoint_stream(stream))
     }
 
     /// Subscribe to best bid/ask updates with custom features enabled.
@@ -663,4 +685,35 @@ fn channel_endpoint(base: &str, channel: ChannelType) -> String {
         ChannelType::User => "user",
     };
     format!("{trimmed}/ws/{segment}")
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt as _;
+    use rust_decimal_macros::dec;
+    use serde_json::json;
+
+    use super::*;
+    use crate::ws::WsError;
+
+    #[tokio::test]
+    async fn midpoint_stream_continues_after_lag_notification() {
+        let book = serde_json::from_value(json!({
+            "asset_id": "1",
+            "market": format!("0x{:064x}", 1),
+            "timestamp": "2",
+            "bids": [{"price": "0.4", "size": "1"}],
+            "asks": [{"price": "0.6", "size": "1"}]
+        }))
+        .unwrap();
+        let input = futures::stream::iter([Err(WsError::Lagged { count: 1 }.into()), Ok(book)]);
+        let mut stream = Box::pin(midpoint_stream(input));
+
+        let error = stream.next().await.unwrap().unwrap_err();
+        assert!(matches!(
+            error.downcast_ref::<WsError>(),
+            Some(WsError::Lagged { count: 1 })
+        ));
+        assert_eq!(stream.next().await.unwrap().unwrap().midpoint, dec!(0.5));
+    }
 }

--- a/src/clob/ws/client.rs
+++ b/src/clob/ws/client.rs
@@ -18,6 +18,7 @@ use crate::auth::{Credentials, Kind as AuthKind, Normal};
 use crate::error::Error;
 use crate::types::{Address, B256, Decimal, U256};
 use crate::ws::ConnectionManager;
+use crate::ws::WsError;
 use crate::ws::config::Config;
 use crate::ws::connection::ConnectionState;
 
@@ -40,9 +41,18 @@ where
                         });
                     }
                 }
-                // Lag is a recoverable stream item. Forward it without ending
-                // this derived stream so later order books still produce midpoints.
-                Err(error) => yield Err(error),
+                // Lag is recoverable: forward it and keep the stream alive so
+                // later order books still produce midpoints.
+                Err(error)
+                    if matches!(error.downcast_ref::<WsError>(), Some(WsError::Lagged { .. })) =>
+                {
+                    yield Err(error);
+                }
+                // Any other error is terminal for the derived stream.
+                Err(error) => {
+                    yield Err(error);
+                    break;
+                }
             }
         }
     }
@@ -691,21 +701,24 @@ fn channel_endpoint(base: &str, channel: ChannelType) -> String {
 mod tests {
     use futures::StreamExt as _;
     use rust_decimal_macros::dec;
-    use serde_json::json;
+    use serde_json::{Value, json};
 
     use super::*;
     use crate::ws::WsError;
 
-    #[tokio::test]
-    async fn midpoint_stream_continues_after_lag_notification() {
-        let book = serde_json::from_value(json!({
+    fn book() -> Value {
+        json!({
             "asset_id": "1",
             "market": format!("0x{:064x}", 1),
             "timestamp": "2",
             "bids": [{"price": "0.4", "size": "1"}],
             "asks": [{"price": "0.6", "size": "1"}]
-        }))
-        .unwrap();
+        })
+    }
+
+    #[tokio::test]
+    async fn midpoint_stream_continues_after_lag_notification() {
+        let book = serde_json::from_value(book()).unwrap();
         let input = futures::stream::iter([Err(WsError::Lagged { count: 1 }.into()), Ok(book)]);
         let mut stream = Box::pin(midpoint_stream(input));
 
@@ -715,5 +728,19 @@ mod tests {
             Some(WsError::Lagged { count: 1 })
         ));
         assert_eq!(stream.next().await.unwrap().unwrap().midpoint, dec!(0.5));
+    }
+
+    #[tokio::test]
+    async fn midpoint_stream_ends_after_non_lag_error() {
+        let book = serde_json::from_value(book()).unwrap();
+        let input = futures::stream::iter([Err(WsError::ConnectionClosed.into()), Ok(book)]);
+        let mut stream = Box::pin(midpoint_stream(input));
+
+        let error = stream.next().await.unwrap().unwrap_err();
+        assert!(matches!(
+            error.downcast_ref::<WsError>(),
+            Some(WsError::ConnectionClosed)
+        ));
+        assert!(stream.next().await.is_none());
     }
 }

--- a/src/clob/ws/subscription.rs
+++ b/src/clob/ws/subscription.rs
@@ -8,10 +8,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, PoisonError, RwLock};
 use std::time::Instant;
 
-use async_stream::try_stream;
+use async_stream::stream;
 use dashmap::{DashMap, Entry};
 use futures::Stream;
-use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::broadcast::{Receiver, error::RecvError};
 
 use super::interest::{InterestTracker, MessageInterest};
 use super::types::request::SubscriptionRequest;
@@ -22,6 +22,32 @@ use crate::types::{B256, U256};
 use crate::ws::ConnectionManager;
 use crate::ws::WsError;
 use crate::ws::connection::ConnectionState;
+
+fn filtered_stream<F>(
+    mut rx: Receiver<WsMessage>,
+    should_yield: F,
+) -> impl Stream<Item = Result<WsMessage>>
+where
+    F: Fn(&WsMessage) -> bool,
+{
+    stream! {
+        loop {
+            match rx.recv().await {
+                Ok(msg) => {
+                    if should_yield(&msg) {
+                        yield Ok(msg);
+                    }
+                }
+                Err(RecvError::Lagged(n)) => {
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!("Subscription lagged, missed {n} messages — continuing");
+                    yield Err(WsError::Lagged { count: n }.into());
+                }
+                Err(RecvError::Closed) => break,
+            }
+        }
+    }
+}
 
 /// What a subscription is targeting.
 #[non_exhaustive]
@@ -281,50 +307,29 @@ impl SubscriptionManager {
         );
 
         // Create filtered stream with its own receiver
-        let mut rx = self.connection.subscribe();
+        let rx = self.connection.subscribe();
         let asset_ids_set: HashSet<U256> = asset_ids.into_iter().collect();
 
-        Ok(try_stream! {
-            loop {
-                match rx.recv().await {
-                    Ok(msg) => {
-                        // Filter messages by asset_id
-                        let should_yield = match &msg {
-                            WsMessage::Book(book) => asset_ids_set.contains(&book.asset_id),
-                            WsMessage::PriceChange(price) => {
-                                price
-                                    .price_changes
-                                    .iter()
-                                    .any(|pc| asset_ids_set.contains(&pc.asset_id))
-                            },
-                            WsMessage::LastTradePrice(ltp) => asset_ids_set.contains(&ltp.asset_id),
-                            WsMessage::TickSizeChange(tsc) => asset_ids_set.contains(&tsc.asset_id),
-                            WsMessage::BestBidAsk(bba) => asset_ids_set.contains(&bba.asset_id),
-                            WsMessage::NewMarket(nm) => {
-                                nm.asset_ids.iter().any(|id| asset_ids_set.contains(id))
-                            },
-                            WsMessage::MarketResolved(mr) => {
-                                mr.asset_ids.iter().any(|id| asset_ids_set.contains(id))
-                            },
-                            _ => false,
-                        };
-
-                        if should_yield {
-                            yield msg
-                        }
-                    }
-                    Err(RecvError::Lagged(n)) => {
-                        #[cfg(not(feature = "tracing"))]
-                        let _ = n;
-                        #[cfg(feature = "tracing")]
-                        tracing::warn!("Subscription lagged, missed {n} messages — continuing");
-                    }
-                    Err(RecvError::Closed) => {
-                        break;
-                    }
+        Ok(filtered_stream(rx, move |msg| {
+            // Filter messages by asset_id
+            match msg {
+                WsMessage::Book(book) => asset_ids_set.contains(&book.asset_id),
+                WsMessage::PriceChange(price) => price
+                    .price_changes
+                    .iter()
+                    .any(|pc| asset_ids_set.contains(&pc.asset_id)),
+                WsMessage::LastTradePrice(ltp) => asset_ids_set.contains(&ltp.asset_id),
+                WsMessage::TickSizeChange(tsc) => asset_ids_set.contains(&tsc.asset_id),
+                WsMessage::BestBidAsk(bba) => asset_ids_set.contains(&bba.asset_id),
+                WsMessage::NewMarket(nm) => {
+                    nm.asset_ids.iter().any(|id| asset_ids_set.contains(id))
                 }
+                WsMessage::MarketResolved(mr) => {
+                    mr.asset_ids.iter().any(|id| asset_ids_set.contains(id))
+                }
+                _ => false,
             }
-        })
+        }))
     }
 
     /// Subscribe to authenticated user channel.
@@ -390,28 +395,9 @@ impl SubscriptionManager {
         );
 
         // Create stream for user messages
-        let mut rx = self.connection.subscribe();
+        let rx = self.connection.subscribe();
 
-        Ok(try_stream! {
-            loop {
-                match rx.recv().await {
-                    Ok(msg) => {
-                        if msg.is_user() {
-                            yield msg;
-                        }
-                    }
-                    Err(RecvError::Lagged(n)) => {
-                        #[cfg(not(feature = "tracing"))]
-                        let _ = n;
-                        #[cfg(feature = "tracing")]
-                        tracing::warn!("Subscription lagged, missed {n} messages — continuing");
-                    }
-                    Err(RecvError::Closed) => {
-                        break;
-                    }
-                }
-            }
-        })
+        Ok(filtered_stream(rx, WsMessage::is_user))
     }
 
     /// Get information about all active subscriptions.
@@ -561,5 +547,54 @@ impl SubscriptionManager {
         });
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt as _;
+    use serde_json::json;
+    use tokio::sync::broadcast;
+
+    use super::*;
+
+    fn message(timestamp: i64) -> WsMessage {
+        serde_json::from_value(json!({
+            "event_type": "book",
+            "asset_id": "1",
+            "market": format!("0x{:064x}", 1),
+            "timestamp": timestamp.to_string(),
+            "bids": [],
+            "asks": []
+        }))
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn lag_is_reported_without_terminating_subscription() {
+        let (tx, rx) = broadcast::channel(2);
+        tx.send(message(1)).unwrap();
+        tx.send(message(2)).unwrap();
+        tx.send(message(3)).unwrap();
+
+        let mut stream = Box::pin(filtered_stream(rx, |_| true));
+        let error = stream
+            .next()
+            .await
+            .expect("lag must produce a stream item")
+            .expect_err("lag must be visible as an error");
+        assert!(matches!(
+            error.downcast_ref::<WsError>(),
+            Some(WsError::Lagged { count: 1 })
+        ));
+
+        assert!(matches!(
+            stream.next().await.unwrap().unwrap(),
+            WsMessage::Book(book) if book.timestamp == 2
+        ));
+        assert!(matches!(
+            stream.next().await.unwrap().unwrap(),
+            WsMessage::Book(book) if book.timestamp == 3
+        ));
     }
 }

--- a/src/rtds/client.rs
+++ b/src/rtds/client.rs
@@ -156,7 +156,7 @@ impl<S: State> Client<S> {
     /// # Example
     ///
     /// ```no_run
-    /// use polymarket_client_sdk_v2::rtds::Client;
+    /// use polymarket_client_sdk_v2::rtds::{Client, RtdsError};
     /// use polymarket_client_sdk_v2::ws::config::Config;
     /// use futures::StreamExt;
     /// use tokio::pin;
@@ -168,8 +168,17 @@ impl<S: State> Client<S> {
     /// pin!(stream);
     ///
     /// while let Some(price_result) = stream.next().await {
-    ///     let price = price_result?;
-    ///     println!("BTC Price: ${}", price.value);
+    ///     match price_result {
+    ///         Ok(price) => println!("BTC Price: ${}", price.value),
+    ///         Err(error) if matches!(
+    ///             error.downcast_ref::<RtdsError>(),
+    ///             Some(RtdsError::Lagged { .. })
+    ///         ) => {
+    ///             // Reconcile any state that requires lossless delivery, then continue.
+    ///             continue;
+    ///         }
+    ///         Err(error) => return Err(error.into()),
+    ///     }
     /// }
     /// # Ok(())
     /// # }

--- a/src/rtds/error.rs
+++ b/src/rtds/error.rs
@@ -24,6 +24,15 @@ pub enum RtdsError {
     Timeout,
     /// Received an invalid or unexpected message
     InvalidMessage(String),
+    /// Subscription receiver lagged behind the shared RTDS stream.
+    ///
+    /// The skipped messages cannot be recovered from this stream, but the
+    /// subscription remains open and can continue yielding later messages.
+    Lagged {
+        /// Number of shared-channel messages skipped before subscription filtering.
+        /// Some skipped messages may not have matched this subscription.
+        count: u64,
+    },
 }
 
 impl fmt::Display for RtdsError {
@@ -36,6 +45,9 @@ impl fmt::Display for RtdsError {
             Self::ConnectionClosed => write!(f, "RTDS WebSocket connection closed"),
             Self::Timeout => write!(f, "RTDS WebSocket operation timed out"),
             Self::InvalidMessage(msg) => write!(f, "Invalid RTDS message: {msg}"),
+            Self::Lagged { count } => {
+                write!(f, "RTDS subscription lagged, missed {count} messages")
+            }
         }
     }
 }

--- a/src/rtds/subscription.rs
+++ b/src/rtds/subscription.rs
@@ -6,10 +6,10 @@
 use std::sync::{Arc, PoisonError, RwLock};
 use std::time::Instant;
 
-use async_stream::try_stream;
+use async_stream::stream;
 use dashmap::{DashMap, Entry};
 use futures::Stream;
-use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::broadcast::{Receiver, error::RecvError};
 
 use super::error::RtdsError;
 use super::types::request::{Subscription, SubscriptionRequest};
@@ -26,6 +26,33 @@ pub struct SimpleParser;
 impl crate::ws::traits::MessageParser<RtdsMessage> for SimpleParser {
     fn parse(&self, bytes: &[u8]) -> Result<Vec<RtdsMessage>> {
         parse_messages(bytes)
+    }
+}
+
+fn filtered_stream(
+    mut rx: Receiver<RtdsMessage>,
+    target_topic: String,
+    target_type: String,
+) -> impl Stream<Item = Result<RtdsMessage>> {
+    stream! {
+        loop {
+            match rx.recv().await {
+                Ok(msg) => {
+                    let matches_topic = msg.topic == target_topic;
+                    let matches_type = target_type == "*" || msg.msg_type == target_type;
+
+                    if matches_topic && matches_type {
+                        yield Ok(msg);
+                    }
+                }
+                Err(RecvError::Lagged(n)) => {
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!("RTDS subscription lagged, missed {n} messages — continuing");
+                    yield Err(RtdsError::Lagged { count: n }.into());
+                }
+                Err(RecvError::Closed) => break,
+            }
+        }
     }
 }
 
@@ -231,34 +258,11 @@ impl SubscriptionManager {
         );
 
         // Create filtered stream with its own receiver
-        let mut rx = self.connection.subscribe();
+        let rx = self.connection.subscribe();
         let target_topic = topic_type.topic;
         let target_type = topic_type.msg_type;
 
-        Ok(try_stream! {
-            loop {
-                match rx.recv().await {
-                    Ok(msg) => {
-                        // Filter messages by topic and type
-                        let matches_topic = msg.topic == target_topic;
-                        let matches_type = target_type == "*" || msg.msg_type == target_type;
-
-                        if matches_topic && matches_type {
-                            yield msg;
-                        }
-                    }
-                    Err(RecvError::Lagged(n)) => {
-                        #[cfg(not(feature = "tracing"))]
-                        let _ = n;
-                        #[cfg(feature = "tracing")]
-                        tracing::warn!("RTDS subscription lagged, missed {n} messages — continuing");
-                    }
-                    Err(RecvError::Closed) => {
-                        break;
-                    }
-                }
-            }
-        })
+        Ok(filtered_stream(rx, target_topic, target_type))
     }
 
     /// Get information about all active subscriptions.
@@ -323,5 +327,49 @@ impl SubscriptionManager {
             .retain(|_, info| self.subscribed_topics.contains_key(&info.topic_type));
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt as _;
+    use serde_json::json;
+    use tokio::sync::broadcast;
+
+    use super::*;
+
+    fn message(timestamp: i64) -> RtdsMessage {
+        RtdsMessage::builder()
+            .topic("activity".to_owned())
+            .msg_type("trades".to_owned())
+            .timestamp(timestamp)
+            .payload(json!({"sequence": timestamp}))
+            .build()
+    }
+
+    #[tokio::test]
+    async fn lag_is_reported_without_terminating_subscription() {
+        let (tx, rx) = broadcast::channel(2);
+        tx.send(message(1)).unwrap();
+        tx.send(message(2)).unwrap();
+        tx.send(message(3)).unwrap();
+
+        let mut stream = Box::pin(filtered_stream(
+            rx,
+            "activity".to_owned(),
+            "trades".to_owned(),
+        ));
+        let error = stream
+            .next()
+            .await
+            .expect("lag must produce a stream item")
+            .expect_err("lag must be visible as an error");
+        assert!(matches!(
+            error.downcast_ref::<RtdsError>(),
+            Some(RtdsError::Lagged { count: 1 })
+        ));
+
+        assert_eq!(stream.next().await.unwrap().unwrap().timestamp, 2);
+        assert_eq!(stream.next().await.unwrap().unwrap().timestamp, 3);
     }
 }

--- a/src/ws/error.rs
+++ b/src/ws/error.rs
@@ -24,6 +24,15 @@ pub enum WsError {
     Timeout,
     /// Received an invalid or unexpected message
     InvalidMessage(String),
+    /// Subscription receiver lagged behind the shared WebSocket stream.
+    ///
+    /// The skipped messages cannot be recovered from this stream, but the
+    /// subscription remains open and can continue yielding later messages.
+    Lagged {
+        /// Number of shared-channel messages skipped before subscription filtering.
+        /// Some skipped messages may not have matched this subscription.
+        count: u64,
+    },
 }
 
 impl fmt::Display for WsError {
@@ -36,6 +45,9 @@ impl fmt::Display for WsError {
             Self::ConnectionClosed => write!(f, "WebSocket connection closed"),
             Self::Timeout => write!(f, "WebSocket operation timed out"),
             Self::InvalidMessage(msg) => write!(f, "Invalid WebSocket message: {msg}"),
+            Self::Lagged { count } => {
+                write!(f, "Subscription lagged, missed {count} messages")
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- surface `broadcast::RecvError::Lagged(n)` as nonterminal `WsError::Lagged` and `RtdsError::Lagged` stream items
- keep CLOB market, authenticated user, and RTDS subscriptions alive so retained and future messages continue after the gap notification
- keep the derived midpoint stream alive when its order-book source reports lag
- document recovery handling and that `count` measures shared-channel messages skipped before per-subscription filtering
- add deterministic CLOB, RTDS, and midpoint continuation regression tests

## Why

The current high-level streams warn and continue after receiver overflow, but the warning disappears when `tracing` is disabled. Consumers therefore cannot know that order-book deltas, user events, or RTDS events were skipped and cannot resnapshot or reconcile at the right time.

A larger buffer in #31 lowers the frequency but cannot eliminate overflow from a finite queue. The heartbeat reconnect fix in #63 repairs a separate connection-liveness failure and does not expose receiver-local loss.

This change preserves the approved recoverable behavior while making the gap visible. Existing public signatures remain `Stream<Item = Result<...>>`: the consumer receives one `Err` that downcasts to the domain `Lagged` variant, then can continue polling the same stream.

Addresses #86. Complements #31 and #63; it does not supersede either PR.

## Verification

- `cargo test --locked --workspace --all-features`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --doc --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`

All passed locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking WebSocket consumer contract: apps using unconditional `?` on stream items will exit on lag instead of silently missing data; behavior change is intentional but requires explicit handling for trading/real-time state.
> 
> **Overview**
> **Breaking:** When a subscription receiver falls behind the shared broadcast channel, CLOB and RTDS streams now emit a recoverable `Err` (`WsError::Lagged` / `RtdsError::Lagged` with a skip `count`) and **keep polling** instead of only logging under the `tracing` feature. Market, user, and RTDS subscriptions share a `filtered_stream` path that maps `broadcast::RecvError::Lagged` to that error item.
> 
> The derived **midpoint** stream forwards lag the same way so later order-book updates still produce midpoints; other errors still end that stream. Docs and examples show matching on `Lagged`, resnapshotting or reconciling if needed, then continuing—callers that use `item?` on every poll will stop on lag until they handle it.
> 
> Regression tests cover lag-with-continuation for CLOB filters, RTDS filters, and midpoint derivation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13f7c533d35dfb74982e47ebbda0d860fdd91bca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->