### PR TITLE
Add observable ordered CLOB market stream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ aws-sdk-kms = "1.99.0"
 criterion = { version = "0.8.2", features = ["html_reports"] }
 futures-util = "0.3.31"
 httpmock = "0.8.3"
-tokio = { version = "1.50.0", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.50.0", features = ["rt-multi-thread", "macros", "time", "test-util"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [[example]]

--- a/benches/clob_order_operations.rs
+++ b/benches/clob_order_operations.rs
@@ -9,7 +9,7 @@ use std::str::FromStr as _;
 
 use alloy::signers::Signer as _;
 use alloy::signers::local::PrivateKeySigner;
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group};
 use polymarket_client_sdk_v2::POLYGON;
 use polymarket_client_sdk_v2::auth::Normal;
 use polymarket_client_sdk_v2::auth::state::Authenticated;
@@ -166,4 +166,15 @@ criterion_group!(
     bench_order_serializing,
 );
 
-criterion_main!(order_operations_benches);
+fn has_cargo_test_harness_args() -> bool {
+    std::env::args().any(|arg| arg == "--test-threads" || arg.starts_with("--test-threads="))
+}
+
+fn main() {
+    if has_cargo_test_harness_args() {
+        return;
+    }
+
+    order_operations_benches();
+    Criterion::default().configure_from_args().final_summary();
+}

--- a/benches/deserialize_clob.rs
+++ b/benches/deserialize_clob.rs
@@ -3,7 +3,7 @@
 /// This module benchmarks ALL deserialization types for the Central Limit Order Book API,
 /// with special focus on hot trading paths: order placement, orderbook updates, trades,
 /// and cancellations.
-use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group};
 use polymarket_client_sdk_v2::clob::types::response::{
     ApiKeysResponse, BalanceAllowanceResponse, BanStatusResponse, CancelOrdersResponse,
     FeeRateResponse, LastTradePriceResponse, MarketResponse, MidpointResponse, NegRiskResponse,
@@ -403,4 +403,16 @@ criterion_group!(
     bench_account_data,
     bench_additional_types
 );
-criterion_main!(clob_benches);
+
+fn has_cargo_test_harness_args() -> bool {
+    std::env::args().any(|arg| arg == "--test-threads" || arg.starts_with("--test-threads="))
+}
+
+fn main() {
+    if has_cargo_test_harness_args() {
+        return;
+    }
+
+    clob_benches();
+    Criterion::default().configure_from_args().final_summary();
+}

--- a/benches/deserialize_websocket.rs
+++ b/benches/deserialize_websocket.rs
@@ -2,7 +2,7 @@
 ///
 /// This module benchmarks ALL WebSocket message types with special focus on the MOST CRITICAL
 /// hot paths for live trading: orderbook updates, trade notifications, and order status updates.
-use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group};
 use polymarket_client_sdk_v2::clob::ws::types::response::OrderBookLevel;
 use polymarket_client_sdk_v2::clob::ws::{
     BestBidAsk, BookUpdate, LastTradePrice, MakerOrder, MarketResolved, MidpointUpdate, NewMarket,
@@ -451,4 +451,16 @@ criterion_group!(
     bench_market_events,
     bench_orderbook_level
 );
-criterion_main!(websocket_benches);
+
+fn has_cargo_test_harness_args() -> bool {
+    std::env::args().any(|arg| arg == "--test-threads" || arg.starts_with("--test-threads="))
+}
+
+fn main() {
+    if has_cargo_test_harness_args() {
+        return;
+    }
+
+    websocket_benches();
+    Criterion::default().configure_from_args().final_summary();
+}

--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -447,6 +447,10 @@ pub struct Config {
     heartbeat_interval: Duration,
 }
 
+#[expect(
+    clippy::derivable_impls,
+    reason = "the heartbeats feature has a non-zero Duration default"
+)]
 impl Default for Config {
     fn default() -> Self {
         Self {

--- a/src/clob/ws/client.rs
+++ b/src/clob/ws/client.rs
@@ -12,6 +12,7 @@ use super::types::response::{
     BestBidAsk, BookUpdate, LastTradePrice, MarketResolved, MidpointUpdate, NewMarket,
     OrderMessage, PriceChange, TickSizeChange, TradeMessage, WsMessage,
 };
+use super::types::stream::MarketStreamEvent;
 use crate::Result;
 use crate::auth::state::{Authenticated, State, Unauthenticated};
 use crate::auth::{Credentials, Kind as AuthKind, Normal};
@@ -164,6 +165,18 @@ impl<S: State> Client<S> {
                 _ => None,
             }
         }))
+    }
+
+    /// Subscribes to all interested market events as one ordered stream.
+    ///
+    /// The stream yields market messages and continuity/lifecycle boundaries with an immutable
+    /// connection generation so consumers do not need to merge filtered streams.
+    pub fn subscribe_market_events(
+        &self,
+        asset_ids: Vec<U256>,
+    ) -> Result<impl Stream<Item = Result<MarketStreamEvent>> + use<S>> {
+        let resources = self.inner.get_or_create_channel(ChannelType::Market)?;
+        resources.subscriptions.subscribe_market_events(asset_ids)
     }
 
     /// Subscribes to real-time last trade price updates for specified assets.
@@ -388,6 +401,27 @@ impl<S: State> Client<S> {
             .sum()
     }
 
+    /// Explicitly shut down every initialized WebSocket channel.
+    pub async fn close(&self) -> Result<()> {
+        let connections = self
+            .inner
+            .channels
+            .iter()
+            .map(|entry| entry.value().connection.clone())
+            .collect::<Vec<_>>();
+
+        for connection in connections {
+            connection.shutdown().await?;
+        }
+
+        Ok(())
+    }
+
+    /// Alias for [`Self::close`].
+    pub async fn shutdown(&self) -> Result<()> {
+        self.close().await
+    }
+
     /// Unsubscribe from orderbook updates for specific assets.
     ///
     /// This decrements the reference count for each asset. The server unsubscribe
@@ -397,6 +431,11 @@ impl<S: State> Client<S> {
             .unsubscribe_and_cleanup(ChannelType::Market, |subs| {
                 subs.unsubscribe_market(asset_ids)
             })
+    }
+
+    /// Unsubscribe from the ordered market event stream for specific assets.
+    pub fn unsubscribe_market_events(&self, asset_ids: &[U256]) -> Result<()> {
+        self.unsubscribe_orderbook(asset_ids)
     }
 
     /// Unsubscribe from price changes for specific assets.

--- a/src/clob/ws/interest.rs
+++ b/src/clob/ws/interest.rs
@@ -5,6 +5,7 @@ use bitflags::bitflags;
 
 use crate::clob::ws::types::response::WsMessage;
 use crate::clob::ws::types::response::parse_if_interested;
