### PR TITLE
docs: examples use clob-v2.polymarket.com which does not resolve; production host already serves V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ use polymarket_client_sdk_v2::clob::{Client, Config};
 async fn main() -> anyhow::Result<()> {
     let private_key = std::env::var(PRIVATE_KEY_VAR).expect("Need a private key");
     let signer = LocalSigner::from_str(&private_key)?.with_chain_id(Some(POLYGON));
-    let client = Client::new("https://clob-v2.polymarket.com", Config::default())?
+    let client = Client::new("https://clob.polymarket.com", Config::default())?
         .authentication_builder(&signer)
         .authenticate()
         .await?;
@@ -179,7 +179,7 @@ async fn main() -> anyhow::Result<()> {
 For proxy/Safe wallets, the funder address is **automatically derived** using CREATE2 from your signer's EOA address:
 
 ```rust,ignore
-let client = Client::new("https://clob-v2.polymarket.com", Config::default())?
+let client = Client::new("https://clob.polymarket.com", Config::default())?
     .authentication_builder(&signer)
     .signature_type(SignatureType::GnosisSafe)  // Funder auto-derived via CREATE2
     .authenticate()
@@ -192,7 +192,7 @@ shown on polymarket.com when you log in with a browser wallet.
 If you need to override the derived address (e.g., for advanced use cases), you can explicitly provide it:
 
 ```rust,ignore
-let client = Client::new("https://clob-v2.polymarket.com", Config::default())?
+let client = Client::new("https://clob.polymarket.com", Config::default())?
     .authentication_builder(&signer)
     .funder(address!("<your-polymarket-wallet-address>"))
     .signature_type(SignatureType::GnosisSafe)
@@ -231,7 +231,7 @@ See [`SignatureType`](src/clob/types/mod.rs) for more information.
 For deposit wallets, pass the deployed deposit wallet as the funder and use `SignatureType::Poly1271`:
 
 ```rust,ignore
-let client = Client::new("https://clob-v2.polymarket.com", Config::default())?
+let client = Client::new("https://clob.polymarket.com", Config::default())?
     .authentication_builder(&signer)
     .funder(deposit_wallet)
     .signature_type(SignatureType::Poly1271)
@@ -255,7 +255,7 @@ use polymarket_client_sdk_v2::types::Decimal;
 async fn main() -> anyhow::Result<()> {
     let private_key = std::env::var(PRIVATE_KEY_VAR).expect("Need a private key");
     let signer = LocalSigner::from_str(&private_key)?.with_chain_id(Some(POLYGON));
-    let client = Client::new("https://clob-v2.polymarket.com", Config::default())?
+    let client = Client::new("https://clob.polymarket.com", Config::default())?
         .authentication_builder(&signer)
         .authenticate()
         .await?;
@@ -293,7 +293,7 @@ use rust_decimal_macros::dec;
 async fn main() -> anyhow::Result<()> {
     let private_key = std::env::var(PRIVATE_KEY_VAR).expect("Need a private key");
     let signer = LocalSigner::from_str(&private_key)?.with_chain_id(Some(POLYGON));
-    let client = Client::new("https://clob-v2.polymarket.com", Config::default())?
+    let client = Client::new("https://clob.polymarket.com", Config::default())?
         .authentication_builder(&signer)
         .authenticate()
         .await?;
@@ -322,7 +322,7 @@ the protocol by pointing the client at the corresponding host:
 
 | Protocol | Host                              | Collateral   | EIP-712 domain version |
 |----------|-----------------------------------|--------------|------------------------|
-| V2       | `https://clob-v2.polymarket.com` | pUSD         | `"2"`                  |
+| V2       | `https://clob.polymarket.com` | pUSD         | `"2"`                  |
 | V1       | `https://clob.polymarket.com`     | USDC.e       | `"1"`                  |
 
 V2 orders add `timestamp`, `metadata`, and `builder` fields. V1 orders use `taker`, `nonce`,
@@ -390,7 +390,7 @@ async fn main() -> anyhow::Result<()> {
     let signer = LocalSigner::from_str(&private_key)?.with_chain_id(Some(POLYGON));
 
     let config = Config::builder().builder_code(builder_code).build();
-    let client = Client::new("https://clob-v2.polymarket.com", config)?
+    let client = Client::new("https://clob.polymarket.com", config)?
         .authentication_builder(&signer)
         .authenticate()
         .await?;

--- a/examples/clob/account/get_balance_allowance.rs
+++ b/examples/clob/account/get_balance_allowance.rs
@@ -17,7 +17,7 @@ use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));
 

--- a/examples/clob/account/get_notifications.rs
+++ b/examples/clob/account/get_notifications.rs
@@ -15,7 +15,7 @@ use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));
 

