### PR TITLE
feat(ws): add fail-closed ordered market stream and shutdown

### DIFF
--- a/src/clob/ws/client.rs
+++ b/src/clob/ws/client.rs
@@ -1,10 +1,12 @@
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, PoisonError};
 
 use async_stream::try_stream;
 use dashmap::mapref::one::{Ref, RefMut};
 use dashmap::{DashMap, Entry};
 use futures::Stream;
 use futures::StreamExt as _;
+use tokio::sync::Notify;
 
 use super::interest::InterestTracker;
 use super::subscription::{ChannelType, SubscriptionManager};
@@ -17,9 +19,9 @@ use crate::auth::state::{Authenticated, State, Unauthenticated};
 use crate::auth::{Credentials, Kind as AuthKind, Normal};
 use crate::error::Error;
 use crate::types::{Address, B256, Decimal, U256};
-use crate::ws::ConnectionManager;
 use crate::ws::config::Config;
 use crate::ws::connection::ConnectionState;
+use crate::ws::{ConnectionManager, WsError};
 
 /// WebSocket client for real-time market data and user updates.
 ///
@@ -75,6 +77,9 @@ struct ClientInner<S: State> {
     base_endpoint: String,
     /// Resources for each WebSocket channel (lazily initialized)
     channels: DashMap<ChannelType, ChannelResources>,
+    lifecycle: Mutex<()>,
+    shutdown_in_progress: AtomicBool,
+    shutdown_done: Notify,
 }
 
 impl Client<Unauthenticated> {
@@ -93,6 +98,9 @@ impl Client<Unauthenticated> {
                 config,
                 base_endpoint,
                 channels: DashMap::new(),
+                lifecycle: Mutex::new(()),
+                shutdown_in_progress: AtomicBool::new(false),
+                shutdown_done: Notify::new(),
             }),
         })
     }
@@ -129,6 +137,9 @@ impl Client<Unauthenticated> {
                 config,
                 base_endpoint,
                 channels,
+                lifecycle: Mutex::new(()),
+                shutdown_in_progress: AtomicBool::new(false),
+                shutdown_done: Notify::new(),
             }),
         })
     }
@@ -252,6 +263,30 @@ impl<S: State> Client<S> {
                 _ => None,
             }
         }))
+    }
+
+    /// Subscribes to one ordered stream of all public market events for the specified assets.
+    ///
+    /// Unlike the typed subscriptions, this stream uses one receiver for orderbook snapshots,
+    /// price-change batches, trade prices, and custom market events, preserving their connection
+    /// order for local orderbook reconstruction.
+    pub fn subscribe_market_events(
+        &self,
+        asset_ids: Vec<U256>,
+    ) -> Result<impl Stream<Item = Result<WsMessage>> + use<S>> {
+        self.subscribe_market_events_with_options(asset_ids, false)
+    }
+
+    /// Subscribes to one ordered stream of market events, optionally enabling custom events.
+    pub fn subscribe_market_events_with_options(
+        &self,
+        asset_ids: Vec<U256>,
+        custom_features: bool,
+    ) -> Result<impl Stream<Item = Result<WsMessage>> + use<S>> {
+        let resources = self.inner.get_or_create_channel(ChannelType::Market)?;
+        resources
+            .subscriptions
+            .subscribe_market_with_options(asset_ids, custom_features)
     }
 
     /// Subscribes to real-time midpoint price updates for specified assets.
@@ -422,6 +457,64 @@ impl<S: State> Client<S> {
     pub fn unsubscribe_midpoints(&self, asset_ids: &[U256]) -> Result<()> {
         self.unsubscribe_orderbook(asset_ids)
     }
+
+    /// Stop all WebSocket channels and wait for their background tasks to exit.
+    ///
+    /// Shutdown is idempotent. A later subscription creates a fresh channel.
+    pub async fn shutdown(&self) {
+        if self
+            .inner
+            .shutdown_in_progress
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            loop {
+                if !self.inner.shutdown_in_progress.load(Ordering::Acquire) {
+                    return;
+                }
+                let notified = self.inner.shutdown_done.notified();
+                tokio::pin!(notified);
+                notified.as_mut().enable();
+                if !self.inner.shutdown_in_progress.load(Ordering::Acquire) {
+                    return;
+                }
+                notified.await;
+            }
+        }
+
+        let subscriptions = {
+            let _lifecycle = self
+                .inner
+                .lifecycle
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            self.inner
+                .channels
+                .iter()
+                .map(|entry| Arc::clone(&entry.value().subscriptions))
+                .collect::<Vec<_>>()
+        };
+        for subscription in subscriptions {
+            subscription.shutdown().await;
+        }
+        {
+            let _lifecycle = self
+                .inner
+                .lifecycle
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            self.inner.channels.clear();
+            self.inner
+                .shutdown_in_progress
+                .store(false, Ordering::Release);
+        }
+        self.inner.shutdown_done.notify_waiters();
+    }
+
+    /// Alias for [`Self::shutdown`].
+    pub async fn close(&self) {
+        self.shutdown().await;
+    }
 }
 
 // Methods only available for authenticated clients
@@ -568,6 +661,9 @@ impl<K: AuthKind> Client<Authenticated<K>> {
                 config,
                 base_endpoint,
                 channels,
+                lifecycle: Mutex::new(()),
+                shutdown_in_progress: AtomicBool::new(false),
+                shutdown_done: Notify::new(),
             }),
         })
     }
@@ -578,6 +674,13 @@ impl<S: State> ClientInner<S> {
         &self,
         channel_type: ChannelType,
     ) -> Result<Ref<'_, ChannelType, ChannelResources>> {
+        let _lifecycle = self
+            .lifecycle
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        if self.shutdown_in_progress.load(Ordering::Acquire) {
+            return Err(WsError::ConnectionClosed.into());
+        }
         self.channels
             .entry(channel_type)
             .or_try_insert_with(|| {
@@ -606,12 +709,9 @@ impl<S: State> ClientInner<S> {
                 // Do potentially blocking network I/O without holding the Entry lock
                 unsubscribe_fn(&subs)?;
 
-                // Atomically check and remove channel if empty
-                if let Entry::Occupied(entry) = self.channels.entry(channel_type)
-                    && !entry.get().subscriptions.has_subscriptions(channel_type)
-                {
-                    entry.remove();
-                }
+                // Keep the channel alive long enough to flush the unsubscribe request and allow
+                // a later subscription to reuse the same connection. Explicit `shutdown` owns
+                // task/socket termination; dropping the final Client also drops these resources.
                 Ok(())
             }
         }

--- a/src/clob/ws/client.rs
+++ b/src/clob/ws/client.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, PoisonError};
 
 use async_stream::try_stream;
-use dashmap::mapref::one::{Ref, RefMut};
+use dashmap::mapref::one::Ref;
 use dashmap::{DashMap, Entry};
 use futures::Stream;
 use futures::StreamExt as _;