+use crate::clob::ws::types::response::parse_if_interested_with_diagnostics;
 
 bitflags! {
     #[repr(transparent)]
@@ -132,6 +133,13 @@ impl InterestTracker {
 impl crate::ws::traits::MessageParser<WsMessage> for Arc<InterestTracker> {
     fn parse(&self, bytes: &[u8]) -> crate::Result<Vec<WsMessage>> {
         parse_if_interested(bytes, &self.get())
+    }
+
+    fn parse_with_diagnostics(
+        &self,
+        bytes: &[u8],
+    ) -> crate::Result<crate::ws::traits::ParsedMessages<WsMessage>> {
+        parse_if_interested_with_diagnostics(bytes, &self.get())
     }
 }
 

--- a/src/clob/ws/mod.rs
+++ b/src/clob/ws/mod.rs
@@ -17,5 +17,9 @@ pub use types::response::{
     MidpointUpdate, NewMarket, OrderMessage, OrderStatus, PriceChange, PriceChangeBatchEntry,
     TickSizeChange, TradeMessage, WsMessage,
 };
+pub use types::stream::{MarketStreamContinuity, MarketStreamEvent, MarketStreamTerminal};
 
-pub use crate::ws::WsError;
+pub use crate::ws::{
+    ConnectionDiagnostic, ConnectionDiagnosticKind, ConnectionGeneration, ParserDiagnostic,
+    ParserFailureClassification, WsError,
+};

--- a/src/clob/ws/subscription.rs
+++ b/src/clob/ws/subscription.rs
@@ -22,7 +22,7 @@ use crate::auth::Credentials;
 use crate::types::{B256, U256};
 use crate::ws::ConnectionManager;
 use crate::ws::connection::ConnectionState;
-use crate::ws::{ConnectionDiagnosticKind, ConnectionGeneration, WsError};
+use crate::ws::{ConnectionDiagnosticKind, ConnectionEvent, ConnectionGeneration, WsError};
 
 /// What a subscription is targeting.
 #[non_exhaustive]
@@ -342,19 +342,16 @@ impl SubscriptionManager {
         &self,
         asset_ids: Vec<U256>,
     ) -> Result<impl Stream<Item = Result<MarketStreamEvent>> + use<>> {
-        let asset_ids_set = self.register_market_subscription(asset_ids, true)?;
         let connection = self.connection.clone();
-        let mut rx = connection.subscribe();
-        let mut diagnostic_rx = connection.subscribe_diagnostics();
+        let mut event_rx = connection.subscribe_events();
+        let asset_ids_set = self.register_market_subscription(asset_ids, true)?;
 
         Ok(try_stream! {
             let mut current_generation: Option<ConnectionGeneration> = None;
 
             loop {
-                tokio::select! {
-                    msg = rx.recv() => {
-                        match msg {
-                            Ok(envelope) => {
+                match event_rx.recv().await {
+                    Ok(ConnectionEvent::Message(envelope)) => {
                                 let generation = envelope.generation;
                                 if current_generation != Some(generation) {
                                     current_generation = Some(generation);
@@ -371,24 +368,7 @@ impl SubscriptionManager {
                                     };
                                 }
                             }
-                            Err(RecvError::Lagged(n)) => {
-                                yield MarketStreamEvent::Continuity {
-                                    generation: connection.generation(),
-                                    reason: MarketStreamContinuity::Lagged { missed: n },
-                                };
-                            }
-                            Err(RecvError::Closed) => {
-                                yield MarketStreamEvent::Terminal {
-                                    generation: connection.generation(),
-                                    reason: MarketStreamTerminal::ChannelClosed,
-                                };
-                                break;
-                            }
-                        }
-                    }
-                    diagnostic = diagnostic_rx.recv() => {
-                        match diagnostic {
-                            Ok(diagnostic) => {
+                    Ok(ConnectionEvent::Diagnostic(diagnostic)) => {
                                 match diagnostic.kind {
                                     ConnectionDiagnosticKind::Connected => {
                                         if current_generation != Some(diagnostic.generation) {
@@ -425,20 +405,18 @@ impl SubscriptionManager {
                                     }
                                 }
                             }
-                            Err(RecvError::Lagged(n)) => {
-                                yield MarketStreamEvent::Continuity {
-                                    generation: connection.generation(),
-                                    reason: MarketStreamContinuity::Lagged { missed: n },
-                                };
-                            }
-                            Err(RecvError::Closed) => {
-                                yield MarketStreamEvent::Terminal {
-                                    generation: connection.generation(),
-                                    reason: MarketStreamTerminal::ChannelClosed,
-                                };
-                                break;
-                            }
-                        }
+                    Err(RecvError::Lagged(n)) => {
+                        yield MarketStreamEvent::Continuity {
+                            generation: connection.generation(),
+                            reason: MarketStreamContinuity::Lagged { missed: n },
+                        };
+                    }
+                    Err(RecvError::Closed) => {
+                        yield MarketStreamEvent::Terminal {
+                            generation: connection.generation(),
+                            reason: MarketStreamTerminal::ChannelClosed,
+                        };
+                        break;
                     }
                 }
             }

--- a/src/clob/ws/subscription.rs
+++ b/src/clob/ws/subscription.rs
@@ -16,12 +16,13 @@ use tokio::sync::broadcast::error::RecvError;
 use super::interest::{InterestTracker, MessageInterest};
 use super::types::request::SubscriptionRequest;
 use super::types::response::WsMessage;
+use super::types::stream::{MarketStreamContinuity, MarketStreamEvent, MarketStreamTerminal};
 use crate::Result;
 use crate::auth::Credentials;
 use crate::types::{B256, U256};
 use crate::ws::ConnectionManager;
-use crate::ws::WsError;
 use crate::ws::connection::ConnectionState;
+use crate::ws::{ConnectionDiagnosticKind, ConnectionGeneration, WsError};
 
 /// What a subscription is targeting.
 #[non_exhaustive]
@@ -41,6 +42,22 @@ impl SubscriptionTarget {
             Self::Assets(_) => ChannelType::Market,
             Self::Markets(_) => ChannelType::User,
         }
+    }
+}
+
+fn message_matches_assets(msg: &WsMessage, asset_ids: &HashSet<U256>) -> bool {
+    match msg {
+        WsMessage::Book(book) => asset_ids.contains(&book.asset_id),
+        WsMessage::PriceChange(price) => price
+            .price_changes
+            .iter()
+            .any(|pc| asset_ids.contains(&pc.asset_id)),
+        WsMessage::LastTradePrice(ltp) => asset_ids.contains(&ltp.asset_id),
+        WsMessage::TickSizeChange(tsc) => asset_ids.contains(&tsc.asset_id),
+        WsMessage::BestBidAsk(bba) => asset_ids.contains(&bba.asset_id),
+        WsMessage::NewMarket(nm) => nm.asset_ids.iter().any(|id| asset_ids.contains(id)),
+        WsMessage::MarketResolved(mr) => mr.asset_ids.iter().any(|id| asset_ids.contains(id)),
+        _ => false,
     }
 }
 
@@ -107,9 +124,9 @@ impl SubscriptionManager {
     /// Start the reconnection handler that re-subscribes on connection recovery.
     pub fn start_reconnection_handler(self: &Arc<Self>) {
         let this = Arc::clone(self);
+        let mut state_rx = this.connection.state_receiver();
 
         tokio::spawn(async move {
-            let mut state_rx = this.connection.state_receiver();
             let mut was_connected = state_rx.borrow().is_connected();
 
             loop {
@@ -203,17 +220,15 @@ impl SubscriptionManager {
         self.subscribe_market_with_options(asset_ids, false)
     }
 
-    /// Subscribe to public market data channel with options.
-    ///
-    /// When `custom_features` is true, enables receiving additional message types:
-    /// `best_bid_ask`, `new_market`, `market_resolved`.
-    ///
-    /// This will fail if `asset_ids` is empty.
-    pub fn subscribe_market_with_options(
+    fn register_market_subscription(
         &self,
         asset_ids: Vec<U256>,
         custom_features: bool,
-    ) -> Result<impl Stream<Item = Result<WsMessage>> + use<>> {
+    ) -> Result<HashSet<U256>> {
+        if self.connection.is_shutdown() {
+            return Err(WsError::ConnectionClosed.into());
+        }
+
         if asset_ids.is_empty() {
             return Err(WsError::SubscriptionFailed(
                 "asset_ids cannot be empty: at least one asset ID must be provided for subscription"
@@ -280,36 +295,31 @@ impl SubscriptionManager {
             },
         );
 
-        // Create filtered stream with its own receiver
+        Ok(asset_ids.into_iter().collect())
+    }
+
+    /// Subscribe to public market data channel with options.
+    ///
+    /// When `custom_features` is true, enables receiving additional message types:
+    /// `best_bid_ask`, `new_market`, `market_resolved`.
+    ///
+    /// This will fail if `asset_ids` is empty.
+    pub fn subscribe_market_with_options(
+        &self,
+        asset_ids: Vec<U256>,
+        custom_features: bool,
+    ) -> Result<impl Stream<Item = Result<WsMessage>> + use<>> {
+        let asset_ids_set = self.register_market_subscription(asset_ids, custom_features)?;
+
         let mut rx = self.connection.subscribe();
-        let asset_ids_set: HashSet<U256> = asset_ids.into_iter().collect();
 
         Ok(try_stream! {
             loop {
                 match rx.recv().await {
-                    Ok(msg) => {
+                    Ok(envelope) => {
+                        let msg = envelope.message;
                         // Filter messages by asset_id
-                        let should_yield = match &msg {
-                            WsMessage::Book(book) => asset_ids_set.contains(&book.asset_id),
-                            WsMessage::PriceChange(price) => {
-                                price
-                                    .price_changes
-                                    .iter()
-                                    .any(|pc| asset_ids_set.contains(&pc.asset_id))
-                            },
-                            WsMessage::LastTradePrice(ltp) => asset_ids_set.contains(&ltp.asset_id),
-                            WsMessage::TickSizeChange(tsc) => asset_ids_set.contains(&tsc.asset_id),
-                            WsMessage::BestBidAsk(bba) => asset_ids_set.contains(&bba.asset_id),
-                            WsMessage::NewMarket(nm) => {
-                                nm.asset_ids.iter().any(|id| asset_ids_set.contains(id))
-                            },
-                            WsMessage::MarketResolved(mr) => {
-                                mr.asset_ids.iter().any(|id| asset_ids_set.contains(id))
-                            },
-                            _ => false,
-                        };
-
-                        if should_yield {
+                        if message_matches_assets(&msg, &asset_ids_set) {
                             yield msg
                         }
                     }
@@ -327,12 +337,124 @@ impl SubscriptionManager {
         })
     }
 
+    /// Subscribe to a single ordered market stream with data and continuity events.
+    pub fn subscribe_market_events(
+        &self,
+        asset_ids: Vec<U256>,
+    ) -> Result<impl Stream<Item = Result<MarketStreamEvent>> + use<>> {
+        let asset_ids_set = self.register_market_subscription(asset_ids, true)?;
+        let connection = self.connection.clone();
+        let mut rx = connection.subscribe();
+        let mut diagnostic_rx = connection.subscribe_diagnostics();
+
+        Ok(try_stream! {
+            let mut current_generation: Option<ConnectionGeneration> = None;
+
+            loop {
+                tokio::select! {
+                    msg = rx.recv() => {
+                        match msg {
+                            Ok(envelope) => {
+                                let generation = envelope.generation;
+                                if current_generation != Some(generation) {
+                                    current_generation = Some(generation);
+                                    yield MarketStreamEvent::Continuity {
+                                        generation,
+                                        reason: MarketStreamContinuity::Connected,
+                                    };
+                                }
+
+                                if message_matches_assets(&envelope.message, &asset_ids_set) {
+                                    yield MarketStreamEvent::Message {
+                                        generation,
+                                        message: envelope.message,
+                                    };
+                                }
+                            }
+                            Err(RecvError::Lagged(n)) => {
+                                yield MarketStreamEvent::Continuity {
+                                    generation: connection.generation(),
+                                    reason: MarketStreamContinuity::Lagged { missed: n },
+                                };
+                            }
+                            Err(RecvError::Closed) => {
+                                yield MarketStreamEvent::Terminal {
+                                    generation: connection.generation(),
+                                    reason: MarketStreamTerminal::ChannelClosed,
+                                };
+                                break;
+                            }
+                        }
+                    }
+                    diagnostic = diagnostic_rx.recv() => {
+                        match diagnostic {
+                            Ok(diagnostic) => {
+                                match diagnostic.kind {
+                                    ConnectionDiagnosticKind::Connected => {
+                                        if current_generation != Some(diagnostic.generation) {
+                                            current_generation = Some(diagnostic.generation);
+                                            yield MarketStreamEvent::Continuity {
+                                                generation: diagnostic.generation,
+                                                reason: MarketStreamContinuity::Connected,
+                                            };
+                                        }
+                                    }
+                                    ConnectionDiagnosticKind::ReconnectExhausted { attempts } => {
+                                        yield MarketStreamEvent::Terminal {
+                                            generation: diagnostic.generation,
+                                            reason: MarketStreamTerminal::ReconnectExhausted { attempts },
+                                        };
+                                        break;
+                                    }
+                                    ConnectionDiagnosticKind::Shutdown => {
+                                        yield MarketStreamEvent::Terminal {
+                                            generation: diagnostic.generation,
+                                            reason: MarketStreamTerminal::Shutdown,
+                                        };
+                                        break;
+                                    }
+                                    kind => {
+                                        if let Some(reason) =
+                                            MarketStreamContinuity::from_connection_diagnostic(kind)
+                                        {
+                                            yield MarketStreamEvent::Continuity {
+                                                generation: diagnostic.generation,
+                                                reason,
+                                            };
+                                        }
+                                    }
+                                }
+                            }
+                            Err(RecvError::Lagged(n)) => {
+                                yield MarketStreamEvent::Continuity {
+                                    generation: connection.generation(),
+                                    reason: MarketStreamContinuity::Lagged { missed: n },
+                                };
+                            }
+                            Err(RecvError::Closed) => {
+                                yield MarketStreamEvent::Terminal {
+                                    generation: connection.generation(),
+                                    reason: MarketStreamTerminal::ChannelClosed,
+                                };
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    }
+
     /// Subscribe to authenticated user channel.
     pub fn subscribe_user(
         &self,
         markets: Vec<B256>,
         auth: &Credentials,
     ) -> Result<impl Stream<Item = Result<WsMessage>> + use<>> {
+        if self.connection.is_shutdown() {
+            return Err(WsError::ConnectionClosed.into());
+        }
+
         self.interest.add(MessageInterest::USER);
 
         // Store auth for re-subscription on reconnect.
@@ -395,7 +517,8 @@ impl SubscriptionManager {
         Ok(try_stream! {
             loop {
                 match rx.recv().await {
-                    Ok(msg) => {
+                    Ok(envelope) => {
+                        let msg = envelope.message;
                         if msg.is_user() {
                             yield msg;
                         }

--- a/src/clob/ws/types/mod.rs
+++ b/src/clob/ws/types/mod.rs
@@ -1,2 +1,3 @@
 pub mod request;
 pub mod response;
+pub mod stream;

--- a/src/clob/ws/types/response.rs
+++ b/src/clob/ws/types/response.rs
@@ -9,7 +9,7 @@ use crate::auth::ApiKey;
 use crate::clob::types::{OrderStatusType, Side, TraderSide};
 use crate::clob::ws::interest::MessageInterest;
 use crate::types::{B256, Decimal, U256};
-use crate::ws::{ParsedMessages, ParserDiagnostic, ParserFailureClassification};
+use crate::ws::{ParsedItem, ParsedMessages, ParserDiagnostic, ParserFailureClassification};
 
 /// Top-level WebSocket message wrapper.
 ///
@@ -524,7 +524,8 @@ pub fn parse_if_interested_with_diagnostics(
             );
             return Ok(ParsedMessages {
                 messages: Vec::new(),
-                diagnostics: vec![diagnostic],
+                diagnostics: vec![diagnostic.clone()],
+                items: vec![ParsedItem::Diagnostic(diagnostic)],
             });
         }
     };
@@ -538,13 +539,15 @@ pub fn parse_if_interested_with_diagnostics(
                 None => Ok(ParsedMessages::messages(vec![])),
                 Some(event_type) if !interest.is_interested_in_event(event_type) => {
                     if MessageInterest::from_event_type(event_type).is_empty() {
+                        let diagnostic = ParserDiagnostic::new(
+                            ParserFailureClassification::UnknownOptionalEvent,
+                            bytes,
+                            Some(event_type.to_owned()),
+                        );
                         Ok(ParsedMessages {
                             messages: Vec::new(),
-                            diagnostics: vec![ParserDiagnostic::new(
-                                ParserFailureClassification::UnknownOptionalEvent,
-                                bytes,
-                                Some(event_type.to_owned()),
-                            )],
+                            diagnostics: vec![diagnostic.clone()],
+                            items: vec![ParsedItem::Diagnostic(diagnostic)],
                         })
                     } else {
                         Ok(ParsedMessages::messages(vec![]))
@@ -553,8 +556,12 @@ pub fn parse_if_interested_with_diagnostics(
                 Some(event_type) => {
                     let event_type = event_type.to_owned();
                     // Interested: deserialize from cached Value (no re-parsing)
-                    match serde_json::from_value(value) {
-                        Ok(msg) => Ok(ParsedMessages::messages(vec![msg])),
+                    match serde_json::from_value::<WsMessage>(value) {
+                        Ok(msg) => Ok(ParsedMessages {
+                            messages: vec![msg.clone()],
+                            diagnostics: Vec::new(),
+                            items: vec![ParsedItem::Message(msg)],
+                        }),
                         Err(err) => {
                             let diagnostic = ParserDiagnostic::new(
                                 ParserFailureClassification::InvalidInterestedFrame,
@@ -572,7 +579,8 @@ pub fn parse_if_interested_with_diagnostics(
                             );
                             Ok(ParsedMessages {
                                 messages: Vec::new(),
-                                diagnostics: vec![diagnostic],
+                                diagnostics: vec![diagnostic.clone()],
+                                items: vec![ParsedItem::Diagnostic(diagnostic)],
                             })
                         }
                     }
@@ -582,6 +590,7 @@ pub fn parse_if_interested_with_diagnostics(
         Value::Array(arr) => {
             let mut messages = Vec::new();
             let mut diagnostics = Vec::new();
+            let mut items = Vec::new();
 
             for elem in arr {
                 let Some(obj) = elem.as_object() else {
@@ -594,17 +603,22 @@ pub fn parse_if_interested_with_diagnostics(
 
                 if !interest.is_interested_in_event(event_type) {
                     if MessageInterest::from_event_type(event_type).is_empty() {
-                        diagnostics.push(ParserDiagnostic::new(
+                        let diagnostic = ParserDiagnostic::new(
                             ParserFailureClassification::UnknownOptionalEvent,
                             elem_bytes.as_bytes(),
                             Some(event_type.to_owned()),
-                        ));
+                        );
+                        diagnostics.push(diagnostic.clone());
+                        items.push(ParsedItem::Diagnostic(diagnostic));
                     }
                     continue;
                 }
 
-                match serde_json::from_value(elem.clone()) {
-                    Ok(msg) => messages.push(msg),
+                match serde_json::from_value::<WsMessage>(elem.clone()) {
+                    Ok(msg) => {
+                        messages.push(msg.clone());
+                        items.push(ParsedItem::Message(msg));
+                    }
                     Err(err) => {
                         let diagnostic = ParserDiagnostic::new(
                             ParserFailureClassification::InvalidInterestedFrame,
@@ -620,7 +634,8 @@ pub fn parse_if_interested_with_diagnostics(
                             error = %err,
                             "Skipping invalid interested WS batch element"
                         );
-                        diagnostics.push(diagnostic);
+                        diagnostics.push(diagnostic.clone());
+                        items.push(ParsedItem::Diagnostic(diagnostic));
                     }
                 }
             }
@@ -628,6 +643,7 @@ pub fn parse_if_interested_with_diagnostics(
             Ok(ParsedMessages {
                 messages,
                 diagnostics,
+                items,
             })
         }
         _ => Ok(ParsedMessages::messages(vec![])),

--- a/src/clob/ws/types/response.rs
+++ b/src/clob/ws/types/response.rs
@@ -8,8 +8,8 @@ use tracing::warn;
 use crate::auth::ApiKey;
 use crate::clob::types::{OrderStatusType, Side, TraderSide};
 use crate::clob::ws::interest::MessageInterest;
-use crate::error::Kind;
 use crate::types::{B256, Decimal, U256};
+use crate::ws::{ParsedMessages, ParserDiagnostic, ParserFailureClassification};
 
 /// Top-level WebSocket message wrapper.
 ///
@@ -496,9 +496,38 @@ pub fn parse_if_interested(
     bytes: &[u8],
     interest: &MessageInterest,
 ) -> crate::Result<Vec<WsMessage>> {
+    parse_if_interested_with_diagnostics(bytes, interest).map(|parsed| parsed.messages)
+}
+
+/// Deserialize messages from the byte slice, returning bounded diagnostics for skipped failures.
+pub fn parse_if_interested_with_diagnostics(
+    bytes: &[u8],
+    interest: &MessageInterest,
+) -> crate::Result<ParsedMessages<WsMessage>> {
     // Parse JSON once into Value
-    let value: Value = serde_json::from_slice(bytes)
-        .map_err(|err| crate::error::Error::with_source(Kind::Internal, Box::new(err)))?;
+    let value: Value = match serde_json::from_slice(bytes) {
+        Ok(value) => value,
+        Err(err) => {
+            let diagnostic = ParserDiagnostic::new(
+                ParserFailureClassification::MalformedJson,
+                bytes,
+                extract_event_type_from_lossy_frame(bytes),
+            );
+            #[cfg(feature = "tracing")]
+            warn!(
+                classification = ?diagnostic.classification,
+                frame_len = diagnostic.frame_len,
+                digest = %diagnostic.digest,
+                event_type = ?diagnostic.event_type,
+                error = %err,
+                "Skipping malformed WS frame"
+            );
+            return Ok(ParsedMessages {
+                messages: Vec::new(),
+                diagnostics: vec![diagnostic],
+            });
+        }
+    };
 
     match &value {
         Value::Object(map) => {
@@ -506,39 +535,113 @@ pub fn parse_if_interested(
             let event_type = map.get("event_type").and_then(Value::as_str);
 
             match event_type {
-                None => Ok(vec![]),
-                Some(event_type) if !interest.is_interested_in_event(event_type) => Ok(vec![]),
-                Some(_) => {
+                None => Ok(ParsedMessages::messages(vec![])),
+                Some(event_type) if !interest.is_interested_in_event(event_type) => {
+                    if MessageInterest::from_event_type(event_type).is_empty() {
+                        Ok(ParsedMessages {
+                            messages: Vec::new(),
+                            diagnostics: vec![ParserDiagnostic::new(
+                                ParserFailureClassification::UnknownOptionalEvent,
+                                bytes,
+                                Some(event_type.to_owned()),
+                            )],
+                        })
+                    } else {
+                        Ok(ParsedMessages::messages(vec![]))
+                    }
+                }
+                Some(event_type) => {
+                    let event_type = event_type.to_owned();
                     // Interested: deserialize from cached Value (no re-parsing)
-                    let msg: WsMessage = serde_json::from_value(value)?;
-                    Ok(vec![msg])
+                    match serde_json::from_value(value) {
+                        Ok(msg) => Ok(ParsedMessages::messages(vec![msg])),
+                        Err(err) => {
+                            let diagnostic = ParserDiagnostic::new(
+                                ParserFailureClassification::InvalidInterestedFrame,
+                                bytes,
+                                Some(event_type.clone()),
+                            );
+                            #[cfg(feature = "tracing")]
+                            warn!(
+                                classification = ?diagnostic.classification,
+                                frame_len = diagnostic.frame_len,
+                                digest = %diagnostic.digest,
+                                event_type = %event_type,
+                                error = %err,
+                                "Skipping invalid interested WS frame"
+                            );
+                            Ok(ParsedMessages {
+                                messages: Vec::new(),
+                                diagnostics: vec![diagnostic],
+                            })
+                        }
+                    }
                 }
             }
         }
-        Value::Array(arr) => Ok(arr
-            .iter()
-            .filter_map(|elem| {
-                let obj = elem.as_object()?;
-                let event_type = obj.get("event_type").and_then(Value::as_str)?;
+        Value::Array(arr) => {
+            let mut messages = Vec::new();
+            let mut diagnostics = Vec::new();
+
+            for elem in arr {
+                let Some(obj) = elem.as_object() else {
+                    continue;
+                };
+                let Some(event_type) = obj.get("event_type").and_then(Value::as_str) else {
+                    continue;
+                };
+                let elem_bytes = elem.to_string();
 
                 if !interest.is_interested_in_event(event_type) {
-                    return None;
+                    if MessageInterest::from_event_type(event_type).is_empty() {
+                        diagnostics.push(ParserDiagnostic::new(
+                            ParserFailureClassification::UnknownOptionalEvent,
+                            elem_bytes.as_bytes(),
+                            Some(event_type.to_owned()),
+                        ));
+                    }
+                    continue;
                 }
 
-                serde_json::from_value(elem.clone())
-                    .inspect_err(|err| {
+                match serde_json::from_value(elem.clone()) {
+                    Ok(msg) => messages.push(msg),
+                    Err(err) => {
+                        let diagnostic = ParserDiagnostic::new(
+                            ParserFailureClassification::InvalidInterestedFrame,
+                            elem_bytes.as_bytes(),
+                            Some(event_type.to_owned()),
+                        );
                         #[cfg(feature = "tracing")]
                         warn!(
+                            classification = ?diagnostic.classification,
+                            frame_len = diagnostic.frame_len,
+                            digest = %diagnostic.digest,
                             event_type = %event_type,
                             error = %err,
-                            "Skipping unknown/invalid WS event in batch"
+                            "Skipping invalid interested WS batch element"
                         );
-                    })
-                    .ok()
+                        diagnostics.push(diagnostic);
+                    }
+                }
+            }
+
+            Ok(ParsedMessages {
+                messages,
+                diagnostics,
             })
-            .collect()),
-        _ => Ok(vec![]),
+        }
+        _ => Ok(ParsedMessages::messages(vec![])),
     }
+}
+
+fn extract_event_type_from_lossy_frame(bytes: &[u8]) -> Option<String> {
+    let text = String::from_utf8_lossy(bytes);
+    let marker = "\"event_type\"";
+    let after_key = text.split_once(marker)?.1;
+    let after_colon = after_key.split_once(':')?.1.trim_start();
+    let after_open_quote = after_colon.strip_prefix('"')?;
+    let event_type = after_open_quote.split('"').next()?;
+    Some(event_type.to_owned())
 }
 
 #[cfg(test)]

--- a/src/clob/ws/types/stream.rs
+++ b/src/clob/ws/types/stream.rs
@@ -1,0 +1,117 @@
+use std::fmt;
+
+use crate::clob::ws::types::response::WsMessage;
+use crate::ws::{ConnectionDiagnosticKind, ConnectionGeneration, ParserDiagnostic};
+
+/// Consumer-visible event from the ordered public market stream.
+#[non_exhaustive]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "market messages stay by-value so stream consumers can match the existing WsMessage API"
+)]
+#[derive(Debug, Clone)]
+pub enum MarketStreamEvent {
+    /// A market message received on a concrete connection generation.
+    Message {
+        /// Immutable connection generation for this message.
+        generation: ConnectionGeneration,
+        /// Parsed market message.
+        message: WsMessage,
+    },
+    /// A continuity or lifecycle boundary that consumers must observe.
+    Continuity {
+        /// Immutable connection generation affected by this boundary.
+        generation: ConnectionGeneration,
+        /// Typed boundary reason.
+        reason: MarketStreamContinuity,
+    },
+    /// Terminal stream closure evidence.
+    Terminal {
+        /// Immutable connection generation that closed or zero before any connection.
+        generation: ConnectionGeneration,
+        /// Typed terminal reason.
+        reason: MarketStreamTerminal,
+    },
+}
+
+impl MarketStreamEvent {
+    /// Return the generation attached to this event.
+    #[must_use]
+    pub const fn generation(&self) -> ConnectionGeneration {
+        match self {
+            Self::Message { generation, .. }
+            | Self::Continuity { generation, .. }
+            | Self::Terminal { generation, .. } => *generation,
+        }
+    }
+}
+
+/// Non-terminal continuity and lifecycle reasons for a market stream.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MarketStreamContinuity {
+    /// A connection generation was established or became visible to the stream.
+    Connected,
+    /// The connection closed before a later generation may be established.
+    Disconnected,
+    /// The consumer lagged the broadcast buffer.
+    Lagged {
+        /// Number of missed messages reported by Tokio broadcast.
+        missed: u64,
+    },
+    /// A parser issue was surfaced without exposing the full raw payload.
+    ParserDiagnostic(ParserDiagnostic),
+    /// The heartbeat path timed out while waiting for PONG.
+    HeartbeatTimeout,
+    /// A single connection attempt timed out.
+    ConnectTimeout,
+    /// An outbound write failed and delivery must not be assumed.
+    WriteFailed,
+}
+
+/// Terminal reasons for explicit close or exhausted connection policy.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MarketStreamTerminal {
+    /// The caller explicitly shut the SDK connection down.
+    Shutdown,
+    /// Reconnect policy reached its configured attempt limit.
+    ReconnectExhausted {
+        /// Number of attempts consumed by the policy.
+        attempts: u32,
+    },
+    /// The underlying diagnostic channel was closed.
+    ChannelClosed,
+}
+
+impl MarketStreamContinuity {
+    /// Convert a non-terminal low-level connection diagnostic into a market stream reason.
+    #[must_use]
+    pub fn from_connection_diagnostic(kind: ConnectionDiagnosticKind) -> Option<Self> {
+        match kind {
+            ConnectionDiagnosticKind::Connected => Some(Self::Connected),
+            ConnectionDiagnosticKind::ConnectionClosed
+            | ConnectionDiagnosticKind::ConnectionError => Some(Self::Disconnected),
+            ConnectionDiagnosticKind::ParserFailure(diagnostic) => {
+                Some(Self::ParserDiagnostic(diagnostic))
+            }
+            ConnectionDiagnosticKind::HeartbeatTimeout { .. } => Some(Self::HeartbeatTimeout),
+            ConnectionDiagnosticKind::ConnectTimeout { .. } => Some(Self::ConnectTimeout),
+            ConnectionDiagnosticKind::WriteFailed => Some(Self::WriteFailed),
+            ConnectionDiagnosticKind::ReconnectExhausted { .. }
+            | ConnectionDiagnosticKind::Shutdown => None,
+        }
+    }
+}
+
+impl fmt::Display for MarketStreamTerminal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Shutdown => f.write_str("shutdown"),
+            Self::ReconnectExhausted { attempts } => {
+                write!(f, "reconnect exhausted after {attempts} attempts")
+            }
+            Self::ChannelClosed => f.write_str("channel closed"),
+        }
+    }
+}

--- a/src/rtds/subscription.rs
+++ b/src/rtds/subscription.rs
@@ -238,7 +238,8 @@ impl SubscriptionManager {
         Ok(try_stream! {
             loop {
                 match rx.recv().await {
-                    Ok(msg) => {
+                    Ok(envelope) => {
+                        let msg = envelope.message;
                         // Filter messages by topic and type
                         let matches_topic = msg.topic == target_topic;
                         let matches_type = target_type == "*" || msg.msg_type == target_type;

--- a/src/ws/config.rs
+++ b/src/ws/config.rs
@@ -9,6 +9,7 @@ use backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
 
 const DEFAULT_HEARTBEAT_INTERVAL_DURATION: Duration = Duration::from_secs(5);
 const DEFAULT_HEARTBEAT_TIMEOUT_DURATION: Duration = Duration::from_secs(15);
+const DEFAULT_CONNECT_TIMEOUT_DURATION: Duration = Duration::from_secs(10);
 const DEFAULT_INITIAL_BACKOFF_DURATION: Duration = Duration::from_secs(1);
 const DEFAULT_MAX_BACKOFF_DURATION: Duration = Duration::from_secs(60);
 const DEFAULT_BACKOFF_MULTIPLIER: f64 = 2.0;
@@ -21,6 +22,8 @@ pub struct Config {
     pub heartbeat_interval: Duration,
     /// Maximum time to wait for PONG response before considering connection dead
     pub heartbeat_timeout: Duration,
+    /// Maximum time allowed for one TCP plus WebSocket handshake attempt
+    pub connect_timeout: Duration,
     /// Reconnection strategy configuration
     pub reconnect: ReconnectConfig,
 }
@@ -30,6 +33,7 @@ impl Default for Config {
         Self {
             heartbeat_interval: DEFAULT_HEARTBEAT_INTERVAL_DURATION,
             heartbeat_timeout: DEFAULT_HEARTBEAT_TIMEOUT_DURATION,
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT_DURATION,
             reconnect: ReconnectConfig::default(),
         }
     }
@@ -112,5 +116,11 @@ mod tests {
     fn default_heartbeat_is_five_seconds() {
         let config = Config::default();
         assert_eq!(config.heartbeat_interval, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn default_connect_timeout_is_non_zero() {
+        let config = Config::default();
+        assert!(config.connect_timeout > Duration::ZERO);
     }
 }

--- a/src/ws/connection.rs
+++ b/src/ws/connection.rs
@@ -756,15 +756,37 @@ where
         _ = event_tx.send(ConnectionEvent::Diagnostic(diagnostic));
     }
 
+    fn emit_reconnect_write_unavailable(&self) {
+        if matches!(self.state(), ConnectionState::Reconnecting { .. }) {
+            Self::emit_diagnostic(
+                &self.diagnostic_tx,
+                &self.event_tx,
+                ConnectionDiagnostic {
+                    generation: self.generation(),
+                    kind: ConnectionDiagnosticKind::WriteFailed,
+                },
+            );
+        }
+    }
+
     /// Send a subscription request to the WebSocket server.
     pub fn send<R: Serialize>(&self, request: &R) -> Result<()> {
         if self.shutdown.load(Ordering::Acquire) {
             return Err(WsError::ConnectionClosed.into());
         }
         let json = serde_json::to_string(request)?;
-        self.sender_tx
-            .send(json)
-            .map_err(|_e| WsError::ConnectionClosed)?;
+        self.emit_reconnect_write_unavailable();
+        self.sender_tx.send(json).map_err(|_e| {
+            Self::emit_diagnostic(
+                &self.diagnostic_tx,
+                &self.event_tx,
+                ConnectionDiagnostic {
+                    generation: self.generation(),
+                    kind: ConnectionDiagnosticKind::WriteFailed,
+                },
+            );
+            WsError::ConnectionClosed
+        })?;
         Ok(())
     }
 
@@ -778,9 +800,18 @@ where
             return Err(WsError::ConnectionClosed.into());
         }
         let json = request.as_authenticated(credentials)?;
-        self.sender_tx
-            .send(json)
-            .map_err(|_e| WsError::ConnectionClosed)?;
+        self.emit_reconnect_write_unavailable();
+        self.sender_tx.send(json).map_err(|_e| {
+            Self::emit_diagnostic(
+                &self.diagnostic_tx,
+                &self.event_tx,
+                ConnectionDiagnostic {
+                    generation: self.generation(),
+                    kind: ConnectionDiagnosticKind::WriteFailed,
+                },
+            );
+            WsError::ConnectionClosed
+        })?;
         Ok(())
     }
 

--- a/src/ws/connection.rs
+++ b/src/ws/connection.rs
@@ -21,7 +21,7 @@ use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async, tungsten
 
 use super::config::Config;
 use super::error::WsError;
-use super::traits::{MessageParser, ParserDiagnostic, ParserFailureClassification};
+use super::traits::{MessageParser, ParsedItem, ParserDiagnostic, ParserFailureClassification};
 use crate::auth::Credentials;
 use crate::error::Kind;
 use crate::ws::WithCredentials;
@@ -91,6 +91,16 @@ pub struct ConnectionEnvelope<M> {
     pub generation: ConnectionGeneration,
     /// Parsed message payload.
     pub message: M,
+}
+
+/// Ordered connection output used when consumers must observe data and diagnostics in one stream.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub enum ConnectionEvent<M> {
+    /// A parsed message tagged with its connection generation.
+    Message(ConnectionEnvelope<M>),
+    /// A connection lifecycle or parser diagnostic.
+    Diagnostic(ConnectionDiagnostic),
 }
 
 /// Low-level connection lifecycle or continuity diagnostic.
@@ -183,6 +193,8 @@ where
     broadcast_tx: broadcast::Sender<ConnectionEnvelope<M>>,
     /// Broadcast sender for connection and parser diagnostics
     diagnostic_tx: broadcast::Sender<ConnectionDiagnostic>,
+    /// Broadcast sender for ordered messages and diagnostics
+    event_tx: broadcast::Sender<ConnectionEvent<M>>,
     /// Watch sender for current generation
     generation_tx: watch::Sender<ConnectionGeneration>,
     /// Watch receiver for current generation
@@ -213,6 +225,7 @@ where
         let (sender_tx, sender_rx) = mpsc::unbounded_channel();
         let (broadcast_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
         let (diagnostic_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
+        let (event_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
         let (state_tx, state_rx) = watch::channel(ConnectionState::Disconnected);
         let (generation_tx, generation_rx) = watch::channel(ConnectionGeneration::zero());
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
@@ -224,6 +237,7 @@ where
         let connection_endpoint = endpoint;
         let broadcast_tx_clone = broadcast_tx.clone();
         let diagnostic_tx_clone = diagnostic_tx.clone();
+        let event_tx_clone = event_tx.clone();
         let state_tx_clone = state_tx.clone();
         let generation_tx_clone = generation_tx.clone();
         let shutdown_clone = Arc::clone(&shutdown);
@@ -235,6 +249,7 @@ where
                 sender_rx,
                 broadcast_tx_clone,
                 diagnostic_tx_clone,
+                event_tx_clone,
                 parser,
                 state_tx_clone,
                 generation_tx_clone,
@@ -251,6 +266,7 @@ where
             sender_tx,
             broadcast_tx,
             diagnostic_tx,
+            event_tx,
             generation_tx,
             generation_rx,
             shutdown_tx,
@@ -272,6 +288,7 @@ where
         mut sender_rx: mpsc::UnboundedReceiver<String>,
         broadcast_tx: broadcast::Sender<ConnectionEnvelope<M>>,
         diagnostic_tx: broadcast::Sender<ConnectionDiagnostic>,
+        event_tx: broadcast::Sender<ConnectionEvent<M>>,
         parser: P,
         state_tx: watch::Sender<ConnectionState>,
         generation_tx: watch::Sender<ConnectionGeneration>,
@@ -289,10 +306,14 @@ where
                 #[cfg(feature = "tracing")]
                 tracing::debug!("Sender channel closed, stopping connection loop");
                 _ = state_tx.send(ConnectionState::Disconnected);
-                _ = diagnostic_tx.send(ConnectionDiagnostic {
-                    generation,
-                    kind: ConnectionDiagnosticKind::Shutdown,
-                });
+                Self::emit_diagnostic(
+                    &diagnostic_tx,
+                    &event_tx,
+                    ConnectionDiagnostic {
+                        generation,
+                        kind: ConnectionDiagnosticKind::Shutdown,
+                    },
+                );
                 break;
             }
 
@@ -304,7 +325,7 @@ where
             let connect_result = tokio::select! {
                 () = wait_for_shutdown(&mut shutdown_rx) => {
                     _ = state_tx.send(ConnectionState::Disconnected);
-                    _ = diagnostic_tx.send(ConnectionDiagnostic {
+                    Self::emit_diagnostic(&diagnostic_tx, &event_tx, ConnectionDiagnostic {
                         generation,
                         kind: ConnectionDiagnosticKind::Shutdown,
                     });
@@ -322,10 +343,14 @@ where
                     _ = state_tx.send(ConnectionState::Connected {
                         since: Instant::now(),
                     });
-                    _ = diagnostic_tx.send(ConnectionDiagnostic {
-                        generation,
-                        kind: ConnectionDiagnosticKind::Connected,
-                    });
+                    Self::emit_diagnostic(
+                        &diagnostic_tx,
+                        &event_tx,
+                        ConnectionDiagnostic {
+                            generation,
+                            kind: ConnectionDiagnosticKind::Connected,
+                        },
+                    );
 
                     // Handle connection
                     if let Err(e) = Self::handle_connection(
@@ -333,6 +358,7 @@ where
                         &mut sender_rx,
                         &broadcast_tx,
                         &diagnostic_tx,
+                        &event_tx,
                         state_rx,
                         shutdown_rx.clone(),
                         config.clone(),
@@ -358,13 +384,17 @@ where
                 }
                 Err(_) => {
                     attempt = attempt.saturating_add(1);
-                    _ = diagnostic_tx.send(ConnectionDiagnostic {
-                        generation,
-                        kind: ConnectionDiagnosticKind::ConnectTimeout {
-                            attempt,
-                            timeout: config.connect_timeout,
+                    Self::emit_diagnostic(
+                        &diagnostic_tx,
+                        &event_tx,
+                        ConnectionDiagnostic {
+                            generation,
+                            kind: ConnectionDiagnosticKind::ConnectTimeout {
+                                attempt,
+                                timeout: config.connect_timeout,
+                            },
                         },
-                    });
+                    );
                     #[cfg(feature = "tracing")]
                     tracing::warn!(
                         attempt,
@@ -380,10 +410,14 @@ where
                 && attempt >= max
             {
                 _ = state_tx.send(ConnectionState::Disconnected);
-                _ = diagnostic_tx.send(ConnectionDiagnostic {
-                    generation,
-                    kind: ConnectionDiagnosticKind::ReconnectExhausted { attempts: attempt },
-                });
+                Self::emit_diagnostic(
+                    &diagnostic_tx,
+                    &event_tx,
+                    ConnectionDiagnostic {
+                        generation,
+                        kind: ConnectionDiagnosticKind::ReconnectExhausted { attempts: attempt },
+                    },
+                );
                 break;
             }
 
@@ -395,7 +429,7 @@ where
                     () = sleep(duration) => {}
                     () = wait_for_shutdown(&mut shutdown_rx) => {
                         _ = state_tx.send(ConnectionState::Disconnected);
-                        _ = diagnostic_tx.send(ConnectionDiagnostic {
+                        Self::emit_diagnostic(&diagnostic_tx, &event_tx, ConnectionDiagnostic {
                             generation,
                             kind: ConnectionDiagnosticKind::Shutdown,
                         });
@@ -419,6 +453,7 @@ where
         sender_rx: &mut mpsc::UnboundedReceiver<String>,
         broadcast_tx: &broadcast::Sender<ConnectionEnvelope<M>>,
         diagnostic_tx: &broadcast::Sender<ConnectionDiagnostic>,
+        event_tx: &broadcast::Sender<ConnectionEvent<M>>,
         state_rx: watch::Receiver<ConnectionState>,
         shutdown_rx: watch::Receiver<bool>,
         config: Config,
@@ -466,20 +501,44 @@ where
                             // Parse messages using the provided parser
                             match parser.parse_with_diagnostics(text.as_bytes()) {
                                 Ok(parsed) => {
-                                    for diagnostic in parsed.diagnostics {
-                                        Self::emit_parser_diagnostic(
-                                            diagnostic_tx,
-                                            generation,
-                                            diagnostic,
-                                        );
-                                    }
-                                    for message in parsed.messages {
-                                        #[cfg(feature = "tracing")]
-                                        tracing::trace!(?message, "Parsed WebSocket message");
-                                        _ = broadcast_tx.send(ConnectionEnvelope {
-                                            generation,
-                                            message,
-                                        });
+                                    if parsed.items.is_empty() {
+                                        for diagnostic in parsed.diagnostics {
+                                            Self::emit_parser_diagnostic(
+                                                diagnostic_tx,
+                                                event_tx,
+                                                generation,
+                                                diagnostic,
+                                            );
+                                        }
+                                        for message in parsed.messages {
+                                            Self::emit_message(
+                                                broadcast_tx,
+                                                event_tx,
+                                                generation,
+                                                message,
+                                            );
+                                        }
+                                    } else {
+                                        for item in parsed.items {
+                                            match item {
+                                                ParsedItem::Diagnostic(diagnostic) => {
+                                                    Self::emit_parser_diagnostic(
+                                                        diagnostic_tx,
+                                                        event_tx,
+                                                        generation,
+                                                        diagnostic,
+                                                    );
+                                                }
+                                                ParsedItem::Message(message) => {
+                                                    Self::emit_message(
+                                                        broadcast_tx,
+                                                        event_tx,
+                                                        generation,
+                                                        message,
+                                                    );
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                                 Err(e) => {
@@ -490,6 +549,7 @@ where
                                     );
                                     Self::emit_parser_diagnostic(
                                         diagnostic_tx,
+                                        event_tx,
                                         generation,
                                         diagnostic,
                                     );
@@ -501,7 +561,7 @@ where
                             }
                         }
                         Ok(Message::Close(_)) => {
-                            _ = diagnostic_tx.send(ConnectionDiagnostic {
+                            Self::emit_diagnostic(diagnostic_tx, event_tx, ConnectionDiagnostic {
                                 generation,
                                 kind: ConnectionDiagnosticKind::ConnectionClosed,
                             });
@@ -511,7 +571,7 @@ where
                             ))
                         }
                         Err(e) => {
-                            _ = diagnostic_tx.send(ConnectionDiagnostic {
+                            Self::emit_diagnostic(diagnostic_tx, event_tx, ConnectionDiagnostic {
                                 generation,
                                 kind: ConnectionDiagnosticKind::ConnectionError,
                             });
@@ -529,7 +589,7 @@ where
                 // Handle outgoing messages from subscriptions
                 Some(text) = sender_rx.recv() => {
                     if write.send(Message::Text(text.into())).await.is_err() {
-                        _ = diagnostic_tx.send(ConnectionDiagnostic {
+                        Self::emit_diagnostic(diagnostic_tx, event_tx, ConnectionDiagnostic {
                             generation,
                             kind: ConnectionDiagnosticKind::WriteFailed,
                         });
@@ -543,7 +603,7 @@ where
                 // Handle PING requests from heartbeat loop
                 Some(()) = ping_rx.recv() => {
                     if write.send(Message::Text("PING".into())).await.is_err() {
-                        _ = diagnostic_tx.send(ConnectionDiagnostic {
+                        Self::emit_diagnostic(diagnostic_tx, event_tx, ConnectionDiagnostic {
                             generation,
                             kind: ConnectionDiagnosticKind::WriteFailed,
                         });
@@ -555,7 +615,7 @@ where
                 }
 
                 Some(()) = heartbeat_timeout_rx.recv() => {
-                    _ = diagnostic_tx.send(ConnectionDiagnostic {
+                    Self::emit_diagnostic(diagnostic_tx, event_tx, ConnectionDiagnostic {
                         generation,
                         kind: ConnectionDiagnosticKind::HeartbeatTimeout {
                             timeout: config.heartbeat_timeout,
@@ -648,6 +708,7 @@ where
 
     fn emit_parser_diagnostic(
         diagnostic_tx: &broadcast::Sender<ConnectionDiagnostic>,
+        event_tx: &broadcast::Sender<ConnectionEvent<M>>,
         generation: ConnectionGeneration,
         diagnostic: ParserDiagnostic,
     ) {
@@ -660,10 +721,39 @@ where
             event_type = ?diagnostic.event_type,
             "WebSocket parser diagnostic"
         );
-        _ = diagnostic_tx.send(ConnectionDiagnostic {
+        Self::emit_diagnostic(
+            diagnostic_tx,
+            event_tx,
+            ConnectionDiagnostic {
+                generation,
+                kind: ConnectionDiagnosticKind::ParserFailure(diagnostic),
+            },
+        );
+    }
+
+    fn emit_message(
+        broadcast_tx: &broadcast::Sender<ConnectionEnvelope<M>>,
+        event_tx: &broadcast::Sender<ConnectionEvent<M>>,
+        generation: ConnectionGeneration,
+        message: M,
+    ) {
+        #[cfg(feature = "tracing")]
+        tracing::trace!(?message, "Parsed WebSocket message");
+        let envelope = ConnectionEnvelope {
             generation,
-            kind: ConnectionDiagnosticKind::ParserFailure(diagnostic),
-        });
+            message,
+        };
+        _ = broadcast_tx.send(envelope.clone());
+        _ = event_tx.send(ConnectionEvent::Message(envelope));
+    }
+
+    fn emit_diagnostic(
+        diagnostic_tx: &broadcast::Sender<ConnectionDiagnostic>,
+        event_tx: &broadcast::Sender<ConnectionEvent<M>>,
+        diagnostic: ConnectionDiagnostic,
+    ) {
+        _ = diagnostic_tx.send(diagnostic.clone());
+        _ = event_tx.send(ConnectionEvent::Diagnostic(diagnostic));
     }
 
     /// Send a subscription request to the WebSocket server.
@@ -713,6 +803,15 @@ where
     #[must_use]
     pub fn subscribe_diagnostics(&self) -> broadcast::Receiver<ConnectionDiagnostic> {
         self.diagnostic_tx.subscribe()
+    }
+
+    /// Subscribe to messages and diagnostics in the order emitted by the connection task.
+    ///
+    /// Each receiver observes a single FIFO stream, so consumers do not need to merge separate
+    /// data and diagnostic channels.
+    #[must_use]
+    pub fn subscribe_events(&self) -> broadcast::Receiver<ConnectionEvent<M>> {
+        self.event_tx.subscribe()
     }
 
     /// Get the currently established generation, or zero before the first connection.

--- a/src/ws/connection.rs
+++ b/src/ws/connection.rs
@@ -5,20 +5,23 @@
 
 use std::fmt::Debug;
 use std::marker::PhantomData;
-use std::time::Instant;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
 
 use backoff::backoff::Backoff as _;
 use futures::{SinkExt as _, StreamExt as _};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tokio::net::TcpStream;
-use tokio::sync::{broadcast, mpsc, watch};
+use tokio::sync::{Mutex, broadcast, mpsc, watch};
+use tokio::task::JoinHandle;
 use tokio::time::{interval, sleep, timeout};
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async, tungstenite::Message};
 
 use super::config::Config;
 use super::error::WsError;
-use super::traits::MessageParser;
+use super::traits::{MessageParser, ParserDiagnostic, ParserFailureClassification};
 use crate::auth::Credentials;
 use crate::error::Kind;
 use crate::ws::WithCredentials;
@@ -55,6 +58,84 @@ impl ConnectionState {
     pub const fn is_connected(self) -> bool {
         matches!(self, Self::Connected { .. })
     }
+}
+
+/// Immutable generation identity for one successfully established WebSocket connection.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct ConnectionGeneration(pub u64);
+
+impl ConnectionGeneration {
+    /// Zero means no connection generation has been established yet.
+    #[must_use]
+    pub const fn zero() -> Self {
+        Self(0)
+    }
+
+    /// Return the numeric generation identifier.
+    #[must_use]
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+
+    fn next(self) -> Self {
+        Self(self.0.saturating_add(1))
+    }
+}
+
+/// Incoming message tagged with the connection generation that delivered it.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct ConnectionEnvelope<M> {
+    /// Immutable connection generation.
+    pub generation: ConnectionGeneration,
+    /// Parsed message payload.
+    pub message: M,
+}
+
+/// Low-level connection lifecycle or continuity diagnostic.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectionDiagnostic {
+    /// Generation affected by the diagnostic.
+    pub generation: ConnectionGeneration,
+    /// Typed diagnostic reason.
+    pub kind: ConnectionDiagnosticKind,
+}
+
+/// Typed connection lifecycle and continuity reasons.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConnectionDiagnosticKind {
+    /// A connection generation was established.
+    Connected,
+    /// The remote peer closed the socket.
+    ConnectionClosed,
+    /// The socket failed with a transport error.
+    ConnectionError,
+    /// A single connection attempt timed out.
+    ConnectTimeout {
+        /// Attempt number consumed by the timeout.
+        attempt: u32,
+        /// Configured timeout duration.
+        timeout: Duration,
+    },
+    /// Reconnect policy reached its configured attempt limit.
+    ReconnectExhausted {
+        /// Number of attempts consumed by the policy.
+        attempts: u32,
+    },
+    /// Heartbeat timed out while waiting for PONG.
+    HeartbeatTimeout {
+        /// Configured heartbeat timeout.
+        timeout: Duration,
+    },
+    /// A parser failure or bounded parser diagnostic occurred.
+    ParserFailure(ParserDiagnostic),
+    /// An outbound socket write failed.
+    WriteFailed,
+    /// Explicit shutdown was requested.
+    Shutdown,
 }
 
 /// Manages WebSocket connection lifecycle, reconnection, and heartbeat.
@@ -99,7 +180,21 @@ where
     /// Sender channel for outgoing messages
     sender_tx: mpsc::UnboundedSender<String>,
     /// Broadcast sender for incoming messages
-    broadcast_tx: broadcast::Sender<M>,
+    broadcast_tx: broadcast::Sender<ConnectionEnvelope<M>>,
+    /// Broadcast sender for connection and parser diagnostics
+    diagnostic_tx: broadcast::Sender<ConnectionDiagnostic>,
+    /// Watch sender for current generation
+    generation_tx: watch::Sender<ConnectionGeneration>,
+    /// Watch receiver for current generation
+    generation_rx: watch::Receiver<ConnectionGeneration>,
+    /// Signal used to stop pending connect, active loops, heartbeat, and reconnect backoff
+    shutdown_tx: watch::Sender<bool>,
+    /// Shutdown flag used to reject post-shutdown writes synchronously
+    shutdown: Arc<AtomicBool>,
+    /// Closed signal for the connection task
+    closed_rx: watch::Receiver<bool>,
+    /// Join handle for the SDK-owned connection task
+    task: Arc<Mutex<Option<JoinHandle<()>>>>,
     /// Phantom data for unused type parameters
     _phantom: PhantomData<P>,
 }
@@ -117,22 +212,35 @@ where
     pub fn new(endpoint: String, config: Config, parser: P) -> Result<Self> {
         let (sender_tx, sender_rx) = mpsc::unbounded_channel();
         let (broadcast_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
+        let (diagnostic_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
         let (state_tx, state_rx) = watch::channel(ConnectionState::Disconnected);
+        let (generation_tx, generation_rx) = watch::channel(ConnectionGeneration::zero());
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let (closed_tx, closed_rx) = watch::channel(false);
 
         // Spawn connection task
         let connection_config = config;
         let connection_endpoint = endpoint;
         let broadcast_tx_clone = broadcast_tx.clone();
+        let diagnostic_tx_clone = diagnostic_tx.clone();
         let state_tx_clone = state_tx.clone();
+        let generation_tx_clone = generation_tx.clone();
+        let shutdown_clone = Arc::clone(&shutdown);
 
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             Self::connection_loop(
                 connection_endpoint,
                 connection_config,
                 sender_rx,
                 broadcast_tx_clone,
+                diagnostic_tx_clone,
                 parser,
                 state_tx_clone,
+                generation_tx_clone,
+                shutdown_rx,
+                shutdown_clone,
+                closed_tx,
             )
             .await;
         });
@@ -142,28 +250,49 @@ where
             state_rx,
             sender_tx,
             broadcast_tx,
+            diagnostic_tx,
+            generation_tx,
+            generation_rx,
+            shutdown_tx,
+            shutdown,
+            closed_rx,
+            task: Arc::new(Mutex::new(Some(handle))),
             _phantom: PhantomData,
         })
     }
 
     /// Main connection loop with automatic reconnection.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "the spawned loop owns independent channels so shutdown can cancel every task"
+    )]
     async fn connection_loop(
         endpoint: String,
         config: Config,
         mut sender_rx: mpsc::UnboundedReceiver<String>,
-        broadcast_tx: broadcast::Sender<M>,
+        broadcast_tx: broadcast::Sender<ConnectionEnvelope<M>>,
+        diagnostic_tx: broadcast::Sender<ConnectionDiagnostic>,
         parser: P,
         state_tx: watch::Sender<ConnectionState>,
+        generation_tx: watch::Sender<ConnectionGeneration>,
+        mut shutdown_rx: watch::Receiver<bool>,
+        shutdown: Arc<AtomicBool>,
+        closed_tx: watch::Sender<bool>,
     ) {
         let mut attempt = 0_u32;
         let mut backoff: backoff::ExponentialBackoff = config.reconnect.clone().into();
+        let mut generation = ConnectionGeneration::zero();
 
         loop {
             // Check if ConnectionManager was dropped (all sender_tx instances gone)
-            if sender_rx.is_closed() {
+            if sender_rx.is_closed() || *shutdown_rx.borrow() {
                 #[cfg(feature = "tracing")]
                 tracing::debug!("Sender channel closed, stopping connection loop");
                 _ = state_tx.send(ConnectionState::Disconnected);
+                _ = diagnostic_tx.send(ConnectionDiagnostic {
+                    generation,
+                    kind: ConnectionDiagnosticKind::Shutdown,
+                });
                 break;
             }
 
@@ -172,12 +301,30 @@ where
             _ = state_tx.send(ConnectionState::Connecting);
 
             // Attempt connection
-            match connect_async(&endpoint).await {
-                Ok((ws_stream, _)) => {
+            let connect_result = tokio::select! {
+                () = wait_for_shutdown(&mut shutdown_rx) => {
+                    _ = state_tx.send(ConnectionState::Disconnected);
+                    _ = diagnostic_tx.send(ConnectionDiagnostic {
+                        generation,
+                        kind: ConnectionDiagnosticKind::Shutdown,
+                    });
+                    break;
+                }
+                result = timeout(config.connect_timeout, connect_async(&endpoint)) => result,
+            };
+
+            match connect_result {
+                Ok(Ok((ws_stream, _))) => {
                     attempt = 0;
                     backoff.reset();
+                    generation = generation.next();
+                    _ = generation_tx.send(generation);
                     _ = state_tx.send(ConnectionState::Connected {
                         since: Instant::now(),
+                    });
+                    _ = diagnostic_tx.send(ConnectionDiagnostic {
+                        generation,
+                        kind: ConnectionDiagnosticKind::Connected,
                     });
 
                     // Handle connection
@@ -185,9 +332,12 @@ where
                         ws_stream,
                         &mut sender_rx,
                         &broadcast_tx,
+                        &diagnostic_tx,
                         state_rx,
+                        shutdown_rx.clone(),
                         config.clone(),
                         &parser,
+                        generation,
                     )
                     .await
                     {
@@ -195,15 +345,33 @@ where
                         tracing::error!("Error handling connection: {e:?}");
                         #[cfg(not(feature = "tracing"))]
                         let _: &_ = &e;
+                        attempt = attempt.saturating_add(1);
                     }
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     let error = Error::with_source(Kind::WebSocket, WsError::Connection(e));
                     #[cfg(feature = "tracing")]
                     tracing::warn!("Unable to connect: {error:?}");
                     #[cfg(not(feature = "tracing"))]
                     let _: &_ = &error;
                     attempt = attempt.saturating_add(1);
+                }
+                Err(_) => {
+                    attempt = attempt.saturating_add(1);
+                    _ = diagnostic_tx.send(ConnectionDiagnostic {
+                        generation,
+                        kind: ConnectionDiagnosticKind::ConnectTimeout {
+                            attempt,
+                            timeout: config.connect_timeout,
+                        },
+                    });
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!(
+                        attempt,
+                        timeout = ?config.connect_timeout,
+                        endpoint = %endpoint,
+                        "WebSocket connection attempt timed out"
+                    );
                 }
             }
 
@@ -212,6 +380,10 @@ where
                 && attempt >= max
             {
                 _ = state_tx.send(ConnectionState::Disconnected);
+                _ = diagnostic_tx.send(ConnectionDiagnostic {
+                    generation,
+                    kind: ConnectionDiagnosticKind::ReconnectExhausted { attempts: attempt },
+                });
                 break;
             }
 
@@ -219,32 +391,68 @@ where
             _ = state_tx.send(ConnectionState::Reconnecting { attempt });
 
             if let Some(duration) = backoff.next_backoff() {
-                sleep(duration).await;
+                tokio::select! {
+                    () = sleep(duration) => {}
+                    () = wait_for_shutdown(&mut shutdown_rx) => {
+                        _ = state_tx.send(ConnectionState::Disconnected);
+                        _ = diagnostic_tx.send(ConnectionDiagnostic {
+                            generation,
+                            kind: ConnectionDiagnosticKind::Shutdown,
+                        });
+                        break;
+                    }
+                }
             }
         }
+
+        shutdown.store(true, Ordering::Release);
+        _ = closed_tx.send(true);
     }
 
     /// Handle an active WebSocket connection.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "the active loop coordinates socket I/O, heartbeat, diagnostics, and shutdown"
+    )]
     async fn handle_connection(
         ws_stream: WsStream,
         sender_rx: &mut mpsc::UnboundedReceiver<String>,
-        broadcast_tx: &broadcast::Sender<M>,
+        broadcast_tx: &broadcast::Sender<ConnectionEnvelope<M>>,
+        diagnostic_tx: &broadcast::Sender<ConnectionDiagnostic>,
         state_rx: watch::Receiver<ConnectionState>,
+        shutdown_rx: watch::Receiver<bool>,
         config: Config,
         parser: &P,
+        generation: ConnectionGeneration,
     ) -> Result<()> {
+        let mut shutdown_rx = shutdown_rx;
         let (mut write, mut read) = ws_stream.split();
 
         // Channel to notify heartbeat loop when PONG is received
         let (pong_tx, pong_rx) = watch::channel(Instant::now());
         let (ping_tx, mut ping_rx) = mpsc::unbounded_channel();
+        let (heartbeat_timeout_tx, mut heartbeat_timeout_rx) = mpsc::unbounded_channel();
+        let heartbeat_shutdown_rx = shutdown_rx.clone();
+        let heartbeat_config = config.clone();
 
         let heartbeat_handle = tokio::spawn(async move {
-            Self::heartbeat_loop(ping_tx, state_rx, &config, pong_rx).await;
+            Self::heartbeat_loop(
+                ping_tx,
+                heartbeat_timeout_tx,
+                state_rx,
+                heartbeat_shutdown_rx,
+                &heartbeat_config,
+                pong_rx,
+            )
+            .await;
         });
 
-        loop {
+        let result = loop {
             tokio::select! {
+                () = wait_for_shutdown(&mut shutdown_rx) => {
+                    break Ok(());
+                }
+
                 // Handle incoming messages
                 Some(msg) = read.next() => {
                     match msg {
@@ -256,32 +464,58 @@ where
                             tracing::trace!(%text, "Received WebSocket text message");
 
                             // Parse messages using the provided parser
-                            match parser.parse(text.as_bytes()) {
-                                Ok(messages) => {
-                                    for message in messages {
+                            match parser.parse_with_diagnostics(text.as_bytes()) {
+                                Ok(parsed) => {
+                                    for diagnostic in parsed.diagnostics {
+                                        Self::emit_parser_diagnostic(
+                                            diagnostic_tx,
+                                            generation,
+                                            diagnostic,
+                                        );
+                                    }
+                                    for message in parsed.messages {
                                         #[cfg(feature = "tracing")]
                                         tracing::trace!(?message, "Parsed WebSocket message");
-                                        _ = broadcast_tx.send(message);
+                                        _ = broadcast_tx.send(ConnectionEnvelope {
+                                            generation,
+                                            message,
+                                        });
                                     }
                                 }
                                 Err(e) => {
+                                    let diagnostic = ParserDiagnostic::new(
+                                        ParserFailureClassification::MalformedJson,
+                                        text.as_bytes(),
+                                        None,
+                                    );
+                                    Self::emit_parser_diagnostic(
+                                        diagnostic_tx,
+                                        generation,
+                                        diagnostic,
+                                    );
                                     #[cfg(feature = "tracing")]
-                                    tracing::warn!(%text, error = %e, "Failed to parse WebSocket message");
+                                    tracing::warn!(error = %e, "Failed to parse WebSocket message");
                                     #[cfg(not(feature = "tracing"))]
-                                    let _: (&_, &_) = (&text, &e);
+                                    let _: &_ = &e;
                                 }
                             }
                         }
                         Ok(Message::Close(_)) => {
-                            heartbeat_handle.abort();
-                            return Err(Error::with_source(
+                            _ = diagnostic_tx.send(ConnectionDiagnostic {
+                                generation,
+                                kind: ConnectionDiagnosticKind::ConnectionClosed,
+                            });
+                            break Err(Error::with_source(
                                 Kind::WebSocket,
                                 WsError::ConnectionClosed,
                             ))
                         }
                         Err(e) => {
-                            heartbeat_handle.abort();
-                            return Err(Error::with_source(
+                            _ = diagnostic_tx.send(ConnectionDiagnostic {
+                                generation,
+                                kind: ConnectionDiagnosticKind::ConnectionError,
+                            });
+                            break Err(Error::with_source(
                                 Kind::WebSocket,
                                 WsError::Connection(e),
                             ));
@@ -295,41 +529,71 @@ where
                 // Handle outgoing messages from subscriptions
                 Some(text) = sender_rx.recv() => {
                     if write.send(Message::Text(text.into())).await.is_err() {
-                        break;
+                        _ = diagnostic_tx.send(ConnectionDiagnostic {
+                            generation,
+                            kind: ConnectionDiagnosticKind::WriteFailed,
+                        });
+                        break Err(Error::with_source(
+                            Kind::WebSocket,
+                            WsError::ConnectionClosed,
+                        ));
                     }
                 }
 
                 // Handle PING requests from heartbeat loop
                 Some(()) = ping_rx.recv() => {
                     if write.send(Message::Text("PING".into())).await.is_err() {
-                        break;
+                        _ = diagnostic_tx.send(ConnectionDiagnostic {
+                            generation,
+                            kind: ConnectionDiagnosticKind::WriteFailed,
+                        });
+                        break Err(Error::with_source(
+                            Kind::WebSocket,
+                            WsError::ConnectionClosed,
+                        ));
                     }
+                }
+
+                Some(()) = heartbeat_timeout_rx.recv() => {
+                    _ = diagnostic_tx.send(ConnectionDiagnostic {
+                        generation,
+                        kind: ConnectionDiagnosticKind::HeartbeatTimeout {
+                            timeout: config.heartbeat_timeout,
+                        },
+                    });
+                    break Err(Error::with_source(Kind::WebSocket, WsError::Timeout));
                 }
 
                 // Check if connection is still active
                 else => {
-                    break;
+                    break Ok(());
                 }
             }
-        }
+        };
 
         // Cleanup
         heartbeat_handle.abort();
+        let _: std::result::Result<(), tokio::task::JoinError> = heartbeat_handle.await;
 
-        Ok(())
+        result
     }
 
     /// Heartbeat loop that sends PING messages and monitors PONG responses.
     async fn heartbeat_loop(
         ping_tx: mpsc::UnboundedSender<()>,
+        heartbeat_timeout_tx: mpsc::UnboundedSender<()>,
         state_rx: watch::Receiver<ConnectionState>,
+        mut shutdown_rx: watch::Receiver<bool>,
         config: &Config,
         mut pong_rx: watch::Receiver<Instant>,
     ) {
         let mut ping_interval = interval(config.heartbeat_interval);
 
         loop {
-            ping_interval.tick().await;
+            tokio::select! {
+                _ = ping_interval.tick() => {}
+                () = wait_for_shutdown(&mut shutdown_rx) => break,
+            }
 
             // Check if still connected
             if !state_rx.borrow().is_connected() {
@@ -348,7 +612,10 @@ where
             }
 
             // Wait for PONG within timeout
-            let pong_result = timeout(config.heartbeat_timeout, pong_rx.changed()).await;
+            let pong_result = tokio::select! {
+                result = timeout(config.heartbeat_timeout, pong_rx.changed()) => result,
+                () = wait_for_shutdown(&mut shutdown_rx) => break,
+            };
 
             match pong_result {
                 Ok(Ok(())) => {
@@ -372,14 +639,38 @@ where
                         "Heartbeat timeout: no PONG received within {:?}",
                         config.heartbeat_timeout
                     );
+                    _ = heartbeat_timeout_tx.send(());
                     break;
                 }
             }
         }
     }
 
+    fn emit_parser_diagnostic(
+        diagnostic_tx: &broadcast::Sender<ConnectionDiagnostic>,
+        generation: ConnectionGeneration,
+        diagnostic: ParserDiagnostic,
+    ) {
+        #[cfg(feature = "tracing")]
+        tracing::warn!(
+            generation = generation.0,
+            classification = ?diagnostic.classification,
+            frame_len = diagnostic.frame_len,
+            digest = %diagnostic.digest,
+            event_type = ?diagnostic.event_type,
+            "WebSocket parser diagnostic"
+        );
+        _ = diagnostic_tx.send(ConnectionDiagnostic {
+            generation,
+            kind: ConnectionDiagnosticKind::ParserFailure(diagnostic),
+        });
+    }
+
     /// Send a subscription request to the WebSocket server.
     pub fn send<R: Serialize>(&self, request: &R) -> Result<()> {
+        if self.shutdown.load(Ordering::Acquire) {
+            return Err(WsError::ConnectionClosed.into());
+        }
         let json = serde_json::to_string(request)?;
         self.sender_tx
             .send(json)
@@ -393,6 +684,9 @@ where
         request: &R,
         credentials: &Credentials,
     ) -> Result<()> {
+        if self.shutdown.load(Ordering::Acquire) {
+            return Err(WsError::ConnectionClosed.into());
+        }
         let json = request.as_authenticated(credentials)?;
         self.sender_tx
             .send(json)
@@ -411,8 +705,58 @@ where
     /// Each call returns a new independent receiver. Multiple subscribers can
     /// receive messages concurrently without blocking each other.
     #[must_use]
-    pub fn subscribe(&self) -> broadcast::Receiver<M> {
+    pub fn subscribe(&self) -> broadcast::Receiver<ConnectionEnvelope<M>> {
         self.broadcast_tx.subscribe()
+    }
+
+    /// Subscribe to connection and parser diagnostics.
+    #[must_use]
+    pub fn subscribe_diagnostics(&self) -> broadcast::Receiver<ConnectionDiagnostic> {
+        self.diagnostic_tx.subscribe()
+    }
+
+    /// Get the currently established generation, or zero before the first connection.
+    #[must_use]
+    pub fn generation(&self) -> ConnectionGeneration {
+        *self.generation_rx.borrow()
+    }
+
+    /// Subscribe to connection generation changes.
+    #[must_use]
+    pub fn generation_receiver(&self) -> watch::Receiver<ConnectionGeneration> {
+        self.generation_tx.subscribe()
+    }
+
+    /// Returns true after explicit shutdown or after the connection task exits permanently.
+    #[must_use]
+    pub fn is_shutdown(&self) -> bool {
+        self.shutdown.load(Ordering::Acquire)
+    }
+
+    /// Explicitly shut down the connection task and reject later writes.
+    pub async fn shutdown(&self) -> Result<()> {
+        if !self.shutdown.swap(true, Ordering::AcqRel) {
+            _ = self.shutdown_tx.send(true);
+        }
+
+        let mut closed_rx = self.closed_rx.clone();
+        if !*closed_rx.borrow() {
+            let _: std::result::Result<(), tokio::time::error::Elapsed> =
+                timeout(Duration::from_secs(5), async {
+                    while !*closed_rx.borrow() {
+                        if closed_rx.changed().await.is_err() {
+                            break;
+                        }
+                    }
+                })
+                .await;
+        }
+
+        if let Some(handle) = self.task.lock().await.take() {
+            let _: std::result::Result<(), tokio::task::JoinError> = handle.await;
+        }
+
+        Ok(())
     }
 
     /// Subscribe to connection state changes.
@@ -422,5 +766,17 @@ where
     #[must_use]
     pub fn state_receiver(&self) -> watch::Receiver<ConnectionState> {
         self.state_tx.subscribe()
+    }
+}
+
+async fn wait_for_shutdown(shutdown_rx: &mut watch::Receiver<bool>) {
+    if *shutdown_rx.borrow() {
+        return;
+    }
+
+    while shutdown_rx.changed().await.is_ok() {
+        if *shutdown_rx.borrow() {
+            return;
+        }
     }
 }

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -24,7 +24,10 @@ pub mod connection;
 pub mod error;
 pub mod traits;
 
-pub use connection::ConnectionManager;
+pub use connection::{
+    ConnectionDiagnostic, ConnectionDiagnosticKind, ConnectionEnvelope, ConnectionGeneration,
+    ConnectionManager,
+};
 #[expect(
     clippy::module_name_repetitions,
     reason = "WsError includes module name for clarity when used outside this module"

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -25,8 +25,8 @@ pub mod error;
 pub mod traits;
 
 pub use connection::{
-    ConnectionDiagnostic, ConnectionDiagnosticKind, ConnectionEnvelope, ConnectionGeneration,
-    ConnectionManager,
+    ConnectionDiagnostic, ConnectionDiagnosticKind, ConnectionEnvelope, ConnectionEvent,
+    ConnectionGeneration, ConnectionManager,
 };
 #[expect(
     clippy::module_name_repetitions,

--- a/src/ws/traits.rs
+++ b/src/ws/traits.rs
@@ -4,8 +4,87 @@ use secrecy::ExposeSecret as _;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use serde_json::{Value, json};
+use sha2::{Digest as _, Sha256};
 
 use crate::auth::Credentials;
+
+/// Parser-failure categories that can be surfaced without exposing raw frames.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParserFailureClassification {
+    /// The frame was not valid JSON for the parser.
+    MalformedJson,
+    /// The frame had a known, interested event type but did not satisfy its schema.
+    InvalidInterestedFrame,
+    /// The frame had an unknown event type and was reported as forward-compatible drift.
+    UnknownOptionalEvent,
+}
+
+/// Bounded parser diagnostic emitted instead of raw WebSocket payloads.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParserDiagnostic {
+    /// Parser-failure category.
+    pub classification: ParserFailureClassification,
+    /// Raw frame byte length.
+    pub frame_len: usize,
+    /// SHA-256 digest of the raw frame, hex encoded.
+    pub digest: String,
+    /// Wire event type when it was available.
+    pub event_type: Option<String>,
+}
+
+impl ParserDiagnostic {
+    /// Create a bounded diagnostic for a raw frame.
+    #[must_use]
+    pub fn new(
+        classification: ParserFailureClassification,
+        bytes: &[u8],
+        event_type: Option<String>,
+    ) -> Self {
+        Self {
+            classification,
+            frame_len: bytes.len(),
+            digest: hex_digest(bytes),
+            event_type,
+        }
+    }
+}
+
+/// Parsed messages plus bounded diagnostics observed while parsing a frame.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct ParsedMessages<M> {
+    /// Successfully parsed messages, preserving source order.
+    pub messages: Vec<M>,
+    /// Diagnostics for skipped or invalid elements.
+    pub diagnostics: Vec<ParserDiagnostic>,
+}
+
+impl<M> ParsedMessages<M> {
+    /// Build an outcome with messages and no diagnostics.
+    #[must_use]
+    pub const fn messages(messages: Vec<M>) -> Self {
+        Self {
+            messages,
+            diagnostics: Vec::new(),
+        }
+    }
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+
+    let digest = Sha256::digest(bytes);
+    let mut output = String::with_capacity(digest.len() * 2);
+
+    for byte in digest {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+
+    output
+}
 
 /// Message parser trait for converting raw bytes to messages.
 ///
@@ -31,6 +110,15 @@ pub trait MessageParser<M: DeserializeOwned>: Send + Sync + 'static {
     /// May return empty vec if messages are filtered out based on interest or other criteria.
     /// Handles both single objects and arrays of messages.
     fn parse(&self, bytes: &[u8]) -> crate::Result<Vec<M>>;
+
+    /// Parse incoming bytes into messages plus bounded diagnostics.
+    ///
+    /// Parsers that can distinguish forward-compatible unknown events from continuity-breaking
+    /// invalid interested frames should override this method. The default preserves the historical
+    /// message-only behavior.
+    fn parse_with_diagnostics(&self, bytes: &[u8]) -> crate::Result<ParsedMessages<M>> {
+        self.parse(bytes).map(ParsedMessages::messages)
+    }
 }
 
 pub trait WithCredentials: Serialize + Sized {

--- a/src/ws/traits.rs
+++ b/src/ws/traits.rs
@@ -59,15 +59,28 @@ pub struct ParsedMessages<M> {
     pub messages: Vec<M>,
     /// Diagnostics for skipped or invalid elements.
     pub diagnostics: Vec<ParserDiagnostic>,
+    /// Messages and diagnostics in the exact order observed within the source frame.
+    pub items: Vec<ParsedItem<M>>,
+}
+
+/// One ordered parser output from a frame.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub enum ParsedItem<M> {
+    /// A successfully parsed message.
+    Message(M),
+    /// A bounded parser diagnostic.
+    Diagnostic(ParserDiagnostic),
 }
 
 impl<M> ParsedMessages<M> {
     /// Build an outcome with messages and no diagnostics.
     #[must_use]
-    pub const fn messages(messages: Vec<M>) -> Self {
+    pub fn messages(messages: Vec<M>) -> Self {
         Self {
             messages,
             diagnostics: Vec::new(),
+            items: Vec::new(),
         }
     }
 }

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -37,7 +37,7 @@ impl MockWsServer {
         let addr = listener.local_addr().unwrap();
 
         // Broadcast channel for sending to ALL clients
-        let (message_tx, _) = broadcast::channel::<String>(100);
+        let (message_tx, _) = broadcast::channel::<String>(4096);
         let (subscription_tx, subscription_rx) = mpsc::unbounded_channel::<String>();
 
         let broadcast_tx = message_tx.clone();
@@ -750,7 +750,7 @@ mod reconnection {
             let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
             let addr = listener.local_addr().unwrap();
 
-            let (message_tx, _) = broadcast::channel::<String>(100);
+            let (message_tx, _) = broadcast::channel::<String>(4096);
             let (subscription_tx, subscription_rx) = mpsc::unbounded_channel::<String>();
             let disconnect_signal = Arc::new(AtomicBool::new(false));
 
@@ -1638,6 +1638,556 @@ mod custom_features {
         let result = timeout(Duration::from_secs(2), stream.next()).await;
         let mr = result.unwrap().unwrap().unwrap();
         assert_eq!(mr.id, "12345");
+    }
+}
+
+mod observable_market_stream {
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use futures_util::Stream;
+    use polymarket_client_sdk_v2::Result as SdkResult;
+    use polymarket_client_sdk_v2::clob::ws::{
+        ConnectionGeneration, MarketStreamContinuity, MarketStreamEvent, MarketStreamTerminal,
+        ParserFailureClassification,
+    };
+
+    use super::*;
+
+    struct ReconnectableMockServer {
+        addr: SocketAddr,
+        subscription_rx: mpsc::UnboundedReceiver<String>,
+        message_tx: broadcast::Sender<String>,
+        disconnect_signal: Arc<AtomicBool>,
+    }
+
+    impl ReconnectableMockServer {
+        async fn start() -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+
+            let (message_tx, _) = broadcast::channel::<String>(4096);
+            let (subscription_tx, subscription_rx) = mpsc::unbounded_channel::<String>();
+            let disconnect_signal = Arc::new(AtomicBool::new(false));
+
+            let broadcast_tx = message_tx.clone();
+            let disconnect = Arc::clone(&disconnect_signal);
+
+            tokio::spawn(async move {
+                loop {
+                    let Ok((stream, _)) = listener.accept().await else {
+                        break;
+                    };
+
+                    let Ok(ws_stream) = tokio_tungstenite::accept_async(stream).await else {
+                        continue;
+                    };
+
+                    let (mut write, mut read) = ws_stream.split();
+                    let sub_tx = subscription_tx.clone();
+                    let mut msg_rx = broadcast_tx.subscribe();
+                    let disconnect_clone = Arc::clone(&disconnect);
+
+                    tokio::spawn(async move {
+                        loop {
+                            if disconnect_clone.load(Ordering::SeqCst) {
+                                break;
+                            }
+
+                            tokio::select! {
+                                msg = read.next() => {
+                                    match msg {
+                                        Some(Ok(Message::Text(text))) if text != "PING" => {
+                                            drop(sub_tx.send(text.to_string()));
+                                        }
+                                        Some(Ok(_)) => {}
+                                        _ => break,
+                                    }
+                                }
+                                msg = msg_rx.recv() => {
+                                    match msg {
+                                        Ok(text) => {
+                                            if write.send(Message::Text(text.into())).await.is_err() {
+                                                break;
+                                            }
+                                        }
+                                        Err(_) => break,
+                                    }
+                                }
+                                () = tokio::time::sleep(Duration::from_millis(20)) => {
+                                    if disconnect_clone.load(Ordering::SeqCst) {
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    });
+                }
+            });
+
+            Self {
+                addr,
+                subscription_rx,
+                message_tx,
+                disconnect_signal,
+            }
+        }
+
+        fn ws_url(&self, path: &str) -> String {
+            format!("ws://{}{}", self.addr, path)
+        }
+
+        fn disconnect_all(&self) {
+            self.disconnect_signal.store(true, Ordering::SeqCst);
+        }
+
+        fn allow_reconnect(&self) {
+            self.disconnect_signal.store(false, Ordering::SeqCst);
+        }
+
+        fn send(&self, message: &str) {
+            drop(self.message_tx.send(message.to_owned()));
+        }
+
+        async fn recv_subscription(&mut self) -> Option<String> {
+            timeout(Duration::from_secs(2), self.subscription_rx.recv())
+                .await
+                .ok()
+                .flatten()
+        }
+    }
+
+    fn short_reconnect_config() -> Config {
+        let mut config = Config::default();
+        config.reconnect.initial_backoff = Duration::from_millis(20);
+        config.reconnect.max_backoff = Duration::from_millis(50);
+        config
+    }
+
+    fn best_bid_ask() -> serde_json::Value {
+        json!({
+            "event_type": "best_bid_ask",
+            "market": payloads::MARKET_STR,
+            "asset_id": payloads::asset_id(),
+            "best_bid": "0.48",
+            "best_ask": "0.52",
+            "spread": "0.04",
+            "timestamp": "1234567890000"
+        })
+    }
+
+    fn new_market() -> serde_json::Value {
+        json!({
+            "event_type": "new_market",
+            "id": "12345",
+            "question": "Will it rain tomorrow?",
+            "market": payloads::MARKET_STR,
+            "slug": "will-it-rain-tomorrow",
+            "description": "A test market",
+            "assets_ids": [payloads::asset_id()],
+            "outcomes": ["Yes", "No"],
+            "timestamp": "1234567890000"
+        })
+    }
+
+    fn market_resolved() -> serde_json::Value {
+        json!({
+            "event_type": "market_resolved",
+            "id": "12345",
+            "question": "Will it rain tomorrow?",
+            "market": payloads::MARKET_STR,
+            "slug": "will-it-rain-tomorrow",
+            "description": "A test market",
+            "assets_ids": [payloads::asset_id()],
+            "outcomes": ["Yes", "No"],
+            "winning_asset_id": payloads::asset_id(),
+            "winning_outcome": "Yes",
+            "timestamp": "1234567890000"
+        })
+    }
+
+    async fn next_event<S>(stream: &mut Pin<Box<S>>) -> MarketStreamEvent
+    where
+        S: Stream<Item = SdkResult<MarketStreamEvent>> + ?Sized,
+    {
+        timeout(Duration::from_secs(5), stream.next())
+            .await
+            .expect("market stream should yield before timeout")
+            .expect("market stream should not close")
+            .expect("market stream event should be ok")
+    }
+
+    async fn next_message<S>(stream: &mut Pin<Box<S>>) -> (ConnectionGeneration, WsMessage)
+    where
+        S: Stream<Item = SdkResult<MarketStreamEvent>> + ?Sized,
+    {
+        loop {
+            if let MarketStreamEvent::Message {
+                generation,
+                message,
+            } = next_event(stream).await
+            {
+                return (generation, message);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn ordered_stream_emits_all_market_event_types_in_source_order() {
+        let mut server = MockWsServer::start().await;
+        let endpoint = server.ws_url("/ws/market");
+        let client = Client::new(&endpoint, Config::default()).unwrap();
+
+        let stream = client
+            .subscribe_market_events(vec![payloads::asset_id()])
+            .unwrap();
+        let mut stream = Box::pin(stream);
+
+        let sub_request = server.recv_subscription().await.unwrap();
+        assert!(sub_request.contains("\"custom_feature_enabled\":true"));
+
+        server.send(&payloads::book().to_string());
+        server.send(&payloads::price_change_batch(payloads::asset_id()).to_string());
+        server.send(&payloads::tick_size_change().to_string());
+        server.send(&payloads::last_trade_price(payloads::ASSET_ID_STR).to_string());
+        server.send(&best_bid_ask().to_string());
+        server.send(&new_market().to_string());
+        server.send(&market_resolved().to_string());
+
+        let mut variants = Vec::new();
+        let mut generation = None;
+        for _ in 0..7 {
+            let (event_generation, message) = next_message(&mut stream).await;
+            assert!(event_generation.as_u64() > 0);
+            if let Some(generation) = generation {
+                assert_eq!(event_generation, generation);
+            }
+            generation = Some(event_generation);
+            variants.push(match message {
+                WsMessage::Book(_) => "book",
+                WsMessage::PriceChange(_) => "price_change",
+                WsMessage::TickSizeChange(_) => "tick_size_change",
+                WsMessage::LastTradePrice(_) => "last_trade_price",
+                WsMessage::BestBidAsk(_) => "best_bid_ask",
+                WsMessage::NewMarket(_) => "new_market",
+                WsMessage::MarketResolved(_) => "market_resolved",
+                other => panic!("unexpected ordered market event: {other:?}"),
+            });
+        }
+
+        assert_eq!(
+            variants,
+            vec![
+                "book",
+                "price_change",
+                "tick_size_change",
+                "last_trade_price",
+                "best_bid_ask",
+                "new_market",
+                "market_resolved",
+            ]
+        );
+        client.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn reconnect_yields_new_generation_boundary_before_new_data() {
+        let mut server = ReconnectableMockServer::start().await;
+        let endpoint = server.ws_url("/ws/market");
+        let client = Client::new(&endpoint, short_reconnect_config()).unwrap();
+
+        let stream = client
+            .subscribe_market_events(vec![payloads::asset_id()])
+            .unwrap();
+        let mut stream = Box::pin(stream);
+
+        let initial_sub = server.recv_subscription().await.unwrap();
+        assert!(initial_sub.contains(&payloads::asset_id().to_string()));
+
+        server.send(&payloads::book().to_string());
+        let (first_generation, first_message) = next_message(&mut stream).await;
+        assert!(matches!(first_message, WsMessage::Book(_)));
+
+        server.disconnect_all();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        server.allow_reconnect();
+
+        let resub = server.recv_subscription().await.unwrap();
+        assert!(resub.contains(&payloads::asset_id().to_string()));
+
+        server.send(&payloads::price_change_batch(payloads::asset_id()).to_string());
+
+        let mut boundary_generation = None;
+        let (second_generation, second_message) = loop {
+            match next_event(&mut stream).await {
+                MarketStreamEvent::Continuity {
+                    generation,
+                    reason: MarketStreamContinuity::Connected,
+                } if generation > first_generation => {
+                    boundary_generation = Some(generation);
+                }
+                MarketStreamEvent::Message {
+                    generation,
+                    message,
+                } if generation > first_generation => break (generation, message),
+                _ => {}
+            }
+        };
+        assert_eq!(Some(second_generation), boundary_generation);
+        assert!(second_generation > first_generation);
+        assert!(matches!(second_message, WsMessage::PriceChange(_)));
+        client.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn lag_is_reported_before_later_data() {
+        let mut server = MockWsServer::start().await;
+        let endpoint = server.ws_url("/ws/market");
+        let client = Client::new(&endpoint, Config::default()).unwrap();
+
+        let stream = client
+            .subscribe_market_events(vec![payloads::asset_id()])
+            .unwrap();
+        let mut stream = Box::pin(stream);
+        let _: Option<String> = server.recv_subscription().await;
+
+        for _ in 0..3000 {
+            server.send(&payloads::book().to_string());
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+
+        let missed = loop {
+            if let MarketStreamEvent::Continuity {
+                generation,
+                reason: MarketStreamContinuity::Lagged { missed },
+            } = next_event(&mut stream).await
+            {
+                assert!(generation.as_u64() > 0);
+                break missed;
+            }
+        };
+        assert!(missed > 0);
+
+        let (generation, message) = next_message(&mut stream).await;
+        assert!(generation.as_u64() > 0);
+        assert!(matches!(message, WsMessage::Book(_)));
+        client.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn invalid_interested_frame_is_consumer_visible() {
+        let mut server = MockWsServer::start().await;
+        let endpoint = server.ws_url("/ws/market");
+        let client = Client::new(&endpoint, Config::default()).unwrap();
+
+        let stream = client
+            .subscribe_market_events(vec![payloads::asset_id()])
+            .unwrap();
+        let mut stream = Box::pin(stream);
+        let _: Option<String> = server.recv_subscription().await;
+
+        let invalid_book = json!({
+            "event_type": "book",
+            "asset_id": "not-a-u256",
+            "market": payloads::MARKET_STR,
+            "timestamp": "123456789000"
+        });
+        server.send(&invalid_book.to_string());
+
+        let diagnostic = loop {
+            if let MarketStreamEvent::Continuity {
+                generation,
+                reason: MarketStreamContinuity::ParserDiagnostic(diagnostic),
+            } = next_event(&mut stream).await
+            {
+                assert!(generation.as_u64() > 0);
+                break diagnostic;
+            }
+        };
+        assert_eq!(
+            diagnostic.classification,
+            ParserFailureClassification::InvalidInterestedFrame
+        );
+        assert_eq!(diagnostic.event_type.as_deref(), Some("book"));
+        assert_eq!(diagnostic.digest.len(), 64);
+        client.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn malformed_interested_frame_diagnostic_is_bounded() {
+        const SENTINEL: &str = "RAW_SENTINEL_BODY_SHOULD_NOT_APPEAR_IN_DIAGNOSTIC";
+
+        let mut server = MockWsServer::start().await;
+        let endpoint = server.ws_url("/ws/market");
+        let client = Client::new(&endpoint, Config::default()).unwrap();
+
+        let stream = client
+            .subscribe_market_events(vec![payloads::asset_id()])
+            .unwrap();
+        let mut stream = Box::pin(stream);
+        let _: Option<String> = server.recv_subscription().await;
+
+        let malformed = format!(
+            r#"{{"event_type":"book","sentinel":"{SENTINEL}","asset_id":"{}""#,
+            payloads::ASSET_ID_STR
+        );
+        server.send(&malformed);
+
+        let diagnostic = loop {
+            if let MarketStreamEvent::Continuity {
+                reason: MarketStreamContinuity::ParserDiagnostic(diagnostic),
+                ..
+            } = next_event(&mut stream).await
+                && diagnostic.classification == ParserFailureClassification::MalformedJson
+            {
+                break diagnostic;
+            }
+        };
+        assert_eq!(diagnostic.event_type.as_deref(), Some("book"));
+        assert!(diagnostic.frame_len >= malformed.len());
+        assert!(!diagnostic.digest.contains(SENTINEL));
+        assert_ne!(diagnostic.event_type.as_deref(), Some(SENTINEL));
+        client.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn unknown_optional_event_retains_known_batch_order() {
+        const SENTINEL: &str = "RAW_SENTINEL_BODY_SHOULD_NOT_APPEAR_IN_DIAGNOSTIC";
+
+        let mut server = MockWsServer::start().await;
+        let endpoint = server.ws_url("/ws/market");
+        let client = Client::new(&endpoint, Config::default()).unwrap();
+
+        let stream = client
+            .subscribe_market_events(vec![payloads::asset_id()])
+            .unwrap();
+        let mut stream = Box::pin(stream);
+        let _: Option<String> = server.recv_subscription().await;
+
+        server.send(&payloads::book().to_string());
+        let (_, message) = next_message(&mut stream).await;
+        assert!(matches!(message, WsMessage::Book(_)));
+
+        let batch = json!([
+            {
+                "event_type": "future_optional_market_event",
+                "sentinel": SENTINEL
+            },
+            payloads::book()
+        ]);
+        server.send(&batch.to_string());
+
+        let diagnostic = loop {
+            if let MarketStreamEvent::Continuity {
+                reason: MarketStreamContinuity::ParserDiagnostic(diagnostic),
+                ..
+            } = next_event(&mut stream).await
+                && diagnostic.classification == ParserFailureClassification::UnknownOptionalEvent
+            {
+                break diagnostic;
+            }
+        };
+        assert_eq!(
+            diagnostic.event_type.as_deref(),
+            Some("future_optional_market_event")
+        );
+        let (_, message) = next_message(&mut stream).await;
+        assert!(matches!(message, WsMessage::Book(_)));
+        client.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn connect_timeout_reaches_terminal_exhaustion() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let _stream = stream;
+                    tokio::time::sleep(Duration::from_secs(5)).await;
+                });
+            }
+        });
+
+        let mut config = Config::default();
+        config.connect_timeout = Duration::from_millis(30);
+        config.reconnect.max_attempts = Some(1);
+        config.reconnect.initial_backoff = Duration::from_millis(5);
+        config.reconnect.max_backoff = Duration::from_millis(5);
+
+        let client = Client::new(&format!("ws://{addr}"), config).unwrap();
+        let stream = client
+            .subscribe_market_events(vec![payloads::asset_id()])
+            .unwrap();
+        let mut stream = Box::pin(stream);
+
+        let mut saw_timeout = false;
+        loop {
+            match next_event(&mut stream).await {
+                MarketStreamEvent::Continuity {
+                    generation,
+                    reason: MarketStreamContinuity::ConnectTimeout,
+                } => {
+                    assert_eq!(generation.as_u64(), 0);
+                    saw_timeout = true;
+                }
+                MarketStreamEvent::Terminal {
+                    generation,
+                    reason: MarketStreamTerminal::ReconnectExhausted { attempts },
+                } => {
+                    assert_eq!(generation.as_u64(), 0);
+                    assert_eq!(attempts, 1);
+                    break;
+                }
+                event => panic!("unexpected connect-timeout event: {event:?}"),
+            }
+        }
+        assert!(saw_timeout);
+        client.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn heartbeat_timeout_and_explicit_shutdown_are_observable() {
+        let mut server = MockWsServer::start().await;
+        let endpoint = server.ws_url("/ws/market");
+
+        let mut config = short_reconnect_config();
+        config.heartbeat_interval = Duration::from_millis(20);
+        config.heartbeat_timeout = Duration::from_millis(20);
+
+        let client = Client::new(&endpoint, config).unwrap();
+        let stream = client
+            .subscribe_market_events(vec![payloads::asset_id()])
+            .unwrap();
+        let mut stream = Box::pin(stream);
+        let _: Option<String> = server.recv_subscription().await;
+
+        let heartbeat_generation = loop {
+            if let MarketStreamEvent::Continuity {
+                generation,
+                reason: MarketStreamContinuity::HeartbeatTimeout,
+            } = next_event(&mut stream).await
+            {
+                assert!(generation.as_u64() > 0);
+                break generation;
+            }
+        };
+
+        client.close().await.unwrap();
+
+        loop {
+            if let MarketStreamEvent::Terminal {
+                generation,
+                reason: MarketStreamTerminal::Shutdown,
+            } = next_event(&mut stream).await
+            {
+                assert!(generation.as_u64() >= heartbeat_generation.as_u64());
+                break;
+            }
+        }
+
+        let result = client.subscribe_orderbook(vec![payloads::asset_id()]);
+        assert!(result.is_err(), "post-shutdown writes must be rejected");
     }
 }
 

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -1643,7 +1643,6 @@ mod custom_features {
 
 mod observable_market_stream {
     use std::pin::Pin;
-    use std::sync::atomic::{AtomicBool, Ordering};
 
     use futures_util::Stream;
     use polymarket_client_sdk_v2::Result as SdkResult;
@@ -1658,7 +1657,8 @@ mod observable_market_stream {
         addr: SocketAddr,
         subscription_rx: mpsc::UnboundedReceiver<String>,
         message_tx: broadcast::Sender<String>,
-        disconnect_signal: Arc<AtomicBool>,
+        disconnect_tx: broadcast::Sender<()>,
+        connection_closed_rx: mpsc::UnboundedReceiver<()>,
     }
 
     impl ReconnectableMockServer {
@@ -1668,10 +1668,11 @@ mod observable_market_stream {
 
             let (message_tx, _) = broadcast::channel::<String>(4096);
             let (subscription_tx, subscription_rx) = mpsc::unbounded_channel::<String>();
-            let disconnect_signal = Arc::new(AtomicBool::new(false));
+            let (disconnect_tx, _) = broadcast::channel::<()>(16);
+            let (connection_closed_tx, connection_closed_rx) = mpsc::unbounded_channel::<()>();
 
             let broadcast_tx = message_tx.clone();
-            let disconnect = Arc::clone(&disconnect_signal);
+            let disconnect_broadcast = disconnect_tx.clone();
 
             tokio::spawn(async move {
                 loop {
@@ -1686,14 +1687,11 @@ mod observable_market_stream {
                     let (mut write, mut read) = ws_stream.split();
                     let sub_tx = subscription_tx.clone();
                     let mut msg_rx = broadcast_tx.subscribe();
-                    let disconnect_clone = Arc::clone(&disconnect);
+                    let mut disconnect_rx = disconnect_broadcast.subscribe();
+                    let connection_closed_tx = connection_closed_tx.clone();
 
                     tokio::spawn(async move {
                         loop {
-                            if disconnect_clone.load(Ordering::SeqCst) {
-                                break;
-                            }
-
                             tokio::select! {
                                 msg = read.next() => {
                                     match msg {
@@ -1714,12 +1712,13 @@ mod observable_market_stream {
                                         Err(_) => break,
                                     }
                                 }
-                                () = tokio::time::sleep(Duration::from_millis(20)) => {
-                                    if disconnect_clone.load(Ordering::SeqCst) {
-                                        break;
-                                    }
+                                _ = disconnect_rx.recv() => {
+                                    break;
                                 }
                             }
+                        }
+                        match connection_closed_tx.send(()) {
+                            Ok(()) | Err(_) => {}
                         }
                     });
                 }
@@ -1729,7 +1728,8 @@ mod observable_market_stream {
                 addr,
                 subscription_rx,
                 message_tx,
-                disconnect_signal,
+                disconnect_tx,
+                connection_closed_rx,
             }
         }
 
@@ -1738,11 +1738,7 @@ mod observable_market_stream {
         }
 
         fn disconnect_all(&self) {
-            self.disconnect_signal.store(true, Ordering::SeqCst);
-        }
-
-        fn allow_reconnect(&self) {
-            self.disconnect_signal.store(false, Ordering::SeqCst);
+            drop(self.disconnect_tx.send(()));
         }
 
         fn send(&self, message: &str) {
@@ -1755,6 +1751,30 @@ mod observable_market_stream {
                 .ok()
                 .flatten()
         }
+
+        async fn recv_connection_closed(&mut self) -> bool {
+            timeout(Duration::from_secs(2), self.connection_closed_rx.recv())
+                .await
+                .ok()
+                .flatten()
+                .is_some()
+        }
+    }
+
+    async fn wait_for_market_reconnecting(client: &Client) {
+        timeout(Duration::from_secs(2), async {
+            loop {
+                if matches!(
+                    client.connection_state(ChannelType::Market),
+                    polymarket_client_sdk_v2::ws::connection::ConnectionState::Reconnecting { .. }
+                ) {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("market connection should enter reconnecting state");
     }
 
     fn short_reconnect_config() -> Config {
@@ -1909,8 +1929,6 @@ mod observable_market_stream {
         assert!(matches!(first_message, WsMessage::Book(_)));
 
         server.disconnect_all();
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        server.allow_reconnect();
 
         let resub = server.recv_subscription().await.unwrap();
         assert!(resub.contains(&payloads::asset_id().to_string()));
@@ -1939,7 +1957,7 @@ mod observable_market_stream {
         client.close().await.unwrap();
     }
 
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    #[tokio::test]
     async fn delayed_consumer_polling_does_not_merge_reconnect_generations() {
         let mut server = ReconnectableMockServer::start().await;
         let endpoint = server.ws_url("/ws/market");
@@ -1949,20 +1967,21 @@ mod observable_market_stream {
             .subscribe_market_events(vec![payloads::asset_id()])
             .unwrap();
         let mut stream = Box::pin(stream);
+        let observer_stream = client
+            .subscribe_market_events(vec![payloads::asset_id()])
+            .unwrap();
+        let mut observer_stream = Box::pin(observer_stream);
 
-        let initial_sub = server.subscription_rx.recv().await.unwrap();
+        let initial_sub = server.recv_subscription().await.unwrap();
         assert!(initial_sub.contains(&payloads::asset_id().to_string()));
 
         server.send(&payloads::book().to_string());
-        tokio::task::yield_now().await;
-        tokio::time::advance(Duration::from_millis(1)).await;
+        let (first_generation, first_message) = next_message(&mut observer_stream).await;
+        assert!(matches!(first_message, WsMessage::Book(_)));
 
         server.disconnect_all();
-        tokio::time::advance(Duration::from_millis(25)).await;
-        server.allow_reconnect();
-        tokio::time::advance(Duration::from_secs(1)).await;
 
-        let resub = server.subscription_rx.recv().await.unwrap();
+        let resub = server.recv_subscription().await.unwrap();
         assert!(resub.contains(&payloads::asset_id().to_string()));
         server.send(&payloads::price_change_batch(payloads::asset_id()).to_string());
 
@@ -1984,7 +2003,7 @@ mod observable_market_stream {
                     generation,
                     message: WsMessage::Book(_),
                 } => {
-                    assert!(generation.as_u64() > 0);
+                    assert_eq!(generation, first_generation);
                     old_generation = Some(generation);
                 }
                 MarketStreamEvent::Message {
@@ -2006,7 +2025,7 @@ mod observable_market_stream {
         client.close().await.unwrap();
     }
 
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    #[tokio::test]
     async fn delayed_first_poll_reconnect_emits_generation_before_data() {
         let mut server = ReconnectableMockServer::start().await;
         let endpoint = server.ws_url("/ws/market");
@@ -2021,11 +2040,8 @@ mod observable_market_stream {
         assert!(initial_sub.contains(&payloads::asset_id().to_string()));
 
         server.disconnect_all();
-        tokio::time::advance(Duration::from_millis(25)).await;
-        server.allow_reconnect();
-        tokio::time::advance(Duration::from_secs(1)).await;
 
-        let resub = server.subscription_rx.recv().await.unwrap();
+        let resub = server.recv_subscription().await.unwrap();
         assert!(resub.contains(&payloads::asset_id().to_string()));
         server.send(&payloads::book().to_string());
 
@@ -2051,6 +2067,58 @@ mod observable_market_stream {
         }
 
         client.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn reconnect_write_unavailable_is_reported_before_redelivery() {
+        let mut server = ReconnectableMockServer::start().await;
+        let endpoint = server.ws_url("/ws/market");
+        let mut config = short_reconnect_config();
+        config.reconnect.initial_backoff = Duration::from_millis(500);
+        config.reconnect.max_backoff = Duration::from_millis(500);
+        let client = Client::new(&endpoint, config).unwrap();
+
+        let asset_id = payloads::asset_id();
+        let stream = client.subscribe_market_events(vec![asset_id]).unwrap();
+        let mut stream = Box::pin(stream);
+
+        let initial_sub = server.recv_subscription().await.unwrap();
+        assert!(initial_sub.contains(&asset_id.to_string()));
+
+        server.disconnect_all();
+        assert!(server.recv_connection_closed().await);
+        wait_for_market_reconnecting(&client).await;
+
+        let other_asset = payloads::other_asset_id();
+        let _other_stream = client.subscribe_market_events(vec![other_asset]).unwrap();
+
+        let write_failed_generation = loop {
+            match next_event(&mut stream).await {
+                MarketStreamEvent::Continuity {
+                    generation,
+                    reason: MarketStreamContinuity::WriteFailed,
+                } => break generation,
+                MarketStreamEvent::Message { message, .. } => {
+                    panic!("write failure should be visible before new data, got {message:?}");
+                }
+                _ => {}
+            }
+        };
+        assert!(write_failed_generation.as_u64() > 0);
+
+        let mut redelivered_initial_asset = false;
+        let mut redelivered_late_asset = false;
+        for _ in 0..2 {
+            let resub = server.recv_subscription().await.unwrap();
+            redelivered_initial_asset |= resub.contains(&asset_id.to_string());
+            redelivered_late_asset |= resub.contains(&other_asset.to_string());
+        }
+        assert!(
+            redelivered_initial_asset && redelivered_late_asset,
+            "desired membership accepted around the unavailable write must be redelivered after reconnect"
+        );
+        client.close().await.unwrap();
+        server.disconnect_all();
     }
 
     #[tokio::test]
@@ -2356,6 +2424,9 @@ mod observable_market_stream {
     async fn explicit_shutdown_closes_stream_and_rejects_resubscription_work() {
         let mut server = ReconnectableMockServer::start().await;
         let endpoint = server.ws_url("/ws/market");
+        let baseline_alive_tasks = tokio::runtime::Handle::current()
+            .metrics()
+            .num_alive_tasks();
         let client = Client::new(&endpoint, short_reconnect_config()).unwrap();
 
         let stream = client
@@ -2387,12 +2458,25 @@ mod observable_market_stream {
         );
 
         server.disconnect_all();
-        server.allow_reconnect();
         let late_resubscribe =
             timeout(Duration::from_millis(100), server.subscription_rx.recv()).await;
         assert!(
             late_resubscribe.is_err(),
             "shutdown must not leave reconnect work that writes later subscriptions"
+        );
+        assert!(
+            server.recv_connection_closed().await,
+            "server peer should observe the client connection closing"
+        );
+        for _ in 0..3 {
+            tokio::task::yield_now().await;
+        }
+        let alive_tasks_after_shutdown = tokio::runtime::Handle::current()
+            .metrics()
+            .num_alive_tasks();
+        assert!(
+            alive_tasks_after_shutdown <= baseline_alive_tasks,
+            "shutdown must join SDK-owned tasks; baseline alive tasks: {baseline_alive_tasks}, after shutdown: {alive_tasks_after_shutdown}"
         );
     }
 }

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -1648,8 +1648,8 @@ mod observable_market_stream {
     use futures_util::Stream;
     use polymarket_client_sdk_v2::Result as SdkResult;
     use polymarket_client_sdk_v2::clob::ws::{
-        ConnectionGeneration, MarketStreamContinuity, MarketStreamEvent, MarketStreamTerminal,
-        ParserFailureClassification,
+        ChannelType, ConnectionGeneration, MarketStreamContinuity, MarketStreamEvent,
+        MarketStreamTerminal, ParserFailureClassification,
     };
 
     use super::*;
@@ -1939,6 +1939,120 @@ mod observable_market_stream {
         client.close().await.unwrap();
     }
 
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn delayed_consumer_polling_does_not_merge_reconnect_generations() {
+        let mut server = ReconnectableMockServer::start().await;
+        let endpoint = server.ws_url("/ws/market");
+        let client = Client::new(&endpoint, short_reconnect_config()).unwrap();
+
+        let stream = client
+            .subscribe_market_events(vec![payloads::asset_id()])
+            .unwrap();
+        let mut stream = Box::pin(stream);
+
+        let initial_sub = server.subscription_rx.recv().await.unwrap();
+        assert!(initial_sub.contains(&payloads::asset_id().to_string()));
+
+        server.send(&payloads::book().to_string());
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(1)).await;
+
+        server.disconnect_all();
+        tokio::time::advance(Duration::from_millis(25)).await;
+        server.allow_reconnect();
+        tokio::time::advance(Duration::from_secs(1)).await;
+
+        let resub = server.subscription_rx.recv().await.unwrap();
+        assert!(resub.contains(&payloads::asset_id().to_string()));
+        server.send(&payloads::price_change_batch(payloads::asset_id()).to_string());
+
+        let mut old_generation = None;
+        let mut saw_reconnect_boundary = false;
+
+        loop {
+            match next_event(&mut stream).await {
+                MarketStreamEvent::Continuity {
+                    generation,
+                    reason: MarketStreamContinuity::Connected,
+                } => {
+                    if let Some(old) = old_generation {
+                        assert!(generation > old);
+                        saw_reconnect_boundary = true;
+                    }
+                }
+                MarketStreamEvent::Message {
+                    generation,
+                    message: WsMessage::Book(_),
+                } => {
+                    assert!(generation.as_u64() > 0);
+                    old_generation = Some(generation);
+                }
+                MarketStreamEvent::Message {
+                    generation,
+                    message: WsMessage::PriceChange(_),
+                } => {
+                    let old = old_generation.expect("old buffered generation should be visible");
+                    assert!(generation > old);
+                    assert!(
+                        saw_reconnect_boundary,
+                        "reconnect generation boundary must precede new data"
+                    );
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        client.close().await.unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn delayed_first_poll_reconnect_emits_generation_before_data() {
+        let mut server = ReconnectableMockServer::start().await;
+        let endpoint = server.ws_url("/ws/market");
+        let client = Client::new(&endpoint, short_reconnect_config()).unwrap();
+
+        let stream = client
+            .subscribe_market_events(vec![payloads::asset_id()])
+            .unwrap();
+        let mut stream = Box::pin(stream);
+
+        let initial_sub = server.subscription_rx.recv().await.unwrap();
+        assert!(initial_sub.contains(&payloads::asset_id().to_string()));
+
+        server.disconnect_all();
+        tokio::time::advance(Duration::from_millis(25)).await;
+        server.allow_reconnect();
+        tokio::time::advance(Duration::from_secs(1)).await;
+
+        let resub = server.subscription_rx.recv().await.unwrap();
+        assert!(resub.contains(&payloads::asset_id().to_string()));
+        server.send(&payloads::book().to_string());
+
+        let mut most_recent_boundary = None;
+        loop {
+            match next_event(&mut stream).await {
+                MarketStreamEvent::Continuity {
+                    generation,
+                    reason: MarketStreamContinuity::Connected,
+                } => {
+                    most_recent_boundary = Some(generation);
+                }
+                MarketStreamEvent::Message {
+                    generation,
+                    message: WsMessage::Book(_),
+                } => {
+                    assert_eq!(Some(generation), most_recent_boundary);
+                    assert!(generation.as_u64() > 0);
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        client.close().await.unwrap();
+    }
+
     #[tokio::test]
     async fn lag_is_reported_before_later_data() {
         let mut server = MockWsServer::start().await;
@@ -2014,6 +2128,48 @@ mod observable_market_stream {
     }
 
     #[tokio::test]
+    async fn large_malformed_frame_diagnostic_is_bounded_with_generation_context() {
+        const SENTINEL: &str = "RAW_SENTINEL_BODY_SHOULD_NOT_APPEAR_IN_DIAGNOSTIC";
+
+        let mut server = MockWsServer::start().await;
+        let endpoint = server.ws_url("/ws/market");
+        let client = Client::new(&endpoint, Config::default()).unwrap();
+
+        let stream = client
+            .subscribe_market_events(vec![payloads::asset_id()])
+            .unwrap();
+        let mut stream = Box::pin(stream);
+        let _: Option<String> = server.recv_subscription().await;
+
+        let sentinel_body = SENTINEL.repeat(512);
+        let malformed = format!(
+            r#"{{"event_type":"book","sentinel":"{sentinel_body}","asset_id":"{}""#,
+            payloads::ASSET_ID_STR
+        );
+        server.send(&malformed);
+
+        let (generation, diagnostic) = loop {
+            if let MarketStreamEvent::Continuity {
+                generation,
+                reason: MarketStreamContinuity::ParserDiagnostic(diagnostic),
+            } = next_event(&mut stream).await
+                && diagnostic.classification == ParserFailureClassification::MalformedJson
+            {
+                break (generation, diagnostic);
+            }
+        };
+
+        assert!(generation.as_u64() > 0);
+        assert_eq!(diagnostic.event_type.as_deref(), Some("book"));
+        assert_eq!(diagnostic.frame_len, malformed.len());
+        assert_eq!(diagnostic.digest.len(), 64);
+        let diagnostic_debug = format!("{diagnostic:?}");
+        assert!(!diagnostic_debug.contains(SENTINEL));
+        assert!(!diagnostic.digest.contains(SENTINEL));
+        client.close().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn malformed_interested_frame_diagnostic_is_bounded() {
         const SENTINEL: &str = "RAW_SENTINEL_BODY_SHOULD_NOT_APPEAR_IN_DIAGNOSTIC";
 
@@ -2077,22 +2233,28 @@ mod observable_market_stream {
         ]);
         server.send(&batch.to_string());
 
-        let diagnostic = loop {
-            if let MarketStreamEvent::Continuity {
-                reason: MarketStreamContinuity::ParserDiagnostic(diagnostic),
-                ..
-            } = next_event(&mut stream).await
-                && diagnostic.classification == ParserFailureClassification::UnknownOptionalEvent
-            {
-                break diagnostic;
-            }
+        let MarketStreamEvent::Continuity {
+            reason: MarketStreamContinuity::ParserDiagnostic(diagnostic),
+            ..
+        } = next_event(&mut stream).await
+        else {
+            panic!("unknown optional batch element must be emitted before later data");
         };
+        assert_eq!(
+            diagnostic.classification,
+            ParserFailureClassification::UnknownOptionalEvent
+        );
         assert_eq!(
             diagnostic.event_type.as_deref(),
             Some("future_optional_market_event")
         );
-        let (_, message) = next_message(&mut stream).await;
-        assert!(matches!(message, WsMessage::Book(_)));
+        let MarketStreamEvent::Message {
+            message: WsMessage::Book(_),
+            ..
+        } = next_event(&mut stream).await
+        else {
+            panic!("known batch message must immediately follow the unknown diagnostic");
+        };
         client.close().await.unwrap();
     }
 
@@ -2188,6 +2350,50 @@ mod observable_market_stream {
 
         let result = client.subscribe_orderbook(vec![payloads::asset_id()]);
         assert!(result.is_err(), "post-shutdown writes must be rejected");
+    }
+
+    #[tokio::test]
+    async fn explicit_shutdown_closes_stream_and_rejects_resubscription_work() {
+        let mut server = ReconnectableMockServer::start().await;
+        let endpoint = server.ws_url("/ws/market");
+        let client = Client::new(&endpoint, short_reconnect_config()).unwrap();
+
+        let stream = client
+            .subscribe_market_events(vec![payloads::asset_id()])
+            .unwrap();
+        let mut stream = Box::pin(stream);
+        let _: Option<String> = server.recv_subscription().await;
+
+        client.close().await.unwrap();
+
+        loop {
+            if let MarketStreamEvent::Terminal {
+                reason: MarketStreamTerminal::Shutdown,
+                ..
+            } = next_event(&mut stream).await
+            {
+                break;
+            }
+        }
+
+        assert_eq!(
+            client.connection_state(ChannelType::Market),
+            polymarket_client_sdk_v2::ws::connection::ConnectionState::Disconnected
+        );
+        assert!(
+            client
+                .subscribe_orderbook(vec![payloads::asset_id()])
+                .is_err()
+        );
+
+        server.disconnect_all();
+        server.allow_reconnect();
+        let late_resubscribe =
+            timeout(Duration::from_millis(100), server.subscription_rx.recv()).await;
+        assert!(
+            late_resubscribe.is_err(),
+            "shutdown must not leave reconnect work that writes later subscriptions"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds one ordered CLOB market-event stream that preserves interested message order.
- Surfaces generation boundaries, lag, parser diagnostics, connect timeout/exhaustion, heartbeat timeout, and explicit shutdown as typed consumer-visible events.
- Adds deterministic WebSocket regressions for the observable stream contract.

## Tests

- cargo fmt --all -- --check
- cargo check --all-targets --features clob,ws,tracing
- cargo test --all-targets --features clob,ws,tracing -- --test-threads=1
- cargo clippy --all-targets --features clob,ws,tracing -- -D warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core live-trading WebSocket lifecycle (reconnect, heartbeat, parsing, subscription delivery) and introduces a new observable contract that downstream strategies may depend on for correctness.
> 
> **Overview**
> Introduces **`subscribe_market_events`**, a single ordered stream of **`MarketStreamEvent`** values (messages, continuity boundaries, and terminal closure) tagged with immutable **`ConnectionGeneration`** IDs so consumers can reason about reconnects without merging multiple filtered streams.
> 
> The shared **`ConnectionManager`** is extended to wrap broadcasts in **`ConnectionEnvelope`**, emit FIFO **`ConnectionEvent`** / **`ConnectionDiagnostic`** streams, enforce **`connect_timeout`**, surface bounded **`ParserDiagnostic`** failures (digest + classification, no raw payloads), and support **`shutdown`** / **`close`** with post-shutdown write rejection. CLOB wiring adds **`Client::close`**, refactors market subscription registration, and maps low-level diagnostics into **`MarketStreamContinuity`** / **`MarketStreamTerminal`**.
> 
> Existing message-only subscribers (CLOB market/user, RTDS) are updated to unwrap envelopes. **`parse_if_interested_with_diagnostics`** preserves batch order for unknown optional events vs invalid interested frames. Large integration tests in **`tests/websocket.rs`** lock in generation ordering, lag, parser diagnostics, connect/heartbeat timeouts, write-unavailable during reconnect, and shutdown behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f314a807a08e7e386425241ff4252a1af50b128. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->