### PR TITLE
feat(gamma): add teams and sport fields to Event response

### DIFF
--- a/src/gamma/types/response.rs
+++ b/src/gamma/types/response.rs
@@ -61,6 +61,25 @@ pub struct Team {
     pub provider_id: Option<i32>,
 }
 
+/// A team within an event context, including its home/away ordering.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Builder)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct EventTeam {
+    pub id: i32,
+    pub name: Option<String>,
+    pub league: Option<String>,
+    pub record: Option<String>,
+    pub logo: Option<String>,
+    pub abbreviation: Option<String>,
+    pub created_at: Option<DateTime<Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
+    pub color: Option<String>,
+    pub provider_id: Option<i32>,
+    /// `"home"` or `"away"` — which side of the event this team plays.
+    pub ordering: Option<String>,
+}
+
 /// Sports metadata information.
 #[serde_as]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Builder)]
@@ -334,6 +353,8 @@ pub struct Event {
     pub cumulative_markets: Option<bool>,
     pub away_team_name: Option<String>,
     pub home_team_name: Option<String>,
+    pub teams: Option<Vec<EventTeam>>,
+    pub sport: Option<SportsMetadata>,
 }
 
 /// A prediction market.


### PR DESCRIPTION
Adds optional `teams` and `sport` fields to the Gamma `Event` response, so consumers can read team rosters and sport metadata directly from the event payload without extra requests.

- new `EventTeam` struct (`id`, `name`, `ordering`, logo/record/etc.)
- `Event::teams: Option<Vec<EventTeam>>`
- `Event::sport: Option<SportsMetadata>`

Both fields stay `Option` since Gamma omits them for non-sports events.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive serde types only; no auth, networking, or behavior changes beyond extra optional fields on Event.
> 
> **Overview**
> Gamma `Event` payloads can now deserialize nested sports data: optional `teams` (`Vec<EventTeam>`) and `sport` (`SportsMetadata`).
> 
> `EventTeam` is a new type similar to `Team` plus `ordering` (`"home"` / `"away"`). Both fields are `Option` so non-sports events still parse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb45b2025b3a4f3e04d1fe991dd8d275151dd534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->