@@ -173,8 +173,11 @@ impl<S: State> Client<S> {
         &self,
         asset_ids: Vec<U256>,
     ) -> Result<impl Stream<Item = Result<BookUpdate>> + use<S>> {
-        let resources = self.inner.get_or_create_channel(ChannelType::Market)?;
-        let stream = resources.subscriptions.subscribe_market(asset_ids)?;
+        let stream = self
+            .inner
+            .subscribe_channel(ChannelType::Market, |subscriptions| {
+                subscriptions.subscribe_market(asset_ids)
+            })?;
 
         Ok(stream.filter_map(|msg_result| async move {
             match msg_result {
@@ -202,8 +205,11 @@ impl<S: State> Client<S> {
         &self,
         asset_ids: Vec<U256>,
     ) -> Result<impl Stream<Item = Result<LastTradePrice>> + use<S>> {
-        let resources = self.inner.get_or_create_channel(ChannelType::Market)?;
-        let stream = resources.subscriptions.subscribe_market(asset_ids)?;
+        let stream = self
+            .inner
+            .subscribe_channel(ChannelType::Market, |subscriptions| {
+                subscriptions.subscribe_market(asset_ids)
+            })?;
 
         Ok(stream.filter_map(|msg_result| async move {
             match msg_result {
@@ -232,8 +238,11 @@ impl<S: State> Client<S> {
         &self,
         asset_ids: Vec<U256>,
     ) -> Result<impl Stream<Item = Result<PriceChange>> + use<S>> {
-        let resources = self.inner.get_or_create_channel(ChannelType::Market)?;
-        let stream = resources.subscriptions.subscribe_market(asset_ids)?;
+        let stream = self
+            .inner
+            .subscribe_channel(ChannelType::Market, |subscriptions| {
+                subscriptions.subscribe_market(asset_ids)
+            })?;
 
         Ok(stream.filter_map(|msg_result| async move {
             match msg_result {
@@ -261,8 +270,11 @@ impl<S: State> Client<S> {
         &self,
         asset_ids: Vec<U256>,
     ) -> Result<impl Stream<Item = Result<TickSizeChange>> + use<S>> {
-        let resources = self.inner.get_or_create_channel(ChannelType::Market)?;
-        let stream = resources.subscriptions.subscribe_market(asset_ids)?;
+        let stream = self
+            .inner
+            .subscribe_channel(ChannelType::Market, |subscriptions| {
+                subscriptions.subscribe_market(asset_ids)
+            })?;
 
         Ok(stream.filter_map(|msg_result| async move {
             match msg_result {
@@ -291,10 +303,10 @@ impl<S: State> Client<S> {
         asset_ids: Vec<U256>,
         custom_features: bool,
     ) -> Result<impl Stream<Item = Result<WsMessage>> + use<S>> {
-        let resources = self.inner.get_or_create_channel(ChannelType::Market)?;
-        resources
-            .subscriptions
-            .subscribe_market_with_options(asset_ids, custom_features)
+        self.inner
+            .subscribe_channel(ChannelType::Market, |subscriptions| {
+                subscriptions.subscribe_market_with_options(asset_ids, custom_features)
+            })
     }
 
     /// Subscribes to real-time midpoint price updates for specified assets.
@@ -344,9 +356,9 @@ impl<S: State> Client<S> {
     ) -> Result<impl Stream<Item = Result<BestBidAsk>> + use<S>> {
         let stream = self
             .inner
-            .get_or_create_channel(ChannelType::Market)?
-            .subscriptions
-            .subscribe_market_with_options(asset_ids, true)?;
+            .subscribe_channel(ChannelType::Market, |subscriptions| {
+                subscriptions.subscribe_market_with_options(asset_ids, true)
+            })?;
 
         Ok(stream.filter_map(|msg_result| async move {
             match msg_result {
@@ -366,9 +378,9 @@ impl<S: State> Client<S> {
     ) -> Result<impl Stream<Item = Result<NewMarket>> + use<S>> {
         let stream = self
             .inner
-            .get_or_create_channel(ChannelType::Market)?
-            .subscriptions
-            .subscribe_market_with_options(asset_ids, true)?;
+            .subscribe_channel(ChannelType::Market, |subscriptions| {
+                subscriptions.subscribe_market_with_options(asset_ids, true)
+            })?;
 
         Ok(stream.filter_map(|msg_result| async move {
             match msg_result {
@@ -388,9 +400,9 @@ impl<S: State> Client<S> {
     ) -> Result<impl Stream<Item = Result<MarketResolved>> + use<S>> {
         let stream = self
             .inner
-            .get_or_create_channel(ChannelType::Market)?
-            .subscriptions
-            .subscribe_market_with_options(asset_ids, true)?;
+            .subscribe_channel(ChannelType::Market, |subscriptions| {
+                subscriptions.subscribe_market_with_options(asset_ids, true)
+            })?;
 
         Ok(stream.filter_map(|msg_result| async move {
             match msg_result {
@@ -589,11 +601,10 @@ impl<K: AuthKind> Client<Authenticated<K>> {
         &self,
         markets: Vec<B256>,
     ) -> Result<impl Stream<Item = Result<WsMessage>> + use<K>> {
-        let resources = self.inner.get_or_create_channel(ChannelType::User)?;
-
-        resources
-            .subscriptions
-            .subscribe_user(markets, &self.inner.state.credentials)
+        self.inner
+            .subscribe_channel(ChannelType::User, |subscriptions| {
+                subscriptions.subscribe_user(markets, &self.inner.state.credentials)
+            })
     }
 
     /// Subscribes to real-time order status updates for the authenticated user.
@@ -663,8 +674,8 @@ impl<K: AuthKind> Client<Authenticated<K>> {
 
     /// Unsubscribe from user channel events for specific markets.
     ///
-    /// This decrements the reference count for each market. The server unsubscribe
-    /// is only sent when no other subscriptions are using those markets.
+    /// This decrements the reference count for each market. The server unsubscribe is
+    /// only sent when no other subscriptions are using that market.
     pub fn unsubscribe_user_events(&self, markets: &[B256]) -> Result<()> {
         self.inner
             .unsubscribe_and_cleanup(ChannelType::User, |subs| subs.unsubscribe_user(markets))
@@ -718,10 +729,10 @@ impl<K: AuthKind> Client<Authenticated<K>> {
 }
 
 impl<S: State> ClientInner<S> {
-    fn get_or_create_channel(
-        &self,
-        channel_type: ChannelType,
-    ) -> Result<Ref<'_, ChannelType, ChannelResources>> {
+    fn subscribe_channel<T, F>(&self, channel_type: ChannelType, subscribe: F) -> Result<T>
+    where
+        F: FnOnce(&SubscriptionManager) -> Result<T>,
+    {
         let _lifecycle = self
             .lifecycle
             .lock()
@@ -729,13 +740,14 @@ impl<S: State> ClientInner<S> {
         if self.shutdown_in_progress.load(Ordering::Acquire) {
             return Err(WsError::ConnectionClosed.into());
         }
-        self.channels
-            .entry(channel_type)
-            .or_try_insert_with(|| {
+        let subscriptions = {
+            let resources = self.channels.entry(channel_type).or_try_insert_with(|| {
                 let endpoint = channel_endpoint(&self.base_endpoint, channel_type);
                 ChannelResources::new(endpoint, self.config.clone())
-            })
-            .map(RefMut::downgrade)
+            })?;
+            Arc::clone(&resources.subscriptions)
+        };
+        subscribe(&subscriptions)
     }
 
     fn channel(&self, channel_type: ChannelType) -> Option<Ref<'_, ChannelType, ChannelResources>> {
@@ -811,4 +823,63 @@ fn channel_endpoint(base: &str, channel: ChannelType) -> String {
         ChannelType::User => "user",
     };
     format!("{trimmed}/ws/{segment}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn idle_shutdown_waits_for_subscription_registration() {
+        let client = Client::new("ws://127.0.0.1:0", Config::default()).unwrap();
+        let inner = Arc::clone(&client.inner);
+        let subscribe_inner = Arc::clone(&inner);
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+
+        let subscribe_task = tokio::task::spawn_blocking(move || {
+            subscribe_inner.subscribe_channel(ChannelType::Market, |subscriptions| {
+                entered_tx.send(()).unwrap();
+                release_rx.blocking_recv().unwrap();
+                subscriptions
+                    .subscribe_market(vec![U256::from(1)])
+                    .map(|_| ())
+            })
+        });
+        entered_rx.await.unwrap();
+        assert!(inner.lifecycle.try_lock().is_err());
+
+        // The shutdown task cannot admit idle shutdown while subscription registration owns
+        // the lifecycle lock.
+        let shutdown_client = client.clone();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let shutdown_task = tokio::spawn(async move {
+            started_tx.send(()).unwrap();
+            shutdown_client.shutdown_if_idle().await
+        });
+        started_rx.await.unwrap();
+        tokio::task::yield_now().await;
+        assert!(!shutdown_task.is_finished());
+        release_tx.send(()).unwrap();
+
+        subscribe_task.await.unwrap().unwrap();
+        assert!(!shutdown_task.await.unwrap());
+        client.shutdown().await;
+    }
+
+    #[test]
+    fn subscription_fails_after_idle_shutdown_is_admitted() {
+        let client = Client::new("ws://127.0.0.1:0", Config::default()).unwrap();
+        client
+            .inner
+            .shutdown_in_progress
+            .store(true, Ordering::Release);
+
+        let result = client
+            .inner
+            .subscribe_channel(ChannelType::Market, |_| Ok(()));
+
+        assert!(result.is_err());
+        assert!(client.inner.channels.is_empty());
+    }
 }

--- a/src/clob/ws/client.rs
+++ b/src/clob/ws/client.rs
@@ -105,6 +105,14 @@ impl Client<Unauthenticated> {
         })
     }
 
+    /// Creates an independent unauthenticated client with the same endpoint and configuration.
+    ///
+    /// The returned client shares no WebSocket channels, subscriptions, or shutdown lifecycle.
+    /// Use this when each consumer must receive its own provider initial snapshot.
+    pub fn isolated(&self) -> Result<Self> {
+        Self::new(&self.inner.base_endpoint, self.inner.config.clone())
+    }
+
     /// Authenticate this client and elevate to authenticated state.
     ///
     /// Returns an error if there are other references to this client (e.g., from clones).

--- a/src/clob/ws/client.rs
+++ b/src/clob/ws/client.rs
@@ -492,6 +492,36 @@ impl<S: State> Client<S> {
             }
         }
 
+        self.finish_shutdown().await;
+    }
+
+    /// Stop all WebSocket channels only when no subscriptions remain.
+    ///
+    /// Returns `false` without changing the client when any channel still has an active
+    /// subscription or another shutdown is already in progress. The idle check and shutdown
+    /// admission are serialized with new subscriptions.
+    pub async fn shutdown_if_idle(&self) -> bool {
+        {
+            let _lifecycle = self
+                .inner
+                .lifecycle
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            if self.subscription_count() != 0
+                || self
+                    .inner
+                    .shutdown_in_progress
+                    .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                    .is_err()
+            {
+                return false;
+            }
+        }
+        self.finish_shutdown().await;
+        true
+    }
+
+    async fn finish_shutdown(&self) {
         let subscriptions = {
             let _lifecycle = self
                 .inner

--- a/src/clob/ws/client.rs
+++ b/src/clob/ws/client.rs
@@ -423,6 +423,16 @@ impl<S: State> Client<S> {
             .sum()
     }
 
+    /// Unsubscribe from a unified market event stream for specific assets.
+    ///
+    /// This decrements the reference count added by [`Self::subscribe_market_events`].
+    pub fn unsubscribe_market_events(&self, asset_ids: &[U256]) -> Result<()> {
+        self.inner
+            .unsubscribe_and_cleanup(ChannelType::Market, |subs| {
+                subs.unsubscribe_market(asset_ids)
+            })
+    }
+
     /// Unsubscribe from orderbook updates for specific assets.
     ///
     /// This decrements the reference count for each asset. The server unsubscribe

--- a/src/clob/ws/interest.rs
+++ b/src/clob/ws/interest.rs
@@ -108,6 +108,11 @@ impl InterestTracker {
         self.interest.fetch_or(interest.bits(), Ordering::Release);
     }
 
+    /// Remove interest in specific message types.
+    pub fn remove(&self, interest: MessageInterest) {
+        self.interest.fetch_and(!interest.bits(), Ordering::Release);
+    }
+
     /// Get the current interest set.
     #[must_use]
     pub fn get(&self) -> MessageInterest {

--- a/src/clob/ws/subscription.rs
+++ b/src/clob/ws/subscription.rs
@@ -4,7 +4,7 @@
 )]
 
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
 use std::time::Instant;
 
@@ -81,6 +81,8 @@ pub struct SubscriptionManager {
     subscribed_assets: DashMap<U256, usize>,
     /// Subscribed markets with reference counts (for multiplexing)
     subscribed_markets: DashMap<B256, usize>,
+    /// Number of subscriptions that target all user markets.
+    all_markets_subscriptions: AtomicUsize,
     last_auth: Arc<RwLock<Option<Credentials>>>,
     /// Track if custom features were enabled for any market subscription
     /// (enables `best_bid_ask`, `new_market`, `market_resolved` messages)
@@ -106,6 +108,7 @@ impl SubscriptionManager {
             interest,
             subscribed_assets: DashMap::new(),
             subscribed_markets: DashMap::new(),
+            all_markets_subscriptions: AtomicUsize::new(0),
             last_auth: Arc::new(RwLock::new(None)),
             custom_features_enabled: AtomicBool::new(false),
             state_lock: Mutex::new(()),
@@ -209,10 +212,15 @@ impl SubscriptionManager {
             .unwrap_or_else(PoisonError::into_inner)
             .clone();
         if let Some(auth) = auth {
-            let markets: Vec<B256> = self.subscribed_markets.iter().map(|r| *r.key()).collect();
+            let markets: Vec<B256> = if self.all_markets_subscriptions.load(Ordering::Acquire) > 0 {
+                Vec::new()
+            } else {
+                self.subscribed_markets.iter().map(|r| *r.key()).collect()
+            };
 
             #[cfg(feature = "tracing")]
             tracing::debug!(
+                all_markets = self.all_markets_subscriptions.load(Ordering::Acquire) > 0,
                 markets_count = markets.len(),
                 "Re-subscribing to user channel"
             );
@@ -396,7 +404,6 @@ impl SubscriptionManager {
             return Err(WsError::ConnectionClosed.into());
         }
 
-        let had_interest = self.interest.is_interested(MessageInterest::USER);
         let previous_auth = self
             .last_auth
             .read()
@@ -408,26 +415,32 @@ impl SubscriptionManager {
             .write()
             .unwrap_or_else(PoisonError::into_inner) = Some(auth.clone());
 
-        // Increment refcounts and determine which markets are truly new.
-        let new_markets: Vec<B256> = markets
-            .iter()
-            .filter_map(|id| match self.subscribed_markets.entry(*id) {
-                Entry::Occupied(mut o) => {
-                    *o.get_mut() += 1;
-                    None
-                }
-                Entry::Vacant(v) => {
-                    v.insert(1);
-                    Some(*id)
-                }
-            })
-            .collect();
-
-        // Only send a request when needed (an empty market list subscribes to all markets).
-        if !markets.is_empty() && new_markets.is_empty() {
-            #[cfg(feature = "tracing")]
-            tracing::debug!("All requested markets already subscribed, multiplexing");
+        // Track all-markets subscriptions separately because they have no map key.
+        let (new_markets, should_send) = if markets.is_empty() {
+            let previous = self
+                .all_markets_subscriptions
+                .fetch_add(1, Ordering::Relaxed);
+            (Vec::new(), previous == 0)
         } else {
+            let new_markets: Vec<B256> = markets
+                .iter()
+                .filter_map(|id| match self.subscribed_markets.entry(*id) {
+                    Entry::Occupied(mut o) => {
+                        *o.get_mut() += 1;
+                        None
+                    }
+                    Entry::Vacant(v) => {
+                        v.insert(1);
+                        Some(*id)
+                    }
+                })
+                .collect();
+            let should_send = self.all_markets_subscriptions.load(Ordering::Acquire) == 0
+                && !new_markets.is_empty();
+            (new_markets, should_send)
+        };
+
+        if should_send {
             #[cfg(feature = "tracing")]
             tracing::debug!(
                 count = new_markets.len(),
@@ -436,9 +449,12 @@ impl SubscriptionManager {
             );
             let request = SubscriptionRequest::user(new_markets);
             if let Err(error) = self.connection.send_authenticated(&request, auth) {
-                self.rollback_user_subscription(&markets, had_interest, previous_auth);
+                self.rollback_user_subscription(&markets, previous_auth);
                 return Err(error);
             }
+        } else {
+            #[cfg(feature = "tracing")]
+            tracing::debug!("Requested user scope is already subscribed, multiplexing");
         }
 
         let sub_id = format!("user:{}", self.next_sub_id.fetch_add(1, Ordering::Relaxed));
@@ -498,18 +514,18 @@ impl SubscriptionManager {
         }
     }
 
-    fn rollback_user_subscription(
-        &self,
-        markets: &[B256],
-        had_interest: bool,
-        previous_auth: Option<Credentials>,
-    ) {
-        for market in markets {
-            if let Entry::Occupied(mut entry) = self.subscribed_markets.entry(*market) {
-                let refcount = entry.get_mut();
-                *refcount = refcount.saturating_sub(1);
-                if *refcount == 0 {
-                    entry.remove();
+    fn rollback_user_subscription(&self, markets: &[B256], previous_auth: Option<Credentials>) {
+        if markets.is_empty() {
+            self.all_markets_subscriptions
+                .fetch_sub(1, Ordering::Relaxed);
+        } else {
+            for market in markets {
+                if let Entry::Occupied(mut entry) = self.subscribed_markets.entry(*market) {
+                    let refcount = entry.get_mut();
+                    *refcount = refcount.saturating_sub(1);
+                    if *refcount == 0 {
+                        entry.remove();
+                    }
                 }
             }
         }
@@ -517,7 +533,9 @@ impl SubscriptionManager {
             .last_auth
             .write()
             .unwrap_or_else(PoisonError::into_inner) = previous_auth;
-        if !had_interest && self.subscribed_markets.is_empty() {
+        if self.all_markets_subscriptions.load(Ordering::Acquire) == 0
+            && self.subscribed_markets.is_empty()
+        {
             self.interest.remove(MessageInterest::USER);
         }
     }
@@ -546,7 +564,10 @@ impl SubscriptionManager {
     pub fn has_subscriptions(&self, channel: ChannelType) -> bool {
         match channel {
             ChannelType::Market => !self.subscribed_assets.is_empty(),
-            ChannelType::User => !self.subscribed_markets.is_empty(),
+            ChannelType::User => {
+                self.all_markets_subscriptions.load(Ordering::Acquire) > 0
+                    || !self.subscribed_markets.is_empty()
+            }
         }
     }
 
@@ -561,6 +582,7 @@ impl SubscriptionManager {
                 self.active_subs.clear();
                 self.subscribed_assets.clear();
                 self.subscribed_markets.clear();
+                self.all_markets_subscriptions.store(0, Ordering::Release);
                 self.custom_features_enabled.store(false, Ordering::Release);
                 *self
                     .last_auth
@@ -649,9 +671,9 @@ impl SubscriptionManager {
 
     /// Unsubscribe from user events for specific markets.
     ///
-    /// This decrements the reference count for each market. Only sends an unsubscribe
-    /// request to the server when the reference count reaches zero (no other streams
-    /// are using that market).
+    /// This decrements the reference count for each market. The server unsubscribe
+    /// is only sent when no other subscriptions are using that market. An all-markets
+    /// subscription remains active until the channel is explicitly shut down.
     pub fn unsubscribe_user(&self, markets: &[B256]) -> Result<()> {
         if markets.is_empty() {
             return Err(WsError::SubscriptionFailed(
@@ -667,21 +689,23 @@ impl SubscriptionManager {
             .unwrap_or_else(PoisonError::into_inner);
         let mut to_unsubscribe = Vec::new();
 
-        // Atomically decrement refcounts and remove markets that reach zero
-        // Using Entry API to prevent TOCTOU race between decrement and removal
-        for m in markets {
-            if let Entry::Occupied(mut entry) = self.subscribed_markets.entry(*m) {
+        // Atomically decrement refcounts and remove markets that reach zero.
+        for market in markets {
+            if let Entry::Occupied(mut entry) = self.subscribed_markets.entry(*market) {
                 let refcount = entry.get_mut();
                 *refcount = refcount.saturating_sub(1);
                 if *refcount == 0 {
                     entry.remove();
-                    to_unsubscribe.push(*m);
+                    to_unsubscribe.push(*market);
                 }
             }
         }
 
-        // Always finalize local state, even when auth or transport cannot send the unsubscribe.
-        let send_result = if to_unsubscribe.is_empty() {
+        // An all-markets wire subscription already covers every targeted scope. Sending a
+        // targeted unsubscribe here could exclude that market from the global stream.
+        let send_result = if self.all_markets_subscriptions.load(Ordering::Acquire) > 0
+            || to_unsubscribe.is_empty()
+        {
             Ok(())
         } else {
             #[cfg(feature = "tracing")]
@@ -700,17 +724,19 @@ impl SubscriptionManager {
                 .and_then(|auth| self.connection.send_authenticated(&request, &auth))
         };
 
-        // Remove active_subs entries where all markets are now unsubscribed
         self.active_subs.retain(|_, info| {
-            if let SubscriptionTarget::Markets(markets) = &info.target {
-                markets
-                    .iter()
-                    .any(|market| self.subscribed_markets.contains_key(market))
+            if let SubscriptionTarget::Markets(target_markets) = &info.target {
+                target_markets.is_empty()
+                    || target_markets
+                        .iter()
+                        .any(|market| self.subscribed_markets.contains_key(market))
             } else {
                 true
             }
         });
-        if self.subscribed_markets.is_empty() {
+        if self.all_markets_subscriptions.load(Ordering::Acquire) == 0
+            && self.subscribed_markets.is_empty()
+        {
             *self
                 .last_auth
                 .write()

--- a/src/clob/ws/subscription.rs
+++ b/src/clob/ws/subscription.rs
@@ -615,8 +615,10 @@ impl SubscriptionManager {
             }
         }
 
-        // Send unsubscribe only for zero-refcount assets
-        if !to_unsubscribe.is_empty() {
+        // Always finalize local state, even when the transport cannot send the unsubscribe.
+        let send_result = if to_unsubscribe.is_empty() {
+            Ok(())
+        } else {
             #[cfg(feature = "tracing")]
             tracing::debug!(
                 count = to_unsubscribe.len(),
@@ -624,8 +626,8 @@ impl SubscriptionManager {
                 "Unsubscribing from market assets"
             );
             let request = SubscriptionRequest::market_unsubscribe(to_unsubscribe);
-            self.connection.send(&request)?;
-        }
+            self.connection.send(&request)
+        };
 
         // Remove active_subs entries where all assets are now unsubscribed
         self.active_subs.retain(|_, info| {
@@ -642,7 +644,7 @@ impl SubscriptionManager {
             self.interest.remove(MessageInterest::MARKET);
         }
 
-        Ok(())
+        send_result
     }
 
     /// Unsubscribe from user events for specific markets.
@@ -678,8 +680,10 @@ impl SubscriptionManager {
             }
         }
 
-        // Send unsubscribe only for zero-refcount markets
-        if !to_unsubscribe.is_empty() {
+        // Always finalize local state, even when auth or transport cannot send the unsubscribe.
+        let send_result = if to_unsubscribe.is_empty() {
+            Ok(())
+        } else {
             #[cfg(feature = "tracing")]
             tracing::debug!(
                 count = to_unsubscribe.len(),
@@ -687,17 +691,14 @@ impl SubscriptionManager {
                 "Unsubscribing from user markets"
             );
 
-            // Get auth for unsubscribe request
-            let auth = self
-                .last_auth
+            let request = SubscriptionRequest::user_unsubscribe(to_unsubscribe);
+            self.last_auth
                 .read()
                 .unwrap_or_else(PoisonError::into_inner)
                 .clone()
-                .ok_or(WsError::AuthenticationFailed)?;
-
-            let request = SubscriptionRequest::user_unsubscribe(to_unsubscribe);
-            self.connection.send_authenticated(&request, &auth)?;
-        }
+                .ok_or(WsError::AuthenticationFailed.into())
+                .and_then(|auth| self.connection.send_authenticated(&request, &auth))
+        };
 
         // Remove active_subs entries where all markets are now unsubscribed
         self.active_subs.retain(|_, info| {
@@ -717,7 +718,7 @@ impl SubscriptionManager {
             self.interest.remove(MessageInterest::USER);
         }
 
-        Ok(())
+        send_result
     }
 }
 

--- a/src/clob/ws/subscription.rs
+++ b/src/clob/ws/subscription.rs
@@ -4,14 +4,15 @@
 )]
 
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, PoisonError, RwLock};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, PoisonError, RwLock};
 use std::time::Instant;
 
-use async_stream::try_stream;
+use async_stream::stream;
 use dashmap::{DashMap, Entry};
 use futures::Stream;
 use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::watch;
 
 use super::interest::{InterestTracker, MessageInterest};
 use super::types::request::SubscriptionRequest;
@@ -21,7 +22,7 @@ use crate::auth::Credentials;
 use crate::types::{B256, U256};
 use crate::ws::ConnectionManager;
 use crate::ws::WsError;
-use crate::ws::connection::ConnectionState;
+use crate::ws::connection::{ConnectionEvent, ConnectionState};
 
 /// What a subscription is targeting.
 #[non_exhaustive]
@@ -84,6 +85,12 @@ pub struct SubscriptionManager {
     /// Track if custom features were enabled for any market subscription
     /// (enables `best_bid_ask`, `new_market`, `market_resolved` messages)
     custom_features_enabled: AtomicBool,
+    /// Serialize subscription state changes so setup/send rollback is atomic.
+    state_lock: Mutex<()>,
+    next_sub_id: AtomicU64,
+    closed: AtomicBool,
+    reconnect_shutdown_tx: watch::Sender<bool>,
+    reconnect_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 impl SubscriptionManager {
@@ -101,50 +108,76 @@ impl SubscriptionManager {
             subscribed_markets: DashMap::new(),
             last_auth: Arc::new(RwLock::new(None)),
             custom_features_enabled: AtomicBool::new(false),
+            state_lock: Mutex::new(()),
+            next_sub_id: AtomicU64::new(1),
+            closed: AtomicBool::new(false),
+            reconnect_shutdown_tx: watch::channel(false).0,
+            reconnect_task: Mutex::new(None),
         }
     }
 
     /// Start the reconnection handler that re-subscribes on connection recovery.
     pub fn start_reconnection_handler(self: &Arc<Self>) {
-        let this = Arc::clone(self);
-
-        tokio::spawn(async move {
+        let weak = Arc::downgrade(self);
+        let mut shutdown_rx = self.reconnect_shutdown_tx.subscribe();
+        let handle = tokio::spawn(async move {
+            let Some(this) = weak.upgrade() else {
+                return;
+            };
             let mut state_rx = this.connection.state_receiver();
             let mut was_connected = state_rx.borrow().is_connected();
+            drop(this);
 
             loop {
-                // Wait for next state change
-                if state_rx.changed().await.is_err() {
-                    // Channel closed, connection manager is gone
-                    break;
-                }
-
-                let state = *state_rx.borrow_and_update();
-
-                match state {
-                    ConnectionState::Connected { .. } => {
-                        if was_connected {
-                            // Reconnect to subscriptions
-                            #[cfg(feature = "tracing")]
-                            tracing::debug!("WebSocket reconnected, re-establishing subscriptions");
-                            this.resubscribe_all();
+                tokio::select! {
+                    changed = shutdown_rx.changed() => {
+                        if changed.is_err() || *shutdown_rx.borrow() {
+                            break;
                         }
-                        was_connected = true;
                     }
-                    ConnectionState::Disconnected => {
-                        // Connection permanently closed
-                        break;
-                    }
-                    _ => {
-                        // Other states are no-op
+                    changed = state_rx.changed() => {
+                        if changed.is_err() {
+                            break;
+                        }
+
+                        let state = *state_rx.borrow_and_update();
+                        match state {
+                            ConnectionState::Connected { .. } => {
+                                if was_connected {
+                                    #[cfg(feature = "tracing")]
+                                    tracing::debug!("WebSocket reconnected, re-establishing subscriptions");
+                                    if let Some(this) = weak.upgrade() {
+                                        if !this.closed.load(Ordering::Acquire) {
+                                            this.resubscribe_all();
+                                        }
+                                    } else {
+                                        break;
+                                    }
+                                }
+                                was_connected = true;
+                            }
+                            ConnectionState::Disconnected => break,
+                            _ => {}
+                        }
                     }
                 }
             }
         });
+        *self
+            .reconnect_task
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) = Some(handle);
     }
 
     /// Re-send subscription requests for all tracked assets and markets.
     fn resubscribe_all(&self) {
+        let _state_guard = self
+            .state_lock
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        if self.closed.load(Ordering::Acquire) {
+            return;
+        }
         // Collect all subscribed assets
         let assets: Vec<U256> = self.subscribed_assets.iter().map(|r| *r.key()).collect();
 
@@ -222,14 +255,28 @@ impl SubscriptionManager {
             .into());
         }
 
-        self.interest.add(MessageInterest::MARKET);
+        // Register every receiver before changing state or sending the request. A provider can
+        // reply with the initial snapshot synchronously after receiving the request.
+        let mut rx = self.connection.subscribe_events();
+        let mut shutdown_rx = self.connection.shutdown_receiver();
+        let asset_ids_set: HashSet<U256> = asset_ids.iter().copied().collect();
+        let _state_guard = self
+            .state_lock
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
 
-        // Track if custom features are enabled (for re-subscription on reconnect)
-        if custom_features {
-            self.custom_features_enabled.store(true, Ordering::Relaxed);
+        if self.closed.load(Ordering::Acquire) {
+            return Err(WsError::ConnectionClosed.into());
         }
 
-        // Increment refcounts and determine which assets are truly new
+        let had_interest = self.interest.is_interested(MessageInterest::MARKET);
+        let previous_custom_features = self.custom_features_enabled.load(Ordering::Acquire);
+        self.interest.add(MessageInterest::MARKET);
+        if custom_features {
+            self.custom_features_enabled.store(true, Ordering::Release);
+        }
+
+        // Increment refcounts and determine which assets are truly new.
         let new_assets: Vec<U256> = asset_ids
             .iter()
             .filter_map(|id| match self.subscribed_assets.entry(*id) {
@@ -239,12 +286,12 @@ impl SubscriptionManager {
                 }
                 Entry::Vacant(v) => {
                     v.insert(1);
-                    Some(id.to_owned())
+                    Some(*id)
                 }
             })
             .collect();
 
-        // Only send subscription request for new assets
+        // Only send subscription requests for new assets.
         if new_assets.is_empty() {
             #[cfg(feature = "tracing")]
             tracing::debug!("All requested assets already subscribed, multiplexing");
@@ -260,67 +307,71 @@ impl SubscriptionManager {
             if custom_features {
                 request = request.with_custom_features(true);
             }
-            self.connection.send(&request)?;
+            if let Err(error) = self.connection.send(&request) {
+                self.rollback_market_subscription(
+                    &asset_ids,
+                    had_interest,
+                    previous_custom_features,
+                );
+                return Err(error);
+            }
         }
 
-        // Register subscription
         let sub_id = format!(
             "market:{}",
-            asset_ids
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>()
-                .join(",")
+            self.next_sub_id.fetch_add(1, Ordering::Relaxed)
         );
         self.active_subs.insert(
             sub_id,
             SubscriptionInfo {
-                target: SubscriptionTarget::Assets(asset_ids.clone()),
+                target: SubscriptionTarget::Assets(asset_ids),
                 created_at: Instant::now(),
             },
         );
 
-        // Create filtered stream with its own receiver
-        let mut rx = self.connection.subscribe();
-        let asset_ids_set: HashSet<U256> = asset_ids.into_iter().collect();
-
-        Ok(try_stream! {
+        Ok(stream! {
             loop {
-                match rx.recv().await {
-                    Ok(msg) => {
-                        // Filter messages by asset_id
-                        let should_yield = match &msg {
-                            WsMessage::Book(book) => asset_ids_set.contains(&book.asset_id),
-                            WsMessage::PriceChange(price) => {
-                                price
+                tokio::select! {
+                    result = rx.recv() => match result {
+                        Ok(ConnectionEvent::Message(msg)) => {
+                            let should_yield = match &msg {
+                                WsMessage::Book(book) => asset_ids_set.contains(&book.asset_id),
+                                WsMessage::PriceChange(price) => price
                                     .price_changes
                                     .iter()
-                                    .any(|pc| asset_ids_set.contains(&pc.asset_id))
-                            },
-                            WsMessage::LastTradePrice(ltp) => asset_ids_set.contains(&ltp.asset_id),
-                            WsMessage::TickSizeChange(tsc) => asset_ids_set.contains(&tsc.asset_id),
-                            WsMessage::BestBidAsk(bba) => asset_ids_set.contains(&bba.asset_id),
-                            WsMessage::NewMarket(nm) => {
-                                nm.asset_ids.iter().any(|id| asset_ids_set.contains(id))
-                            },
-                            WsMessage::MarketResolved(mr) => {
-                                mr.asset_ids.iter().any(|id| asset_ids_set.contains(id))
-                            },
-                            _ => false,
-                        };
+                                    .any(|pc| asset_ids_set.contains(&pc.asset_id)),
+                                WsMessage::LastTradePrice(ltp) => asset_ids_set.contains(&ltp.asset_id),
+                                WsMessage::TickSizeChange(tsc) => asset_ids_set.contains(&tsc.asset_id),
+                                WsMessage::BestBidAsk(bba) => asset_ids_set.contains(&bba.asset_id),
+                                WsMessage::NewMarket(nm) => nm
+                                    .asset_ids
+                                    .iter()
+                                    .any(|id| asset_ids_set.contains(id)),
+                                WsMessage::MarketResolved(mr) => mr
+                                    .asset_ids
+                                    .iter()
+                                    .any(|id| asset_ids_set.contains(id)),
+                                _ => false,
+                            };
 
-                        if should_yield {
-                            yield msg
+                            if should_yield {
+                                yield Ok(msg);
+                            }
                         }
-                    }
-                    Err(RecvError::Lagged(n)) => {
-                        #[cfg(not(feature = "tracing"))]
-                        let _ = n;
-                        #[cfg(feature = "tracing")]
-                        tracing::warn!("Subscription lagged, missed {n} messages — continuing");
-                    }
-                    Err(RecvError::Closed) => {
-                        break;
+                        Ok(ConnectionEvent::ParseError(error)) => {
+                            yield Err(WsError::InvalidMessage(error.to_string()).into());
+                            break;
+                        }
+                        Err(RecvError::Lagged(n)) => {
+                            yield Err(WsError::Lagged(n).into());
+                            break;
+                        }
+                        Err(RecvError::Closed) => break,
+                    },
+                    changed = shutdown_rx.changed() => {
+                        if changed.is_err() || *shutdown_rx.borrow() {
+                            break;
+                        }
                     }
                 }
             }
@@ -333,31 +384,46 @@ impl SubscriptionManager {
         markets: Vec<B256>,
         auth: &Credentials,
     ) -> Result<impl Stream<Item = Result<WsMessage>> + use<>> {
-        self.interest.add(MessageInterest::USER);
+        // Register every receiver before changing state or sending the request.
+        let mut rx = self.connection.subscribe_events();
+        let mut shutdown_rx = self.connection.shutdown_receiver();
+        let _state_guard = self
+            .state_lock
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
 
-        // Store auth for re-subscription on reconnect.
-        // We can recover from poisoned lock because Option<Credentials> has no inconsistent intermediate state.
+        if self.closed.load(Ordering::Acquire) {
+            return Err(WsError::ConnectionClosed.into());
+        }
+
+        let had_interest = self.interest.is_interested(MessageInterest::USER);
+        let previous_auth = self
+            .last_auth
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone();
+        self.interest.add(MessageInterest::USER);
         *self
             .last_auth
             .write()
             .unwrap_or_else(PoisonError::into_inner) = Some(auth.clone());
 
-        // Increment refcounts and determine which markets are truly new
+        // Increment refcounts and determine which markets are truly new.
         let new_markets: Vec<B256> = markets
             .iter()
-            .filter_map(|id| match self.subscribed_markets.entry(id.to_owned()) {
+            .filter_map(|id| match self.subscribed_markets.entry(*id) {
                 Entry::Occupied(mut o) => {
                     *o.get_mut() += 1;
                     None
                 }
                 Entry::Vacant(v) => {
                     v.insert(1);
-                    Some(id.to_owned())
+                    Some(*id)
                 }
             })
             .collect();
 
-        // Only send subscription request for new markets (or if subscribing to all)
+        // Only send a request when needed (an empty market list subscribes to all markets).
         if !markets.is_empty() && new_markets.is_empty() {
             #[cfg(feature = "tracing")]
             tracing::debug!("All requested markets already subscribed, multiplexing");
@@ -369,18 +435,13 @@ impl SubscriptionManager {
                 "Subscribing to user channel"
             );
             let request = SubscriptionRequest::user(new_markets);
-            self.connection.send_authenticated(&request, auth)?;
+            if let Err(error) = self.connection.send_authenticated(&request, auth) {
+                self.rollback_user_subscription(&markets, had_interest, previous_auth);
+                return Err(error);
+            }
         }
 
-        // Register subscription
-        let sub_id = format!(
-            "user:{}",
-            markets
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>()
-                .join(",")
-        );
+        let sub_id = format!("user:{}", self.next_sub_id.fetch_add(1, Ordering::Relaxed));
         self.active_subs.insert(
             sub_id,
             SubscriptionInfo {
@@ -389,29 +450,76 @@ impl SubscriptionManager {
             },
         );
 
-        // Create stream for user messages
-        let mut rx = self.connection.subscribe();
-
-        Ok(try_stream! {
+        Ok(stream! {
             loop {
-                match rx.recv().await {
-                    Ok(msg) => {
-                        if msg.is_user() {
-                            yield msg;
+                tokio::select! {
+                    result = rx.recv() => match result {
+                        Ok(ConnectionEvent::Message(msg)) if msg.is_user() => yield Ok(msg),
+                        Ok(ConnectionEvent::Message(_)) => {},
+                        Ok(ConnectionEvent::ParseError(error)) => {
+                            yield Err(WsError::InvalidMessage(error.to_string()).into());
+                            break;
                         }
-                    }
-                    Err(RecvError::Lagged(n)) => {
-                        #[cfg(not(feature = "tracing"))]
-                        let _ = n;
-                        #[cfg(feature = "tracing")]
-                        tracing::warn!("Subscription lagged, missed {n} messages — continuing");
-                    }
-                    Err(RecvError::Closed) => {
-                        break;
+                        Err(RecvError::Lagged(n)) => {
+                            yield Err(WsError::Lagged(n).into());
+                            break;
+                        }
+                        Err(RecvError::Closed) => break,
+                    },
+                    changed = shutdown_rx.changed() => {
+                        if changed.is_err() || *shutdown_rx.borrow() {
+                            break;
+                        }
                     }
                 }
             }
         })
+    }
+
+    fn rollback_market_subscription(
+        &self,
+        asset_ids: &[U256],
+        had_interest: bool,
+        previous_custom_features: bool,
+    ) {
+        for id in asset_ids {
+            if let Entry::Occupied(mut entry) = self.subscribed_assets.entry(*id) {
+                let refcount = entry.get_mut();
+                *refcount = refcount.saturating_sub(1);
+                if *refcount == 0 {
+                    entry.remove();
+                }
+            }
+        }
+        self.custom_features_enabled
+            .store(previous_custom_features, Ordering::Release);
+        if !had_interest && self.subscribed_assets.is_empty() {
+            self.interest.remove(MessageInterest::MARKET);
+        }
+    }
+
+    fn rollback_user_subscription(
+        &self,
+        markets: &[B256],
+        had_interest: bool,
+        previous_auth: Option<Credentials>,
+    ) {
+        for market in markets {
+            if let Entry::Occupied(mut entry) = self.subscribed_markets.entry(*market) {
+                let refcount = entry.get_mut();
+                *refcount = refcount.saturating_sub(1);
+                if *refcount == 0 {
+                    entry.remove();
+                }
+            }
+        }
+        *self
+            .last_auth
+            .write()
+            .unwrap_or_else(PoisonError::into_inner) = previous_auth;
+        if !had_interest && self.subscribed_markets.is_empty() {
+            self.interest.remove(MessageInterest::USER);
+        }
     }
 
     /// Get information about all active subscriptions.
@@ -442,6 +550,38 @@ impl SubscriptionManager {
         }
     }
 
+    /// Stop reconnection and connection tasks and clear all subscriptions.
+    pub async fn shutdown(&self) {
+        let handle = {
+            let _state_guard = self
+                .state_lock
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            if !self.closed.swap(true, Ordering::AcqRel) {
+                self.active_subs.clear();
+                self.subscribed_assets.clear();
+                self.subscribed_markets.clear();
+                self.custom_features_enabled.store(false, Ordering::Release);
+                *self
+                    .last_auth
+                    .write()
+                    .unwrap_or_else(PoisonError::into_inner) = None;
+                self.interest
+                    .remove(MessageInterest::MARKET | MessageInterest::USER);
+                let _: std::result::Result<(), _> = self.reconnect_shutdown_tx.send(true);
+            }
+            self.reconnect_task
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .take()
+        };
+
+        if let Some(handle) = handle {
+            let _: std::result::Result<(), _> = handle.await;
+        }
+        self.connection.shutdown().await;
+    }
+
     /// Unsubscribe from market data for specific assets.
     ///
     /// This decrements the reference count for each asset. Only sends an unsubscribe
@@ -456,6 +596,10 @@ impl SubscriptionManager {
             .into());
         }
 
+        let _state_guard = self
+            .state_lock
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
         let mut to_unsubscribe = Vec::new();
 
         // Atomically decrement refcounts and remove assets that reach zero
@@ -486,14 +630,17 @@ impl SubscriptionManager {
         // Remove active_subs entries where all assets are now unsubscribed
         self.active_subs.retain(|_, info| {
             if let SubscriptionTarget::Assets(assets) = &info.target {
-                // Keep entry only if at least one asset is still subscribed
                 assets
                     .iter()
-                    .any(|a| self.subscribed_assets.contains_key(a))
+                    .any(|asset| self.subscribed_assets.contains_key(asset))
             } else {
-                true // Keep non-market subscriptions
+                true
             }
         });
+        if self.subscribed_assets.is_empty() {
+            self.custom_features_enabled.store(false, Ordering::Release);
+            self.interest.remove(MessageInterest::MARKET);
+        }
 
         Ok(())
     }
@@ -512,6 +659,10 @@ impl SubscriptionManager {
             .into());
         }
 
+        let _state_guard = self
+            .state_lock
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
         let mut to_unsubscribe = Vec::new();
 
         // Atomically decrement refcounts and remove markets that reach zero
@@ -551,15 +702,27 @@ impl SubscriptionManager {
         // Remove active_subs entries where all markets are now unsubscribed
         self.active_subs.retain(|_, info| {
             if let SubscriptionTarget::Markets(markets) = &info.target {
-                // Keep entry only if at least one market is still subscribed
                 markets
                     .iter()
-                    .any(|m| self.subscribed_markets.contains_key(m))
+                    .any(|market| self.subscribed_markets.contains_key(market))
             } else {
-                true // Keep non-user subscriptions
+                true
             }
         });
+        if self.subscribed_markets.is_empty() {
+            *self
+                .last_auth
+                .write()
+                .unwrap_or_else(PoisonError::into_inner) = None;
+            self.interest.remove(MessageInterest::USER);
+        }
 
         Ok(())
+    }
+}
+
+impl Drop for SubscriptionManager {
+    fn drop(&mut self) {
+        let _: std::result::Result<(), _> = self.reconnect_shutdown_tx.send(true);
     }
 }

--- a/src/clob/ws/types/response.rs
+++ b/src/clob/ws/types/response.rs
@@ -1,15 +1,12 @@
-use bon::Builder;
-use serde::Deserialize;
-use serde_json::Value;
-use serde_with::{DefaultOnNull, DisplayFromStr, NoneAsEmptyString, serde_as};
-#[cfg(feature = "tracing")]
-use tracing::warn;
-
 use crate::auth::ApiKey;
 use crate::clob::types::{OrderStatusType, Side, TraderSide};
 use crate::clob::ws::interest::MessageInterest;
 use crate::error::Kind;
 use crate::types::{B256, Decimal, U256};
+use bon::Builder;
+use serde::Deserialize;
+use serde_json::Value;
+use serde_with::{DefaultOnNull, DisplayFromStr, NoneAsEmptyString, serde_as};
 
 /// Top-level WebSocket message wrapper.
 ///
@@ -490,8 +487,8 @@ pub struct MidpointUpdate {
 /// extracted to check interest before final deserialization via `from_value()`.
 /// This avoids re-parsing the JSON text twice.
 ///
-/// For arrays, messages are processed one-by-one with tolerant parsing: unknown or invalid
-/// event types are skipped rather than causing the entire batch to fail.
+/// For arrays, uninterested event types are skipped, while a malformed interested event fails
+/// the whole batch so consumers cannot silently retain stale state.
 pub fn parse_if_interested(
     bytes: &[u8],
     interest: &MessageInterest,
@@ -515,28 +512,27 @@ pub fn parse_if_interested(
                 }
             }
         }
-        Value::Array(arr) => Ok(arr
-            .iter()
-            .filter_map(|elem| {
-                let obj = elem.as_object()?;
-                let event_type = obj.get("event_type").and_then(Value::as_str)?;
+        Value::Array(arr) => {
+            let mut messages = Vec::with_capacity(arr.len());
+            for elem in arr {
+                let Some(obj) = elem.as_object() else {
+                    continue;
+                };
+                let Some(event_type) = obj.get("event_type").and_then(Value::as_str) else {
+                    continue;
+                };
 
                 if !interest.is_interested_in_event(event_type) {
-                    return None;
+                    continue;
                 }
 
-                serde_json::from_value(elem.clone())
-                    .inspect_err(|err| {
-                        #[cfg(feature = "tracing")]
-                        warn!(
-                            event_type = %event_type,
-                            error = %err,
-                            "Skipping unknown/invalid WS event in batch"
-                        );
-                    })
-                    .ok()
-            })
-            .collect()),
+                // Do not silently discard malformed events in an interested batch.
+                // A typed consumer must be able to fail closed rather than retain a
+                // book after missing one of its deltas.
+                messages.push(serde_json::from_value(elem.clone())?);
+            }
+            Ok(messages)
+        }
         _ => Ok(vec![]),
     }
 }

--- a/src/rtds/subscription.rs
+++ b/src/rtds/subscription.rs
@@ -16,8 +16,8 @@ use super::types::request::{Subscription, SubscriptionRequest};
 use super::types::response::{RtdsMessage, parse_messages};
 use crate::Result;
 use crate::auth::Credentials;
-use crate::ws::ConnectionManager;
-use crate::ws::connection::ConnectionState;
+use crate::ws::connection::{ConnectionEvent, ConnectionState};
+use crate::ws::{ConnectionManager, WsError};
 
 #[non_exhaustive]
 #[derive(Clone)]
@@ -178,6 +178,7 @@ impl SubscriptionManager {
         subscription: Subscription,
     ) -> Result<impl Stream<Item = Result<RtdsMessage>>> {
         let topic_type = TopicType::new(subscription.topic.clone(), subscription.msg_type.clone());
+        let mut rx = self.connection.subscribe_events();
 
         // Store auth for re-subscription on reconnect.
         // We can recover from poisoned lock because Option<Credentials> has no inconsistent intermediate state.
@@ -230,15 +231,13 @@ impl SubscriptionManager {
             },
         );
 
-        // Create filtered stream with its own receiver
-        let mut rx = self.connection.subscribe();
         let target_topic = topic_type.topic;
         let target_type = topic_type.msg_type;
 
         Ok(try_stream! {
             loop {
                 match rx.recv().await {
-                    Ok(msg) => {
+                    Ok(ConnectionEvent::Message(msg)) => {
                         // Filter messages by topic and type
                         let matches_topic = msg.topic == target_topic;
                         let matches_type = target_type == "*" || msg.msg_type == target_type;
@@ -247,11 +246,11 @@ impl SubscriptionManager {
                             yield msg;
                         }
                     }
+                    Ok(ConnectionEvent::ParseError(error)) => {
+                        Err(WsError::InvalidMessage(error.to_string()))?;
+                    }
                     Err(RecvError::Lagged(n)) => {
-                        #[cfg(not(feature = "tracing"))]
-                        let _ = n;
-                        #[cfg(feature = "tracing")]
-                        tracing::warn!("RTDS subscription lagged, missed {n} messages — continuing");
+                        Err(WsError::Lagged(n))?;
                     }
                     Err(RecvError::Closed) => {
                         break;

--- a/src/rtds/types/response.rs
+++ b/src/rtds/types/response.rs
@@ -167,13 +167,22 @@ pub fn parse_messages(bytes: &[u8]) -> crate::Result<Vec<RtdsMessage>> {
         return Ok(Vec::new());
     }
 
-    // Try parsing as array first, fall back to single object
-    if trimmed.first() == Some(&b'[') {
-        Ok(serde_json::from_slice(trimmed)?)
+    let values = if trimmed.first() == Some(&b'[') {
+        serde_json::from_slice::<Vec<serde_json::Value>>(trimmed)?
     } else {
-        let msg: RtdsMessage = serde_json::from_slice(trimmed)?;
-        Ok(vec![msg])
-    }
+        vec![serde_json::from_slice::<serde_json::Value>(trimmed)?]
+    };
+    values
+        .into_iter()
+        .filter_map(|value| {
+            let is_control = value.as_object().is_some_and(|object| {
+                !object.contains_key("topic")
+                    && !object.contains_key("type")
+                    && !object.contains_key("payload")
+            });
+            (!is_control).then(|| serde_json::from_value(value).map_err(Into::into))
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -287,6 +296,18 @@ mod tests {
         let msgs = parse_messages(json.as_bytes()).unwrap();
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].topic, "crypto_prices");
+    }
+
+    #[test]
+    fn parse_control_ack_without_topic_is_ignored() {
+        let json = br#"{"status":"success","message":"subscribed","connection_id":"abc"}"#;
+        assert!(parse_messages(json).unwrap().is_empty());
+    }
+
+    #[test]
+    fn malformed_update_without_topic_still_fails() {
+        let json = br#"{"type":"update","payload":{"symbol":"btc/usd"}}"#;
+        assert!(parse_messages(json).is_err());
     }
 
     #[test]

--- a/src/ws/connection.rs
+++ b/src/ws/connection.rs
@@ -29,7 +29,7 @@ use crate::{Result, error::Error};
 type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
 /// Broadcast channel capacity for incoming messages.
-const BROADCAST_CAPACITY: usize = 1024;
+const BROADCAST_CAPACITY: usize = 16_384;
 
 #[derive(Debug, Clone)]
 pub(crate) enum ConnectionEvent<M> {

--- a/src/ws/connection.rs
+++ b/src/ws/connection.rs
@@ -5,6 +5,8 @@
 
 use std::fmt::Debug;
 use std::marker::PhantomData;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, PoisonError};
 use std::time::Instant;
 
 use backoff::backoff::Backoff as _;
@@ -12,7 +14,7 @@ use futures::{SinkExt as _, StreamExt as _};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tokio::net::TcpStream;
-use tokio::sync::{broadcast, mpsc, watch};
+use tokio::sync::{Notify, broadcast, mpsc, watch};
 use tokio::time::{interval, sleep, timeout};
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async, tungstenite::Message};
 
@@ -28,6 +30,27 @@ type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
 /// Broadcast channel capacity for incoming messages.
 const BROADCAST_CAPACITY: usize = 1024;
+
+#[derive(Debug, Clone)]
+pub(crate) enum ConnectionEvent<M> {
+    Message(M),
+    ParseError(Arc<str>),
+}
+
+struct ConnectionTask {
+    shutdown_tx: watch::Sender<bool>,
+    requested: AtomicBool,
+    handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    complete: Arc<AtomicBool>,
+    done: Arc<Notify>,
+}
+
+impl ConnectionTask {
+    fn request_shutdown(&self) {
+        self.requested.store(true, Ordering::Release);
+        let _: std::result::Result<(), _> = self.shutdown_tx.send(true);
+    }
+}
 
 /// Connection state tracking.
 #[non_exhaustive]
@@ -100,6 +123,9 @@ where
     sender_tx: mpsc::UnboundedSender<String>,
     /// Broadcast sender for incoming messages
     broadcast_tx: broadcast::Sender<M>,
+    event_tx: broadcast::Sender<ConnectionEvent<M>>,
+    /// Connection task lifecycle and cancellation state
+    task: Arc<ConnectionTask>,
     /// Phantom data for unused type parameters
     _phantom: PhantomData<P>,
 }
@@ -117,52 +143,77 @@ where
     pub fn new(endpoint: String, config: Config, parser: P) -> Result<Self> {
         let (sender_tx, sender_rx) = mpsc::unbounded_channel();
         let (broadcast_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
+        let (event_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
         let (state_tx, state_rx) = watch::channel(ConnectionState::Disconnected);
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let task = Arc::new(ConnectionTask {
+            shutdown_tx,
+            requested: AtomicBool::new(false),
+            handle: Mutex::new(None),
+            complete: Arc::new(AtomicBool::new(false)),
+            done: Arc::new(Notify::new()),
+        });
 
         // Spawn connection task
         let connection_config = config;
         let connection_endpoint = endpoint;
         let broadcast_tx_clone = broadcast_tx.clone();
+        let event_tx_clone = event_tx.clone();
         let state_tx_clone = state_tx.clone();
+        let complete = Arc::clone(&task.complete);
+        let done = Arc::clone(&task.done);
 
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             Self::connection_loop(
                 connection_endpoint,
                 connection_config,
                 sender_rx,
                 broadcast_tx_clone,
+                event_tx_clone,
                 parser,
                 state_tx_clone,
+                shutdown_rx,
             )
             .await;
+            complete.store(true, Ordering::Release);
+            done.notify_waiters();
         });
+        *task.handle.lock().unwrap_or_else(PoisonError::into_inner) = Some(handle);
 
         Ok(Self {
             state_tx,
             state_rx,
             sender_tx,
             broadcast_tx,
+            event_tx,
+            task,
             _phantom: PhantomData,
         })
     }
 
     /// Main connection loop with automatic reconnection.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "the connection task owns all transport channels and lifecycle signals"
+    )]
     async fn connection_loop(
         endpoint: String,
         config: Config,
         mut sender_rx: mpsc::UnboundedReceiver<String>,
         broadcast_tx: broadcast::Sender<M>,
+        event_tx: broadcast::Sender<ConnectionEvent<M>>,
         parser: P,
         state_tx: watch::Sender<ConnectionState>,
+        mut shutdown_rx: watch::Receiver<bool>,
     ) {
         let mut attempt = 0_u32;
         let mut backoff: backoff::ExponentialBackoff = config.reconnect.clone().into();
 
         loop {
-            // Check if ConnectionManager was dropped (all sender_tx instances gone)
-            if sender_rx.is_closed() {
+            // Check if ConnectionManager was dropped or explicitly shut down.
+            if sender_rx.is_closed() || *shutdown_rx.borrow() {
                 #[cfg(feature = "tracing")]
-                tracing::debug!("Sender channel closed, stopping connection loop");
+                tracing::debug!("Connection task stopping");
                 _ = state_tx.send(ConnectionState::Disconnected);
                 break;
             }
@@ -171,8 +222,20 @@ where
 
             _ = state_tx.send(ConnectionState::Connecting);
 
-            // Attempt connection
-            match connect_async(&endpoint).await {
+            // Attempt connection, but make requested shutdown cancellable even while
+            // the underlying connect future is waiting on DNS/TCP/TLS.
+            let connect_result = tokio::select! {
+                changed = shutdown_rx.changed() => {
+                    if changed.is_err() || *shutdown_rx.borrow() {
+                        _ = state_tx.send(ConnectionState::Disconnected);
+                        break;
+                    }
+                    continue;
+                }
+                result = connect_async(&endpoint) => result,
+            };
+
+            match connect_result {
                 Ok((ws_stream, _)) => {
                     attempt = 0;
                     backoff.reset();
@@ -185,9 +248,11 @@ where
                         ws_stream,
                         &mut sender_rx,
                         &broadcast_tx,
+                        &event_tx,
                         state_rx,
                         config.clone(),
                         &parser,
+                        shutdown_rx.clone(),
                     )
                     .await
                     {
@@ -207,6 +272,12 @@ where
                 }
             }
 
+            // A requested shutdown never transitions into reconnecting.
+            if *shutdown_rx.borrow() || sender_rx.is_closed() {
+                _ = state_tx.send(ConnectionState::Disconnected);
+                break;
+            }
+
             // Check if we should stop reconnecting
             if let Some(max) = config.reconnect.max_attempts
                 && attempt >= max
@@ -219,19 +290,33 @@ where
             _ = state_tx.send(ConnectionState::Reconnecting { attempt });
 
             if let Some(duration) = backoff.next_backoff() {
-                sleep(duration).await;
+                tokio::select! {
+                    changed = shutdown_rx.changed() => {
+                        if changed.is_err() || *shutdown_rx.borrow() {
+                            _ = state_tx.send(ConnectionState::Disconnected);
+                            break;
+                        }
+                    }
+                    () = sleep(duration) => {}
+                }
             }
         }
     }
 
     /// Handle an active WebSocket connection.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "one socket loop selects over transport, parser, heartbeat, and shutdown channels"
+    )]
     async fn handle_connection(
         ws_stream: WsStream,
         sender_rx: &mut mpsc::UnboundedReceiver<String>,
         broadcast_tx: &broadcast::Sender<M>,
+        event_tx: &broadcast::Sender<ConnectionEvent<M>>,
         state_rx: watch::Receiver<ConnectionState>,
         config: Config,
         parser: &P,
+        mut shutdown_rx: watch::Receiver<bool>,
     ) -> Result<()> {
         let (mut write, mut read) = ws_stream.split();
 
@@ -261,14 +346,15 @@ where
                                     for message in messages {
                                         #[cfg(feature = "tracing")]
                                         tracing::trace!(?message, "Parsed WebSocket message");
-                                        _ = broadcast_tx.send(message);
+                                        _ = broadcast_tx.send(message.clone());
+                                        _ = event_tx.send(ConnectionEvent::Message(message));
                                     }
                                 }
                                 Err(e) => {
                                     #[cfg(feature = "tracing")]
                                     tracing::warn!(%text, error = %e, "Failed to parse WebSocket message");
-                                    #[cfg(not(feature = "tracing"))]
-                                    let _: (&_, &_) = (&text, &e);
+                                    let error = Arc::<str>::from(e.to_string());
+                                    _ = event_tx.send(ConnectionEvent::ParseError(error));
                                 }
                             }
                         }
@@ -294,15 +380,44 @@ where
 
                 // Handle outgoing messages from subscriptions
                 Some(text) = sender_rx.recv() => {
-                    if write.send(Message::Text(text.into())).await.is_err() {
+                    let sent = tokio::select! {
+                        result = write.send(Message::Text(text.into())) => result,
+                        changed = shutdown_rx.changed() => {
+                            if changed.is_err() || *shutdown_rx.borrow() {
+                                heartbeat_handle.abort();
+                                return Ok(());
+                            }
+                            continue;
+                        }
+                    };
+                    if sent.is_err() {
                         break;
                     }
                 }
 
                 // Handle PING requests from heartbeat loop
                 Some(()) = ping_rx.recv() => {
-                    if write.send(Message::Text("PING".into())).await.is_err() {
+                    let sent = tokio::select! {
+                        result = write.send(Message::Text("PING".into())) => result,
+                        changed = shutdown_rx.changed() => {
+                            if changed.is_err() || *shutdown_rx.borrow() {
+                                heartbeat_handle.abort();
+                                return Ok(());
+                            }
+                            continue;
+                        }
+                    };
+                    if sent.is_err() {
                         break;
+                    }
+                }
+
+                // Requested shutdown is distinct from an unexpected disconnect: close
+                // this socket without entering the reconnect path.
+                changed = shutdown_rx.changed() => {
+                    if changed.is_err() || *shutdown_rx.borrow() {
+                        heartbeat_handle.abort();
+                        return Ok(());
                     }
                 }
 
@@ -380,6 +495,9 @@ where
 
     /// Send a subscription request to the WebSocket server.
     pub fn send<R: Serialize>(&self, request: &R) -> Result<()> {
+        if self.task.requested.load(Ordering::Acquire) {
+            return Err(WsError::ConnectionClosed.into());
+        }
         let json = serde_json::to_string(request)?;
         self.sender_tx
             .send(json)
@@ -393,6 +511,9 @@ where
         request: &R,
         credentials: &Credentials,
     ) -> Result<()> {
+        if self.task.requested.load(Ordering::Acquire) {
+            return Err(WsError::ConnectionClosed.into());
+        }
         let json = request.as_authenticated(credentials)?;
         self.sender_tx
             .send(json)
@@ -413,6 +534,44 @@ where
     #[must_use]
     pub fn subscribe(&self) -> broadcast::Receiver<M> {
         self.broadcast_tx.subscribe()
+    }
+
+    pub(crate) fn subscribe_events(&self) -> broadcast::Receiver<ConnectionEvent<M>> {
+        self.event_tx.subscribe()
+    }
+
+    /// Subscribe to requested shutdown notifications.
+    #[must_use]
+    pub fn shutdown_receiver(&self) -> watch::Receiver<bool> {
+        self.task.shutdown_tx.subscribe()
+    }
+
+    /// Stop the connection and wait for its background task to exit.
+    pub async fn shutdown(&self) {
+        self.task.request_shutdown();
+
+        loop {
+            if self.task.complete.load(Ordering::Acquire) {
+                return;
+            }
+            let notified = self.task.done.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            if self.task.complete.load(Ordering::Acquire) {
+                return;
+            }
+            let handle = self
+                .task
+                .handle
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .take();
+            if let Some(handle) = handle {
+                let _: std::result::Result<(), _> = handle.await;
+                return;
+            }
+            notified.await;
+        }
     }
 
     /// Subscribe to connection state changes.

--- a/src/ws/error.rs
+++ b/src/ws/error.rs
@@ -24,6 +24,8 @@ pub enum WsError {
     Timeout,
     /// Received an invalid or unexpected message
     InvalidMessage(String),
+    /// A subscriber fell behind and missed messages in the broadcast buffer
+    Lagged(u64),
 }
 
 impl fmt::Display for WsError {
@@ -36,6 +38,10 @@ impl fmt::Display for WsError {
             Self::ConnectionClosed => write!(f, "WebSocket connection closed"),
             Self::Timeout => write!(f, "WebSocket operation timed out"),
             Self::InvalidMessage(msg) => write!(f, "Invalid WebSocket message: {msg}"),
+            Self::Lagged(count) => write!(
+                f,
+                "WebSocket subscription lagged and missed {count} messages"
+            ),
         }
     }
 }

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures_util::{SinkExt as _, StreamExt as _};
-use polymarket_client_sdk_v2::clob::ws::{Client, WsMessage};
+use polymarket_client_sdk_v2::clob::ws::{ChannelType, Client, WsMessage};
 use polymarket_client_sdk_v2::types::{Address, U256, b256};
 use polymarket_client_sdk_v2::ws::config::Config;
 use serde_json::json;
@@ -333,6 +333,113 @@ mod market_channel {
         assert_eq!(price.price_changes[0].size, Some(dec!(200)));
         assert_eq!(price.price_changes[0].best_bid, Some(dec!(0.5)));
         assert_eq!(price.price_changes[0].best_ask, Some(dec!(1)));
+    }
+
+    #[tokio::test]
+    async fn subscribe_market_events_preserves_snapshot_delta_order() {
+        let mut server = MockWsServer::start().await;
+        let endpoint = server.ws_url("/ws/market");
+        let client = Client::new(&endpoint, Config::default()).unwrap();
+        let asset_id = payloads::asset_id();
+        let stream = client.subscribe_market_events(vec![asset_id]).unwrap();
+        let mut stream = Box::pin(stream);
+
+        let _: Option<String> = server.recv_subscription().await;
+        server.send(&payloads::book().to_string());
+        server.send(&payloads::price_change_batch(asset_id).to_string());
+
+        let first = timeout(Duration::from_secs(2), stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let second = timeout(Duration::from_secs(2), stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert!(matches!(first, WsMessage::Book(_)));
+        assert!(matches!(second, WsMessage::PriceChange(_)));
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn unknown_market_side_is_surfaced_instead_of_dropped() {
+        let mut server = MockWsServer::start().await;
+        let endpoint = server.ws_url("/ws/market");
+        let client = Client::new(&endpoint, Config::default()).unwrap();
+        let asset_id = payloads::asset_id();
+        let stream = client.subscribe_market_events(vec![asset_id]).unwrap();
+        let mut stream = Box::pin(stream);
+
+        let _: Option<String> = server.recv_subscription().await;
+        let mut invalid = payloads::price_change_batch(asset_id);
+        invalid["price_changes"][0]["side"] = json!("HOLD");
+        server.send(&invalid.to_string());
+
+        let result = timeout(Duration::from_secs(2), stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let WsMessage::PriceChange(change) = result else {
+            panic!("expected price change");
+        };
+        assert_eq!(
+            change.price_changes[0].side,
+            polymarket_client_sdk_v2::clob::types::Side::Unknown
+        );
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn malformed_interested_market_event_fails_closed() {
+        let mut server = MockWsServer::start().await;
+        let endpoint = server.ws_url("/ws/market");
+        let client = Client::new(&endpoint, Config::default()).unwrap();
+        let asset_id = payloads::asset_id();
+        let stream = client.subscribe_market_events(vec![asset_id]).unwrap();
+        let mut stream = Box::pin(stream);
+
+        let _: Option<String> = server.recv_subscription().await;
+        let mut invalid = payloads::price_change_batch(asset_id);
+        invalid["price_changes"][0]["side"] = json!({"invalid": true});
+        server.send(&invalid.to_string());
+
+        let result = timeout(Duration::from_secs(2), stream.next())
+            .await
+            .unwrap()
+            .unwrap();
+        drop(result.unwrap_err());
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn shutdown_is_idempotent_and_disconnects_the_channel() {
+        let mut server = MockWsServer::start().await;
+        let endpoint = server.ws_url("/ws/market");
+        let client = Client::new(&endpoint, Config::default()).unwrap();
+        let _stream = client
+            .subscribe_market_events(vec![payloads::asset_id()])
+            .unwrap();
+        let _: Option<String> = server.recv_subscription().await;
+        assert!(client.is_connected(ChannelType::Market));
+
+        let first = client.shutdown();
+        let second = client.shutdown();
+        timeout(Duration::from_secs(2), async move {
+            tokio::join!(first, second);
+        })
+        .await
+        .unwrap();
+        assert!(!client.is_connected(ChannelType::Market));
+
+        let _new_stream = client
+            .subscribe_market_events(vec![payloads::asset_id()])
+            .unwrap();
+        let request = server.recv_subscription().await.unwrap();
+        assert!(request.contains("\"type\":\"market\""));
+        client.shutdown().await;
     }
 
     #[tokio::test]

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -1442,6 +1442,28 @@ mod client_state {
     }
 
     #[tokio::test]
+    async fn isolated_client_has_independent_channel_lifecycle() {
+        let mut server = MockWsServer::start().await;
+        let endpoint = server.ws_url("/ws/market");
+        let client = Client::new(&endpoint, Config::default()).unwrap();
+        let isolated = client.isolated().unwrap();
+        let _first = client
+            .subscribe_market_events(vec![payloads::asset_id()])
+            .unwrap();
+        let _ = server.recv_subscription().await;
+        let _second = isolated
+            .subscribe_market_events(vec![payloads::other_asset_id()])
+            .unwrap();
+        let _ = server.recv_subscription().await;
+
+        client.shutdown().await;
+
+        assert!(!client.is_connected(ChannelType::Market));
+        assert!(isolated.is_connected(ChannelType::Market));
+        isolated.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn is_connected_returns_true_after_subscription() {
         let mut server = MockWsServer::start().await;
         let endpoint = server.ws_url("/ws/market");

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -382,6 +382,31 @@ mod market_channel {
     }
 
     #[tokio::test]
+    async fn idle_shutdown_does_not_stop_an_active_sibling_stream() {
+        let mut server = MockWsServer::start().await;
+        let endpoint = server.ws_url("/ws/market");
+        let client = Client::new(&endpoint, Config::default()).unwrap();
+        let first_asset = payloads::asset_id();
+        let second_asset = payloads::other_asset_id();
+        let first = client.subscribe_market_events(vec![first_asset]).unwrap();
+        let _ = server.recv_subscription().await;
+        let second = client.subscribe_market_events(vec![second_asset]).unwrap();
+        let _ = server.recv_subscription().await;
+
+        drop(first);
+        client.unsubscribe_market_events(&[first_asset]).unwrap();
+        let _ = server.recv_subscription().await;
+        assert!(!client.shutdown_if_idle().await);
+        assert!(client.is_connected(ChannelType::Market));
+
+        drop(second);
+        client.unsubscribe_market_events(&[second_asset]).unwrap();
+        let _ = server.recv_subscription().await;
+        assert!(client.shutdown_if_idle().await);
+        assert!(!client.is_connected(ChannelType::Market));
+    }
+
+    #[tokio::test]
     async fn unknown_market_side_is_surfaced_instead_of_dropped() {
         let mut server = MockWsServer::start().await;
         let endpoint = server.ws_url("/ws/market");

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -364,6 +364,24 @@ mod market_channel {
     }
 
     #[tokio::test]
+    async fn unified_market_stream_has_matching_unsubscribe() {
+        let mut server = MockWsServer::start().await;
+        let endpoint = server.ws_url("/ws/market");
+        let client = Client::new(&endpoint, Config::default()).unwrap();
+        let asset_id = payloads::asset_id();
+        let stream = client.subscribe_market_events(vec![asset_id]).unwrap();
+        let _ = server.recv_subscription().await;
+
+        drop(stream);
+        client.unsubscribe_market_events(&[asset_id]).unwrap();
+
+        let request = server.recv_subscription().await.unwrap();
+        assert!(request.contains("\"operation\":\"unsubscribe\""));
+        assert!(request.contains(&asset_id.to_string()));
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn unknown_market_side_is_surfaced_instead_of_dropped() {
         let mut server = MockWsServer::start().await;
         let endpoint = server.ws_url("/ws/market");

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -820,6 +820,63 @@ mod user_channel {
     }
 
     #[tokio::test]
+    async fn targeted_unsubscribe_preserves_all_markets_subscription() {
+        let mut server = MockWsServer::start().await;
+        let base_endpoint = format!("ws://{}", server.addr);
+
+        let client = Client::new(&base_endpoint, Config::default())
+            .unwrap()
+            .authenticate(test_credentials(), Address::ZERO)
+            .unwrap();
+
+        let stream = client.subscribe_user_events(vec![]).unwrap();
+        let mut stream = Box::pin(stream);
+        let sub = server.recv_subscription().await.unwrap();
+        assert!(sub.contains("\"type\":\"user\""));
+        assert!(sub.contains("\"markets\":[]"));
+
+        client.unsubscribe_user_events(&[payloads::MARKET]).unwrap();
+        assert_eq!(client.subscription_count(), 1);
+
+        server.send(&payloads::order().to_string());
+        assert!(matches!(
+            timeout(Duration::from_secs(2), stream.next())
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap(),
+            WsMessage::Order(_)
+        ));
+
+        assert!(client.unsubscribe_user_events(&[]).is_err());
+        assert_eq!(client.subscription_count(), 1);
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn duplicate_all_markets_subscriptions_share_one_wire_request() {
+        let mut server = MockWsServer::start().await;
+        let base_endpoint = format!("ws://{}", server.addr);
+        let client = Client::new(&base_endpoint, Config::default())
+            .unwrap()
+            .authenticate(test_credentials(), Address::ZERO)
+            .unwrap();
+
+        let _first = client.subscribe_user_events(vec![]).unwrap();
+        let first_request = server.recv_subscription().await.unwrap();
+        assert!(first_request.contains("\"markets\":[]"));
+
+        let _second = client.subscribe_user_events(vec![]).unwrap();
+        assert_eq!(client.subscription_count(), 2);
+        assert!(
+            timeout(Duration::from_millis(100), server.recv_subscription())
+                .await
+                .is_err()
+        );
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn unsubscribe_user_events_sends_request() {
         let mut server = MockWsServer::start().await;
         let base_endpoint = format!("ws://{}", server.addr);
@@ -997,6 +1054,51 @@ mod reconnection {
         config.reconnect.initial_backoff = Duration::from_millis(50);
         config.reconnect.max_backoff = Duration::from_millis(200);
         config
+    }
+
+    #[tokio::test]
+    async fn resubscribes_all_markets_after_targeted_unsubscribe_and_reconnect() {
+        let mut server = ReconnectableMockServer::start().await;
+        let endpoint = server.ws_url("/ws/user");
+
+        let credentials = polymarket_client_sdk_v2::auth::Credentials::new(
+            crate::common::API_KEY,
+            crate::common::SECRET.to_owned(),
+            crate::common::PASSPHRASE.to_owned(),
+        );
+        let client = Client::new(&endpoint, config())
+            .unwrap()
+            .authenticate(credentials, Address::ZERO)
+            .unwrap();
+
+        let stream = client.subscribe_user_events(vec![]).unwrap();
+        let mut stream = Box::pin(stream);
+        let initial = server.recv_subscription().await.unwrap();
+        assert!(initial.contains("\"type\":\"user\""));
+        assert!(initial.contains("\"markets\":[]"));
+
+        client.unsubscribe_user_events(&[payloads::MARKET]).unwrap();
+        assert_eq!(client.subscription_count(), 1);
+
+        server.disconnect_all();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        server.allow_reconnect();
+
+        let resub = server.recv_subscription().await.unwrap();
+        assert!(resub.contains("\"type\":\"user\""));
+        assert!(resub.contains("\"markets\":[]"));
+        assert!(resub.contains("\"auth\""));
+
+        server.send(&payloads::order().to_string());
+        assert!(matches!(
+            timeout(Duration::from_secs(2), stream.next())
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap(),
+            WsMessage::Order(_)
+        ));
+        client.shutdown().await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #109.

## Motivation

Consumers maintaining a local executable orderbook need the initial `BookUpdate`, every batched `PriceChange`, and related market events in one connection-ordered stream. Merging the existing typed streams can miss/reorder the initial snapshot and deltas; lag and malformed interested frames previously disappeared without a terminal error. Downstream runtimes also had no way to await WebSocket/reconnection shutdown.

## Changes

- adds `Client::subscribe_market_events` and `_with_options`, returning one ordered `Stream<Item = Result<WsMessage>>`;
- registers each internal receiver before sending the subscription request;
- serializes subscribe/unsubscribe/reconnect state and rolls refcounts/interest/auth/custom-feature state back on setup failure;
- gives active subscriptions unique identities;
- surfaces broadcast lag as terminal `WsError::Lagged`;
- carries valid messages and parser errors through one ordered internal `ConnectionEvent` stream while preserving the existing public `ConnectionManager::subscribe() -> Receiver<M>` API;
- stops silently dropping malformed interested batch entries; unknown enum values such as `Side::Unknown` remain visible to callers;
- uses a weak reconnect-handler reference to remove the retention cycle;
- adds idempotent, concurrent-safe `Client::shutdown()` / `close()` that blocks new channel creation during shutdown, stops and awaits reconnect/connection tasks, and permits clean later reuse;
- makes socket writes cancellable by requested shutdown;
- clears stale user auth/interest after final unsubscribe;
- applies the same fail-closed lag/parser behavior to RTDS subscriptions.

Unsubscribe remains transport/refcount management; callers should drop a returned stream when they no longer want to consume it. Channels stay alive to flush unsubscribe messages and support reuse until explicit shutdown or final Client drop.

## Tests

- ordered Book -> PriceChange delivery on the unified stream;
- unknown market side is surfaced, not dropped;
- malformed interested market frame terminates with an error;
- concurrent/idempotent shutdown, disconnected state, and post-shutdown reuse;
- all existing reconnect, multiplex, unsubscribe, market, user, and RTDS tests.

Validation:

- `cargo test --all-features --no-fail-fast` — 611 passed, 20 ignored
- `cargo test --all-features --test websocket` — 45 passed
- `cargo clippy --all-features --lib -- -D warnings`
- `cargo clippy --all-features --test websocket -- -D warnings`
- `cargo check --all-features --workspace --all-targets` (two pre-existing unused imports in unrelated order tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core WebSocket subscription, reconnect, and shutdown paths; behavior changes (lag/parse fail-closed, channel retention, all-markets user semantics) can affect long-running orderbook consumers.
> 
> **Overview**
> Adds **`subscribe_market_events`** (and `_with_options`) so book snapshots, price deltas, and related market frames share **one connection-ordered** `Stream<Item = Result<WsMessage>>`, plus **`unsubscribe_market_events`** and **`Client::isolated()`** for independent channel lifecycles.
> 
> **Lifecycle and transport:** **`shutdown` / `shutdown_if_idle` / `close`** are idempotent and coordinate with a lifecycle lock so idle shutdown cannot race subscription setup; channels are no longer torn down automatically when refcounts hit zero (unsubscribe flush and reuse until explicit shutdown). **`ConnectionManager`** gains cancellable shutdown, a larger broadcast buffer, and an internal **`ConnectionEvent`** path (messages, parse errors, shutdown) while keeping the public `subscribe()` API.
> 
> **Fail-closed streaming:** Subscriptions register receivers **before** wire requests; setup failures roll back refcounts/interest/auth. Broadcast **lag** and **parse errors** end the stream with **`WsError::Lagged`** / **`InvalidMessage`** instead of continuing silently. Interested **batch** parse failures in `parse_if_interested` propagate rather than being skipped. RTDS picks up the same event stream behavior and ignores control acks without topic/type/payload.
> 
> **User channel:** Empty `markets` (“all markets”) subscriptions are refcounted separately so targeted unsubscribes and reconnect resubscribe do not break the global stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39a3fe3ffb4fd02a1672f7dcd32667922b296feb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->