--- a/examples/clob/account/get_open_orders.rs
+++ b/examples/clob/account/get_open_orders.rs
@@ -17,7 +17,7 @@ use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));
 

--- a/examples/clob/account/get_trades.rs
+++ b/examples/clob/account/get_trades.rs
@@ -17,7 +17,7 @@ use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));
 

--- a/examples/clob/account/update_balance_allowance.rs
+++ b/examples/clob/account/update_balance_allowance.rs
@@ -17,7 +17,7 @@ use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));
 

--- a/examples/clob/async.rs
+++ b/examples/clob/async.rs
@@ -53,7 +53,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn unauthenticated() -> anyhow::Result<()> {
-    let client = Client::new("https://clob-v2.polymarket.com", Config::default())?;
+    let client = Client::new("https://clob.polymarket.com", Config::default())?;
     let client_clone = client.clone();
 
     let token_id = U256::from_str(
@@ -115,7 +115,7 @@ async fn authenticated() -> anyhow::Result<()> {
     };
     let signer = LocalSigner::from_str(&private_key)?.with_chain_id(Some(POLYGON));
 
-    let client = Client::new("https://clob-v2.polymarket.com", Config::default())?
+    let client = Client::new("https://clob.polymarket.com", Config::default())?
         .authentication_builder(&signer)
         .authenticate()
         .await?;

--- a/examples/clob/authenticated.rs
+++ b/examples/clob/authenticated.rs
@@ -63,7 +63,7 @@ async fn main() -> anyhow::Result<()> {
     let signer = LocalSigner::from_str(&private_key)?.with_chain_id(Some(POLYGON));
 
     let config = Config::builder().use_server_time(true).build();
-    let client = Client::new("https://clob-v2.polymarket.com", config)?
+    let client = Client::new("https://clob.polymarket.com", config)?
         .authentication_builder(&signer)
         .authenticate()
         .await?;

--- a/examples/clob/aws_authenticated.rs
+++ b/examples/clob/aws_authenticated.rs
@@ -55,7 +55,7 @@ async fn main() -> anyhow::Result<()> {
         .await?
         .with_chain_id(Some(POLYGON));
 
-    let client = Client::new("https://clob-v2.polymarket.com", Config::default())?
+    let client = Client::new("https://clob.polymarket.com", Config::default())?
         .authentication_builder(&alloy_signer)
         .authenticate()
         .await?;

--- a/examples/clob/builder_authenticated.rs
+++ b/examples/clob/builder_authenticated.rs
@@ -32,7 +32,7 @@ async fn main() -> anyhow::Result<()> {
     let signer = LocalSigner::from_str(&private_key)?.with_chain_id(Some(POLYGON));
 
     let config = Config::builder().builder_code(builder_code).build();
-    let client = Client::new("https://clob-v2.polymarket.com", config)?
+    let client = Client::new("https://clob.polymarket.com", config)?
         .authentication_builder(&signer)
         .authenticate()
         .await?;

--- a/examples/clob/heartbeats.rs
+++ b/examples/clob/heartbeats.rs
@@ -23,7 +23,7 @@ async fn main() -> anyhow::Result<()> {
         .use_server_time(true)
         .heartbeat_interval(Duration::from_secs(1))
         .build();
-    let client = Client::new("https://clob-v2.polymarket.com", config)?
+    let client = Client::new("https://clob.polymarket.com", config)?
         .authentication_builder(&signer)
         .authenticate()
         .await?;

--- a/examples/clob/keys/create_or_derive_api_key.rs
+++ b/examples/clob/keys/create_or_derive_api_key.rs
@@ -15,7 +15,7 @@ use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));
 

--- a/examples/clob/keys/delete_api_key.rs
+++ b/examples/clob/keys/delete_api_key.rs
@@ -15,7 +15,7 @@ use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));
 

--- a/examples/clob/keys/get_api_keys.rs
+++ b/examples/clob/keys/get_api_keys.rs
@@ -15,7 +15,7 @@ use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));
 

--- a/examples/clob/market/get_last_trade_price.rs
+++ b/examples/clob/market/get_last_trade_price.rs
@@ -14,7 +14,7 @@ use polymarket_client_sdk_v2::types::U256;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
     let token_id = U256::from_str(&std::env::var("TOKEN_ID")?)?;
 
     let client = Client::new(&host, Config::default())?;

--- a/examples/clob/market/get_midpoint.rs
+++ b/examples/clob/market/get_midpoint.rs
@@ -14,7 +14,7 @@ use polymarket_client_sdk_v2::types::U256;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
     let token_id = U256::from_str(&std::env::var("TOKEN_ID")?)?;
 
     let client = Client::new(&host, Config::default())?;

--- a/examples/clob/market/get_orderbook.rs
+++ b/examples/clob/market/get_orderbook.rs
@@ -14,7 +14,7 @@ use polymarket_client_sdk_v2::types::U256;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
     let token_id = U256::from_str(&std::env::var("TOKEN_ID")?)?;
 
     let client = Client::new(&host, Config::default())?;

--- a/examples/clob/market/get_price.rs
+++ b/examples/clob/market/get_price.rs
@@ -15,7 +15,7 @@ use polymarket_client_sdk_v2::types::U256;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
     let token_id = U256::from_str(&std::env::var("TOKEN_ID")?)?;
 
     let client = Client::new(&host, Config::default())?;

--- a/examples/clob/market/get_server_time.rs
+++ b/examples/clob/market/get_server_time.rs
@@ -10,7 +10,7 @@ use polymarket_client_sdk_v2::clob::{Client, Config};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
 
     let client = Client::new(&host, Config::default())?;
     println!("{}", client.server_time().await?);

--- a/examples/clob/market/get_spread.rs
+++ b/examples/clob/market/get_spread.rs
@@ -14,7 +14,7 @@ use polymarket_client_sdk_v2::types::U256;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
     let token_id = U256::from_str(&std::env::var("TOKEN_ID")?)?;
 
     let client = Client::new(&host, Config::default())?;

--- a/examples/clob/orders/cancel_all.rs
+++ b/examples/clob/orders/cancel_all.rs
@@ -15,7 +15,7 @@ use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));
 

--- a/examples/clob/orders/cancel_order.rs
+++ b/examples/clob/orders/cancel_order.rs
@@ -15,7 +15,7 @@ use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
     let order_id = std::env::var("ORDER_ID")?;
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));

--- a/examples/clob/orders/gtc_limit_buy.rs
+++ b/examples/clob/orders/gtc_limit_buy.rs
@@ -17,7 +17,7 @@ use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
     let token_id = U256::from_str(&std::env::var("TOKEN_ID")?)?;
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));

--- a/examples/clob/orders/gtc_limit_buy_deposit_wallet.rs
+++ b/examples/clob/orders/gtc_limit_buy_deposit_wallet.rs
@@ -17,7 +17,7 @@ use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
     let token_id = U256::from_str(&std::env::var("TOKEN_ID")?)?;
     let deposit_wallet = Address::from_str(&std::env::var("DEPOSIT_WALLET")?)?;
     let price =

--- a/examples/clob/orders/gtc_limit_sell.rs
+++ b/examples/clob/orders/gtc_limit_sell.rs
@@ -17,7 +17,7 @@ use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
     let token_id = U256::from_str(&std::env::var("TOKEN_ID")?)?;
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));

--- a/examples/clob/orders/market_buy.rs
+++ b/examples/clob/orders/market_buy.rs
@@ -17,7 +17,7 @@ use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
     let token_id = U256::from_str(&std::env::var("TOKEN_ID")?)?;
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));

--- a/examples/clob/rfq/quotes.rs
+++ b/examples/clob/rfq/quotes.rs
@@ -51,7 +51,7 @@ async fn main() -> anyhow::Result<()> {
     let private_key = std::env::var(PRIVATE_KEY_VAR).expect("Need POLYMARKET_PRIVATE_KEY");
     let signer = LocalSigner::from_str(&private_key)?.with_chain_id(Some(POLYGON));
 
-    let client = Client::new("https://clob-v2.polymarket.com", Config::default())?
+    let client = Client::new("https://clob.polymarket.com", Config::default())?
         .authentication_builder(&signer)
         .authenticate()
         .await?;

--- a/examples/clob/rfq/requests.rs
+++ b/examples/clob/rfq/requests.rs
@@ -51,7 +51,7 @@ async fn main() -> anyhow::Result<()> {
     let private_key = std::env::var(PRIVATE_KEY_VAR).expect("Need POLYMARKET_PRIVATE_KEY");
     let signer = LocalSigner::from_str(&private_key)?.with_chain_id(Some(POLYGON));
 
-    let client = Client::new("https://clob-v2.polymarket.com", Config::default())?
+    let client = Client::new("https://clob.polymarket.com", Config::default())?
         .authentication_builder(&signer)
         .authenticate()
         .await?;

--- a/examples/clob/scoring/get_closed_only_mode.rs
+++ b/examples/clob/scoring/get_closed_only_mode.rs
@@ -15,7 +15,7 @@ use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));
 

--- a/examples/clob/scoring/is_order_scoring.rs
+++ b/examples/clob/scoring/is_order_scoring.rs
@@ -15,7 +15,7 @@ use polymarket_client_sdk_v2::{POLYGON, PRIVATE_KEY_VAR};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let host =
-        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob-v2.polymarket.com".into());
+        std::env::var("CLOB_API_URL").unwrap_or_else(|_| "https://clob.polymarket.com".into());
     let order_id = std::env::var("ORDER_ID")?;
     let signer =
         LocalSigner::from_str(&std::env::var(PRIVATE_KEY_VAR)?)?.with_chain_id(Some(POLYGON));

--- a/examples/clob/streaming.rs
+++ b/examples/clob/streaming.rs
@@ -56,7 +56,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn unauthenticated() -> anyhow::Result<()> {
-    let client = Client::new("https://clob-v2.polymarket.com", Config::default())?;
+    let client = Client::new("https://clob.polymarket.com", Config::default())?;
 
     info!(
         stream = "sampling_markets",
@@ -114,7 +114,7 @@ async fn authenticated() -> anyhow::Result<()> {
 
     let signer = LocalSigner::from_str(&private_key)?.with_chain_id(Some(POLYGON));
 
-    let client = Client::new("https://clob-v2.polymarket.com", Config::default())?
+    let client = Client::new("https://clob.polymarket.com", Config::default())?
         .authentication_builder(&signer)
         .authenticate()
         .await?;

--- a/examples/clob/unauthenticated.rs
+++ b/examples/clob/unauthenticated.rs
@@ -103,7 +103,7 @@ async fn main() -> anyhow::Result<()> {
         tracing_subscriber::fmt::init();
     }
 
-    let client = Client::new("https://clob-v2.polymarket.com", Config::default())?;
+    let client = Client::new("https://clob.polymarket.com", Config::default())?;
 
     // Health check endpoints
     match client.ok().await {


### PR DESCRIPTION
Every example and the README quickstart point at `https://clob-v2.polymarket.com`, which
has no public DNS record (NXDOMAIN from multiple resolvers/regions). Following the docs
verbatim, the first `authenticate()` fails with a transport error and nothing hints that
the host itself is the problem.

Production `https://clob.polymarket.com` answers `GET /version` → `{"version":2}` and the
SDK's protocol auto-detection handles it correctly — the full Poly1271 deposit-wallet flow
(authenticate → build → sign → post_order → cancel_order) verified end-to-end against it.

This PR is a find-replace of the host across README and examples. If `clob-v2` is a
not-yet-public host, happy to convert this into a README note instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only URL updates in docs and examples; no runtime or auth logic changes in the crate sources touched by this PR.
> 
> **Overview**
> Replaces **`https://clob-v2.polymarket.com`** with **`https://clob.polymarket.com`** everywhere the README and CLOB examples construct a `Client` or set the `CLOB_API_URL` fallback, so copy-paste and default example runs hit a resolvable production endpoint instead of NXDOMAIN.
> 
> The README **V1/V2 protocol** table now lists the production URL for the V2 row (same host string as the V1 row in that table). No SDK library code is changed in this diff—only documentation and `examples/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 532ca3b576a9a404f0ce6c044ebe2d2e67c5590d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->