### PR TITLE
feat(clob): support PolyV2 position IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(clob)* support Polymarket V2 position IDs in Exchange V3 orders and market-data read operations
+
 ## [0.7.0](https://github.com/Polymarket/rs-clob-client-v2/compare/v0.6.0...v0.7.0) - 2026-07-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ The **signature_type** parameter tells the system how to verify your signatures:
    and any wallet where you control the private key directly
 - `signature_type=1`: Email/Magic wallet signatures (delegated signing)
 - `signature_type=2`: Browser wallet proxy signatures (when using a proxy contract, not direct wallet connections)
-- `signature_type=3`: EIP-1271 smart contract wallet signatures (**V2 orders only**)
+- `signature_type=3`: EIP-1271 smart contract wallet signatures (**V2/V3 orders only**)
 
 See [`SignatureType`](src/clob/types/mod.rs) for more information.
 
@@ -314,23 +314,48 @@ async fn main() -> anyhow::Result<()> {
 }
 ```
 
-##### V1 and V2 protocols
+For a Polymarket V2 position-backed outcome, call `position_id` instead of `token_id`. The
+identifier selects Exchange V3 signing automatically:
 
-The SDK supports both V1 (legacy) and V2 exchange contracts. Protocol is **auto-detected** on
-the first order build via `GET /version` and cached for the lifetime of the `Client`. You pick
-the protocol by pointing the client at the corresponding host:
+```rust,ignore
+use std::str::FromStr as _;
 
-| Protocol | Host                              | Collateral   | EIP-712 domain version |
-|----------|-----------------------------------|--------------|------------------------|
-| V2       | `https://clob-v2.polymarket.com` | pUSD         | `"2"`                  |
-| V1       | `https://clob.polymarket.com`     | USDC.e       | `"1"`                  |
+use polymarket_client_sdk_v2::types::U256;
+
+let position_id = U256::from_str("<position-id>")?;
+let order = client
+    .limit_order()
+    .position_id(position_id)
+    .size(Decimal::ONE_HUNDRED)
+    .price(dec!(0.4))
+    .side(Side::Buy)
+    .build()
+    .await?;
+```
+
+Read endpoints accept the same position ID through their protocol-defined `token_id` field. For
+example, `MidpointRequest::builder().token_id(position_id).build()` queries position-backed market
+data. The REST and signed order wire formats retain the names `token_id` and `tokenId` for both CTF
+token IDs and Polymarket V2 position IDs.
+
+##### V1, V2, and V3 protocols
+
+For token-backed orders, the SDK supports V1 (legacy) and V2 exchange contracts. The protocol is
+**auto-detected** on the first token order build via `GET /version` and cached for the lifetime of
+the `Client`. Position-backed orders bypass that lookup and always use Exchange V3:
+
+| Protocol | Asset identifier       | Host                              | EIP-712 domain version |
+|----------|------------------------|-----------------------------------|------------------------|
+| V3       | Polymarket V2 position | `https://clob-v2.polymarket.com` | `"3"`                  |
+| V2       | CTF token              | `https://clob-v2.polymarket.com` | `"2"`                  |
+| V1       | CTF token              | `https://clob.polymarket.com`     | `"1"`                  |
 
 V2 orders add `timestamp`, `metadata`, and `builder` fields. V1 orders use `taker`, `nonce`,
 and `feeRateBps` instead. The order builder exposes both sets of fields — the ones that don't
 apply to the detected protocol are silently ignored at build time, so you can write one
 code-path that works against either server.
 
-V2-specific builder fields (ignored when the server runs V1):
+V2/V3-specific builder fields (ignored when the server runs V1):
 
 ```rust,ignore
 use polymarket_client_sdk_v2::types::B256;
@@ -368,7 +393,7 @@ let order = client
 
 #### Builder-attributed trading
 
-In V2, builder attribution is carried on the order's `builder_code` field (and as a
+In V2/V3, builder attribution is carried on the order's `builder_code` field (and as a
 query parameter on `builder_trades`). Set a default `builder_code` on the [`Config`] and
 every order constructed via [`Client::limit_order`] / [`Client::market_order`] inherits
 it unless overridden.

--- a/README.md
+++ b/README.md
@@ -344,11 +344,11 @@ For token-backed orders, the SDK supports V1 (legacy) and V2 exchange contracts.
 **auto-detected** on the first token order build via `GET /version` and cached for the lifetime of
 the `Client`. Position-backed orders bypass that lookup and always use Exchange V3:
 
-| Protocol | Asset identifier       | Host                              | EIP-712 domain version |
-|----------|------------------------|-----------------------------------|------------------------|
-| V3       | Polymarket V2 position | `https://clob-v2.polymarket.com` | `"3"`                  |
-| V2       | CTF token              | `https://clob-v2.polymarket.com` | `"2"`                  |
-| V1       | CTF token              | `https://clob.polymarket.com`     | `"1"`                  |
+| Protocol | Asset identifier       | Host                              | Collateral | EIP-712 domain version |
+|----------|------------------------|-----------------------------------|------------|------------------------|
+| V3       | Polymarket V2 position | `https://clob-v2.polymarket.com` | pUSD       | `"3"`                  |
+| V2       | CTF token              | `https://clob-v2.polymarket.com` | pUSD       | `"2"`                  |
+| V1       | CTF token              | `https://clob.polymarket.com`     | USDC.e     | `"1"`                  |
 
 V2 orders add `timestamp`, `metadata`, and `builder` fields. V1 orders use `taker`, `nonce`,
 and `feeRateBps` instead. The order builder exposes both sets of fields — the ones that don't

--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -67,6 +67,7 @@ use crate::{
 const ORDER_NAME: Option<Cow<'static, str>> = Some(Cow::Borrowed("Polymarket CTF Exchange"));
 const VERSION_V1: Option<Cow<'static, str>> = Some(Cow::Borrowed("1"));
 const VERSION_V2: Option<Cow<'static, str>> = Some(Cow::Borrowed("2"));
+const VERSION_V3: Option<Cow<'static, str>> = Some(Cow::Borrowed("3"));
 const DEPOSIT_WALLET_NAME: &str = "DepositWallet";
 const DEPOSIT_WALLET_VERSION: &str = "1";
 const ORDER_TYPE_STRING: &str = concat!(
@@ -733,15 +734,15 @@ impl<S: State> Client<S> {
         Ok(body.version)
     }
 
-    /// Retrieves the midpoint price for a single market outcome token.
+    /// Retrieves the midpoint price for a single exchange asset.
     ///
     /// The midpoint is the average of the best bid and best ask prices,
     /// calculated as `(best_bid + best_ask) / 2`. This represents a fair
-    /// market price estimate for the token.
+    /// market price estimate for the CTF token or Polymarket V2 position.
     ///
     /// # Errors
     ///
-    /// Returns an error if the request fails or the token ID is invalid.
+    /// Returns an error if the request fails or the asset ID is invalid.
     pub async fn midpoint(&self, request: &MidpointRequest) -> Result<MidpointResponse> {
         let params = request.query_params(None);
         let request = self
@@ -752,14 +753,14 @@ impl<S: State> Client<S> {
         crate::request(&self.inner.client, request, None).await
     }
 
-    /// Retrieves midpoint prices for multiple market outcome tokens in a single request.
+    /// Retrieves midpoint prices for multiple exchange assets in a single request.
     ///
     /// This is the batch version of [`Self::midpoint`]. Returns midpoint prices
-    /// for all requested tokens, allowing efficient bulk price queries.
+    /// for all requested assets, allowing efficient bulk price queries.
     ///
     /// # Errors
     ///
-    /// Returns an error if the request fails or any token ID is invalid.
+    /// Returns an error if the request fails or any asset ID is invalid.
     pub async fn midpoints(&self, requests: &[MidpointRequest]) -> Result<MidpointsResponse> {
         let request = self
             .client()
@@ -770,14 +771,14 @@ impl<S: State> Client<S> {
         crate::request(&self.inner.client, request, None).await
     }
 
-    /// Retrieves the current price for a market outcome token on a specific side.
+    /// Retrieves the current price for an exchange asset on a specific side.
     ///
     /// Returns the best available price for buying (BUY side) or selling (SELL side)
-    /// the specified token. This reflects the actual executable price on the orderbook.
+    /// the specified asset. This reflects the actual executable price on the orderbook.
     ///
     /// # Errors
     ///
-    /// Returns an error if the request fails or the token ID is invalid.
+    /// Returns an error if the request fails or the asset ID is invalid.
     pub async fn price(&self, request: &PriceRequest) -> Result<PriceResponse> {
         let params = request.query_params(None);
         let request = self
@@ -788,14 +789,14 @@ impl<S: State> Client<S> {
         crate::request(&self.inner.client, request, None).await
     }
 
-    /// Retrieves prices for multiple market outcome tokens on their specific sides.
+    /// Retrieves prices for multiple exchange assets on their specific sides.
     ///
     /// This is the batch version of [`Self::price`]. Allows querying prices
-    /// for many tokens at once, with each request specifying its own side (BUY or SELL).
+    /// for many assets at once, with each request specifying its own side (BUY or SELL).
     ///
     /// # Errors
     ///
-    /// Returns an error if the request fails or any token ID is invalid.
+    /// Returns an error if the request fails or any asset ID is invalid.
     pub async fn prices(&self, requests: &[PriceRequest]) -> Result<PricesResponse> {
         let request = self
             .client()
@@ -806,14 +807,14 @@ impl<S: State> Client<S> {
         crate::request(&self.inner.client, request, None).await
     }
 
-    /// Retrieves historical price data for a market outcome token.
+    /// Retrieves historical price data for an exchange asset.
     ///
     /// Returns time-series price data over a specified time range or interval.
     /// The `fidelity` parameter controls the granularity of data points returned.
     ///
     /// # Errors
     ///
-    /// Returns an error if the request fails or the token ID is invalid.
+    /// Returns an error if the request fails or the asset ID is invalid.
     pub async fn price_history(
         &self,
         request: &PriceHistoryRequest,
@@ -827,7 +828,7 @@ impl<S: State> Client<S> {
         crate::request(&self.inner.client, req.build()?, None).await
     }
 
-    /// Retrieves the bid-ask spread for a single market outcome token.
+    /// Retrieves the bid-ask spread for a single exchange asset.
     ///
     /// The spread is the difference between the best ask price and the best bid price,
     /// representing the cost of immediate execution. A smaller spread indicates higher
@@ -835,7 +836,7 @@ impl<S: State> Client<S> {
     ///
     /// # Errors
     ///
-    /// Returns an error if the request fails or the token ID is invalid.
+    /// Returns an error if the request fails or the asset ID is invalid.
     pub async fn spread(&self, request: &SpreadRequest) -> Result<SpreadResponse> {
         let params = request.query_params(None);
         let request = self
@@ -846,14 +847,14 @@ impl<S: State> Client<S> {
         crate::request(&self.inner.client, request, None).await
     }
 
-    /// Retrieves bid-ask spreads for multiple market outcome tokens.
+    /// Retrieves bid-ask spreads for multiple exchange assets.
     ///
     /// This is the batch version of [`Self::spread`], allowing efficient
-    /// retrieval of spread data for many tokens simultaneously.
+    /// retrieval of spread data for many assets simultaneously.
     ///
     /// # Errors
     ///
-    /// Returns an error if the request fails or any token ID is invalid.
+    /// Returns an error if the request fails or any asset ID is invalid.
     pub async fn spreads(&self, requests: &[SpreadRequest]) -> Result<SpreadsResponse> {
         let request = self
             .client()
@@ -864,31 +865,31 @@ impl<S: State> Client<S> {
         crate::request(&self.inner.client, request, None).await
     }
 
-    /// Retrieves the minimum tick size for a market outcome token.
+    /// Retrieves the minimum tick size for a CTF token or Polymarket V2 position.
     ///
-    /// The tick size defines the minimum price increment for orders on this token.
+    /// The tick size defines the minimum price increment for orders on this asset.
     /// Results are cached internally to reduce API calls. For example, a tick size
     /// of 0.01 means prices must be in increments of $0.01.
     ///
     /// # Errors
     ///
-    /// Returns an error if the request fails or the token ID is invalid.
-    pub async fn tick_size(&self, token_id: U256) -> Result<TickSizeResponse> {
-        if let Some(tick_size) = self.inner.tick_sizes.get(&token_id) {
+    /// Returns an error if the request fails or the asset ID is invalid.
+    pub async fn tick_size(&self, asset_id: U256) -> Result<TickSizeResponse> {
+        if let Some(tick_size) = self.inner.tick_sizes.get(&asset_id) {
             #[cfg(feature = "tracing")]
-            tracing::trace!(token_id = %token_id, tick_size = ?tick_size.value(), "cache hit: tick_size");
+            tracing::trace!(asset_id = %asset_id, tick_size = ?tick_size.value(), "cache hit: tick_size");
             return Ok(TickSizeResponse {
                 minimum_tick_size: *tick_size,
             });
         }
 
         #[cfg(feature = "tracing")]
-        tracing::trace!(token_id = %token_id, "cache miss: tick_size");
+        tracing::trace!(asset_id = %asset_id, "cache miss: tick_size");
 
         let request = self
             .client()
             .request(Method::GET, format!("{}tick-size", self.host()))
-            .query(&[("token_id", token_id.to_string())])
+            .query(&[("token_id", asset_id.to_string())])
             .build()?;
 
         let response =
@@ -896,10 +897,10 @@ impl<S: State> Client<S> {
 
         self.inner
             .tick_sizes
-            .insert(token_id, response.minimum_tick_size);
+            .insert(asset_id, response.minimum_tick_size);
 
         #[cfg(feature = "tracing")]
-        tracing::trace!(token_id = %token_id, "cached tick_size");
+        tracing::trace!(asset_id = %asset_id, "cached tick_size");
 
         Ok(response)
     }
@@ -941,36 +942,36 @@ impl<S: State> Client<S> {
         Ok(response)
     }
 
-    /// Retrieves the trading fee rate for a market outcome token.
+    /// Retrieves the trading fee rate for a CTF token or Polymarket V2 position.
     ///
-    /// Returns the fee rate in basis points (bps) charged on trades for this token.
+    /// Returns the fee rate in basis points (bps) charged on trades for this asset.
     /// For example, 10 bps = 0.10% fee. Results are cached internally to reduce API calls.
     ///
     /// # Errors
     ///
-    /// Returns an error if the request fails or the token ID is invalid.
-    pub async fn fee_rate_bps(&self, token_id: U256) -> Result<FeeRateResponse> {
-        if let Some(cached) = self.inner.fee_rate_bps.get(&token_id) {
+    /// Returns an error if the request fails or the asset ID is invalid.
+    pub async fn fee_rate_bps(&self, asset_id: U256) -> Result<FeeRateResponse> {
+        if let Some(cached) = self.inner.fee_rate_bps.get(&asset_id) {
             #[cfg(feature = "tracing")]
-            tracing::trace!(token_id = %token_id, base_fee = cached.base_fee, "cache hit: fee_rate_bps");
+            tracing::trace!(asset_id = %asset_id, base_fee = cached.base_fee, "cache hit: fee_rate_bps");
             return Ok(cached.clone());
         }
 
         #[cfg(feature = "tracing")]
-        tracing::trace!(token_id = %token_id, "cache miss: fee_rate_bps");
+        tracing::trace!(asset_id = %asset_id, "cache miss: fee_rate_bps");
 
         let request = self
             .client()
             .request(Method::GET, format!("{}fee-rate", self.host()))
-            .query(&[("token_id", token_id.to_string())])
+            .query(&[("token_id", asset_id.to_string())])
             .build()?;
 
         let response = crate::request::<FeeRateResponse>(&self.inner.client, request, None).await?;
 
-        self.inner.fee_rate_bps.insert(token_id, response.clone());
+        self.inner.fee_rate_bps.insert(asset_id, response.clone());
 
         #[cfg(feature = "tracing")]
-        tracing::trace!(token_id = %token_id, "cached fee_rate_bps");
+        tracing::trace!(asset_id = %asset_id, "cached fee_rate_bps");
 
         Ok(response)
     }
@@ -1000,14 +1001,14 @@ impl<S: State> Client<S> {
         Ok(market_fee)
     }
 
-    /// Returns the V2 platform-fee exponent (`fd.e`) for `token_id`. Defaults to `0` on
+    /// Returns the V2/V3 platform-fee exponent (`fd.e`) for `asset_id`. Defaults to `0` on
     /// legacy or fee-free markets.
     ///
     /// # Errors
     ///
     /// Returns an error if market metadata cannot be resolved.
-    pub async fn fee_exponent(&self, token_id: U256) -> Result<u32> {
-        Ok(self.fee_info(token_id).await?.exponent)
+    pub async fn fee_exponent(&self, asset_id: U256) -> Result<u32> {
+        Ok(self.fee_info(asset_id).await?.exponent)
     }
 
     /// Checks if the current IP address is geoblocked from accessing Polymarket.
@@ -1066,7 +1067,7 @@ impl<S: State> Client<S> {
         crate::request(&self.inner.client, request, None).await
     }
 
-    /// Retrieves the full orderbook for a market outcome token.
+    /// Retrieves the full orderbook for a CTF token or Polymarket V2 position.
     ///
     /// Returns all active bids and asks at various price levels, showing
     /// the depth of liquidity available in the market. This includes the
@@ -1074,7 +1075,7 @@ impl<S: State> Client<S> {
     ///
     /// # Errors
     ///
-    /// Returns an error if the request fails or the token ID is invalid.
+    /// Returns an error if the request fails or the asset ID is invalid.
     pub async fn order_book(
         &self,
         request: &OrderBookSummaryRequest,
@@ -1088,14 +1089,14 @@ impl<S: State> Client<S> {
         crate::request(&self.inner.client, request, None).await
     }
 
-    /// Retrieves orderbooks for multiple market outcome tokens.
+    /// Retrieves orderbooks for multiple CTF tokens or Polymarket V2 positions.
     ///
     /// This is the batch version of [`Self::order_book`], allowing efficient
-    /// retrieval of orderbook data for many tokens in a single request.
+    /// retrieval of orderbook data for many assets in a single request.
     ///
     /// # Errors
     ///
-    /// Returns an error if the request fails or any token ID is invalid.
+    /// Returns an error if the request fails or any asset ID is invalid.
     pub async fn order_books(
         &self,
         requests: &[OrderBookSummaryRequest],
@@ -1118,14 +1119,14 @@ impl<S: State> Client<S> {
         book.hash()
     }
 
-    /// Retrieves the price of the most recent trade for a market outcome token.
+    /// Retrieves the most recent trade price for a CTF token or Polymarket V2 position.
     ///
     /// Returns the last executed trade price, which represents the most recent
     /// market consensus price. This is useful for tracking real-time price movements.
     ///
     /// # Errors
     ///
-    /// Returns an error if the request fails or the token ID is invalid.
+    /// Returns an error if the request fails or the asset ID is invalid.
     pub async fn last_trade_price(
         &self,
         request: &LastTradePriceRequest,
@@ -1142,14 +1143,14 @@ impl<S: State> Client<S> {
         crate::request(&self.inner.client, request, None).await
     }
 
-    /// Retrieves the last trade prices for multiple market outcome tokens.
+    /// Retrieves the last trade prices for multiple CTF tokens or Polymarket V2 positions.
     ///
     /// This is the batch version of [`Self::last_trade_price`], returning
     /// the most recent executed trade price for each requested token.
     ///
     /// # Errors
     ///
-    /// Returns an error if the request fails or any token ID is invalid.
+    /// Returns an error if the request fails or any asset ID is invalid.
     pub async fn last_trades_prices(
         &self,
         token_ids: &[LastTradePriceRequest],
@@ -1353,55 +1354,57 @@ impl<S: State> Client<S> {
         Ok(response)
     }
 
-    /// Primes the tick-size, neg-risk, and fee caches for `token_id` from
+    /// Primes the tick-size, neg-risk, and fee caches for `asset_id` from
     /// `/clob-markets/{id}`, resolving the condition via `/markets-by-token` if needed.
     ///
     /// # Errors
     ///
     /// Returns an error if the market lookup or the clob-market-info fetch fails.
-    pub(crate) async fn ensure_market_info_cached(&self, token_id: U256) -> Result<()> {
-        if self.inner.fee_infos.contains_key(&token_id) {
+    pub(crate) async fn ensure_market_info_cached(&self, asset_id: U256) -> Result<()> {
+        if self.inner.fee_infos.contains_key(&asset_id) {
             return Ok(());
         }
-        let condition_id = if let Some(cid) = self.inner.token_condition_map.get(&token_id) {
+        let condition_id = if let Some(cid) = self.inner.token_condition_map.get(&asset_id) {
             *cid
         } else {
-            let market = self.market_by_token(token_id).await?;
+            let market = self.market_by_token(asset_id).await?;
             self.inner
                 .token_condition_map
-                .insert(token_id, market.condition_id);
+                .insert(asset_id, market.condition_id);
             market.condition_id
         };
         self.clob_market_info(&condition_id.to_string()).await?;
         Ok(())
     }
 
-    /// Returns V2 fee parameters for `token_id`, priming the cache as needed.
+    /// Returns V2/V3 fee parameters for `asset_id`, priming the cache as needed.
     ///
     /// # Errors
     ///
     /// Returns an error if market metadata cannot be resolved.
-    pub(crate) async fn fee_info(&self, token_id: U256) -> Result<FeeInfo> {
-        self.ensure_market_info_cached(token_id).await?;
+    pub(crate) async fn fee_info(&self, asset_id: U256) -> Result<FeeInfo> {
+        self.ensure_market_info_cached(asset_id).await?;
         Ok(self
             .inner
             .fee_infos
-            .get(&token_id)
+            .get(&asset_id)
             .map(|e| *e)
             .unwrap_or_default())
     }
 
-    /// Looks up a market by token ID.
+    /// Looks up a market by CTF token ID or Polymarket V2 position ID.
+    ///
+    /// The endpoint retains its protocol-defined `markets-by-token` name for both asset kinds.
     ///
     /// # Errors
     ///
-    /// Returns an error if the request fails or the token ID is invalid.
-    pub async fn market_by_token(&self, token_id: U256) -> Result<MarketByTokenResponse> {
+    /// Returns an error if the request fails or the asset ID is invalid.
+    pub async fn market_by_token(&self, asset_id: U256) -> Result<MarketByTokenResponse> {
         let request = self
             .client()
             .request(
                 Method::GET,
-                format!("{}markets-by-token/{token_id}", self.host()),
+                format!("{}markets-by-token/{asset_id}", self.host()),
             )
             .build()?;
 
@@ -1733,8 +1736,9 @@ impl<K: Kind> Client<Authenticated<K>> {
     /// Signs the provided [`SignableOrder`] using EIP-712 typed data signing.
     ///
     /// The EIP-712 domain and verifying contract are selected from the order's version:
-    /// V2 orders sign against `exchange_v2` with domain version `"2"`; V1 orders sign
-    /// against the legacy `exchange` (or neg-risk variant) with domain version `"1"`.
+    /// V3 position orders sign against `exchange_v3` with domain version `"3"`; V2 token orders
+    /// sign against `exchange_v2` with domain version `"2"`; V1 token orders sign against the
+    /// legacy `exchange` (or neg-risk variant) with domain version `"1"`.
     #[expect(
         clippy::missing_panics_doc,
         reason = "No need to publicly document as we are guarded by the typestate pattern. \
@@ -1754,24 +1758,39 @@ impl<K: Kind> Client<Authenticated<K>> {
             .chain_id()
             .expect("Validated not none in `authenticate`");
 
-        let token_id = match &payload {
+        let asset_id = match &payload {
             OrderPayload::V1(p) => p.order.tokenId,
-            OrderPayload::V2(p) => p.order.tokenId,
+            OrderPayload::V2(p) | OrderPayload::V3(p) => p.order.tokenId,
         };
-        let neg_risk = self.neg_risk(token_id).await?.neg_risk;
+        let is_v3 = matches!(&payload, OrderPayload::V3(_));
+        let neg_risk = if is_v3 {
+            false
+        } else {
+            self.neg_risk(asset_id).await?.neg_risk
+        };
         let config = contract_config(chain_id, neg_risk)
             .ok_or(Error::missing_contract_config(chain_id, neg_risk))?;
 
         let signature = match &payload {
-            OrderPayload::V2(p) => {
-                let exchange = config.exchange_v2.ok_or_else(|| {
-                    Error::validation(format!(
-                        "No V2 exchange contract configured for chain_id={chain_id}, neg_risk={neg_risk}"
-                    ))
-                })?;
+            OrderPayload::V2(p) | OrderPayload::V3(p) => {
+                let (exchange, version) = if is_v3 {
+                    let exchange = config.exchange_v3.ok_or_else(|| {
+                        Error::validation(format!(
+                            "No V3 exchange contract configured for chain_id={chain_id}"
+                        ))
+                    })?;
+                    (exchange, VERSION_V3)
+                } else {
+                    let exchange = config.exchange_v2.ok_or_else(|| {
+                        Error::validation(format!(
+                            "No V2 exchange contract configured for chain_id={chain_id}, neg_risk={neg_risk}"
+                        ))
+                    })?;
+                    (exchange, VERSION_V2)
+                };
                 let domain = Eip712Domain {
                     name: ORDER_NAME,
-                    version: VERSION_V2,
+                    version,
                     chain_id: Some(U256::from(chain_id)),
                     verifying_contract: Some(exchange),
                     ..Eip712Domain::default()
@@ -1878,6 +1897,7 @@ impl<K: Kind> Client<Authenticated<K>> {
     /// [`trade_ids`](PostOrderResponse::trade_ids).
     pub async fn post_order(&self, order: SignedOrder) -> Result<PostOrderResponse> {
         let defer_exec = order.defer_exec == Some(true);
+        let refresh_version = order.payload.version() != 3;
         let request = self
             .client()
             .request(Method::POST, format!("{}order", self.host()))
@@ -1886,7 +1906,9 @@ impl<K: Kind> Client<Authenticated<K>> {
         let headers = self.create_headers(&request).await?;
 
         let result = crate::request(&self.inner.client, request, Some(headers)).await;
-        self.invalidate_version_if_mismatch(&result).await;
+        if refresh_version {
+            self.invalidate_version_if_mismatch(&result).await;
+        }
         let response = result?;
         if defer_exec {
             return Ok(response);
@@ -1904,6 +1926,7 @@ impl<K: Kind> Client<Authenticated<K>> {
     ///
     /// Returns an error if any order fails validation or the request fails.
     pub async fn post_orders(&self, orders: Vec<SignedOrder>) -> Result<Vec<PostOrderResponse>> {
+        let refresh_version = orders.iter().any(|order| order.payload.version() != 3);
         let defer_exec: Vec<bool> = orders
             .iter()
             .map(|order| order.defer_exec == Some(true))
@@ -1916,7 +1939,9 @@ impl<K: Kind> Client<Authenticated<K>> {
         let headers = self.create_headers(&request).await?;
 
         let result = crate::request(&self.inner.client, request, Some(headers)).await;
-        self.invalidate_version_if_mismatch(&result).await;
+        if refresh_version {
+            self.invalidate_version_if_mismatch(&result).await;
+        }
         let mut responses: Vec<PostOrderResponse> = result?;
 
         // Resolve all batch entries against a single polling window so a
@@ -3018,6 +3043,7 @@ impl<K: Kind> Client<Authenticated<K>> {
             funder: self.inner.funder,
             salt_generator: self.inner.salt_generator,
             token_id: None,
+            position_id: None,
             price: None,
             size: None,
             amount: None,

--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -1897,7 +1897,6 @@ impl<K: Kind> Client<Authenticated<K>> {
     /// [`trade_ids`](PostOrderResponse::trade_ids).
     pub async fn post_order(&self, order: SignedOrder) -> Result<PostOrderResponse> {
         let defer_exec = order.defer_exec == Some(true);
-        let refresh_version = order.payload.version() != 3;
         let request = self
             .client()
             .request(Method::POST, format!("{}order", self.host()))
@@ -1906,9 +1905,7 @@ impl<K: Kind> Client<Authenticated<K>> {
         let headers = self.create_headers(&request).await?;
 
         let result = crate::request(&self.inner.client, request, Some(headers)).await;
-        if refresh_version {
-            self.invalidate_version_if_mismatch(&result).await;
-        }
+        self.invalidate_version_if_mismatch(&result).await;
         let response = result?;
         if defer_exec {
             return Ok(response);
@@ -1926,7 +1923,6 @@ impl<K: Kind> Client<Authenticated<K>> {
     ///
     /// Returns an error if any order fails validation or the request fails.
     pub async fn post_orders(&self, orders: Vec<SignedOrder>) -> Result<Vec<PostOrderResponse>> {
-        let refresh_version = orders.iter().any(|order| order.payload.version() != 3);
         let defer_exec: Vec<bool> = orders
             .iter()
             .map(|order| order.defer_exec == Some(true))
@@ -1939,9 +1935,7 @@ impl<K: Kind> Client<Authenticated<K>> {
         let headers = self.create_headers(&request).await?;
 
         let result = crate::request(&self.inner.client, request, Some(headers)).await;
-        if refresh_version {
-            self.invalidate_version_if_mismatch(&result).await;
-        }
+        self.invalidate_version_if_mismatch(&result).await;
         let mut responses: Vec<PostOrderResponse> = result?;
 
         // Resolve all batch entries against a single polling window so a

--- a/src/clob/mod.rs
+++ b/src/clob/mod.rs
@@ -17,9 +17,11 @@
 //!
 //! ## Orders
 //!
-//! This SDK uses the V2 CTF Exchange contract. Order fields include:
-//! `timestamp`, `metadata` (bytes32), `builder` (bytes32 for fee attribution).
-//! EIP-712 domain version is `"2"`.
+//! This SDK uses the V1/V2 CTF Exchange contracts for token-backed orders and Exchange V3 for
+//! Polymarket V2 position-backed orders. V2/V3 order fields include `timestamp`, `metadata`
+//! (bytes32), and `builder` (bytes32 for fee attribution). Call
+//! [`OrderBuilder::position_id`](order_builder::OrderBuilder::position_id) to select Exchange V3;
+//! the signed and wire field remains `tokenId`.
 //! Supports [`Poly1271`](types::SignatureType::Poly1271) signature type for EIP-1271 smart contract wallets.
 //! Supports `deferExec` on order submission to defer execution.
 //!
@@ -30,7 +32,7 @@
 //! | `/` | Health check - returns "OK" |
 //! | `/time` | Current server timestamp |
 //! | `/version` | API version (1 or 2) |
-//! | `/midpoint` | Mid-market price for a token |
+//! | `/midpoint` | Mid-market price for a CTF token or Polymarket V2 position |
 //! | `/midpoints` | Batch midpoint prices |
 //! | `/price` | Best bid or ask price |
 //! | `/prices` | Batch best prices |
@@ -38,7 +40,7 @@
 //! | `/spreads` | Batch spreads |
 //! | `/last-trade-price` | Most recent trade price |
 //! | `/last-trades-prices` | Batch last trade prices |
-//! | `/prices-all` | All token prices |
+//! | `/prices-all` | All exchange-asset prices |
 //! | `/tick-size` | Minimum price increment (cached) |
 //! | `/neg-risk` | `NegRisk` adapter flag (cached) |
 //! | `/fee-rate-bps` | Trading fee in basis points (cached) |

--- a/src/clob/order_builder.rs
+++ b/src/clob/order_builder.rs
@@ -174,7 +174,7 @@ impl<OrderKind, K: AuthKind> OrderBuilder<OrderKind, K> {
             (Some(token_id), None) => Ok(OrderAsset::Token(token_id)),
             (None, Some(position_id)) => Ok(OrderAsset::Position(position_id)),
             (None, None) => Err(Error::validation(
-                "Unable to build Order due to missing token ID",
+                "Unable to build Order: provide one of token ID or position ID",
             )),
             (Some(_), Some(_)) => Err(Error::validation(
                 "Unable to build Order: provide exactly one of token ID or position ID",

--- a/src/clob/order_builder.rs
+++ b/src/clob/order_builder.rs
@@ -42,6 +42,7 @@ pub struct OrderBuilder<OrderKind, K: AuthKind> {
     pub(crate) signature_type: SignatureType,
     pub(crate) salt_generator: fn() -> u64,
     pub(crate) token_id: Option<U256>,
+    pub(crate) position_id: Option<U256>,
     pub(crate) price: Option<Decimal>,
     pub(crate) size: Option<Decimal>,
     pub(crate) amount: Option<Amount>,
@@ -63,11 +64,37 @@ pub struct OrderBuilder<OrderKind, K: AuthKind> {
     pub(crate) _kind: PhantomData<OrderKind>,
 }
 
+#[derive(Clone, Copy, Debug)]
+enum OrderAsset {
+    Token(U256),
+    Position(U256),
+}
+
+impl OrderAsset {
+    const fn id(self) -> U256 {
+        match self {
+            OrderAsset::Token(id) | OrderAsset::Position(id) => id,
+        }
+    }
+}
+
 impl<OrderKind, K: AuthKind> OrderBuilder<OrderKind, K> {
-    /// Sets the `token_id` for this builder. This is a required field.
+    /// Sets the CTF token ID for this builder.
+    ///
+    /// Exactly one of [`Self::token_id`] or [`Self::position_id`] is required.
     #[must_use]
     pub fn token_id(mut self, token_id: U256) -> Self {
         self.token_id = Some(token_id);
+        self
+    }
+
+    /// Sets the Polymarket V2 position ID for this builder.
+    ///
+    /// Position-backed orders are signed against Exchange V3 automatically. Exactly one of
+    /// [`Self::token_id`] or [`Self::position_id`] is required.
+    #[must_use]
+    pub fn position_id(mut self, position_id: U256) -> Self {
+        self.position_id = Some(position_id);
         self
     }
 
@@ -142,21 +169,39 @@ impl<OrderKind, K: AuthKind> OrderBuilder<OrderKind, K> {
         self
     }
 
+    fn order_asset(&self) -> Result<OrderAsset> {
+        match (self.token_id, self.position_id) {
+            (Some(token_id), None) => Ok(OrderAsset::Token(token_id)),
+            (None, Some(position_id)) => Ok(OrderAsset::Position(position_id)),
+            (None, None) => Err(Error::validation(
+                "Unable to build Order due to missing token ID",
+            )),
+            (Some(_), Some(_)) => Err(Error::validation(
+                "Unable to build Order: provide exactly one of token ID or position ID",
+            )),
+        }
+    }
+
     /// Assembles the [`OrderPayload`] for the server's current protocol version.
     ///
-    /// The caller supplies values common to both versions; V1/V2-specific fields
+    /// Position-backed orders always use Exchange V3. Token-backed orders use the server's
+    /// current protocol version. The caller supplies values common to all versions; version-specific fields
     /// (`taker`/`nonce`/`feeRateBps` vs `timestamp`/`metadata`/`builder`) are resolved
     /// here from [`OrderBuilder`] state.
     async fn build_payload(
         &self,
-        token_id: U256,
+        asset: OrderAsset,
         side: Side,
         maker_amount: u128,
         taker_amount: u128,
         salt: u64,
         expiration: U256,
     ) -> Result<OrderPayload> {
-        let version = self.client.resolve_version(false).await?;
+        let asset_id = asset.id();
+        let version = match asset {
+            OrderAsset::Token(_) => self.client.resolve_version(false).await?,
+            OrderAsset::Position(_) => 3,
+        };
         let maker = self.funder.unwrap_or(self.signer);
         let signer = if matches!(self.signature_type, SignatureType::Poly1271) {
             self.funder.ok_or_else(|| {
@@ -177,14 +222,14 @@ impl<OrderKind, K: AuthKind> OrderBuilder<OrderKind, K> {
                 }
                 let fee_rate_bps = self
                     .client
-                    .resolve_fee_rate_bps(token_id, self.fee_rate_bps)
+                    .resolve_fee_rate_bps(asset_id, self.fee_rate_bps)
                     .await?;
                 Ok(OrderPayload::new_v1(OrderV1 {
                     salt: U256::from(salt),
                     maker,
                     signer: self.signer,
                     taker: self.taker.unwrap_or(Address::ZERO),
-                    tokenId: token_id,
+                    tokenId: asset_id,
                     makerAmount: U256::from(maker_amount),
                     takerAmount: U256::from(taker_amount),
                     expiration,
@@ -194,27 +239,29 @@ impl<OrderKind, K: AuthKind> OrderBuilder<OrderKind, K> {
                     signatureType: self.signature_type as u8,
                 }))
             }
-            2 => {
+            2 | 3 => {
                 let timestamp_ms = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
                     .expect("time went backwards")
                     .as_millis();
-                Ok(OrderPayload::new(
-                    OrderV2 {
-                        salt: U256::from(salt),
-                        maker,
-                        signer,
-                        tokenId: token_id,
-                        makerAmount: U256::from(maker_amount),
-                        takerAmount: U256::from(taker_amount),
-                        side: side as u8,
-                        signatureType: self.signature_type as u8,
-                        timestamp: U256::from(timestamp_ms),
-                        metadata: self.metadata.unwrap_or(B256::ZERO),
-                        builder: self.builder_code.unwrap_or(B256::ZERO),
-                    },
-                    expiration,
-                ))
+                let order = OrderV2 {
+                    salt: U256::from(salt),
+                    maker,
+                    signer,
+                    tokenId: asset_id,
+                    makerAmount: U256::from(maker_amount),
+                    takerAmount: U256::from(taker_amount),
+                    side: side as u8,
+                    signatureType: self.signature_type as u8,
+                    timestamp: U256::from(timestamp_ms),
+                    metadata: self.metadata.unwrap_or(B256::ZERO),
+                    builder: self.builder_code.unwrap_or(B256::ZERO),
+                };
+                Ok(if version == 3 {
+                    OrderPayload::new_v3(order, expiration)
+                } else {
+                    OrderPayload::new(order, expiration)
+                })
             }
             other => Err(Error::validation(format!(
                 "unsupported CLOB protocol version: {other}"
@@ -248,11 +295,8 @@ impl<K: AuthKind> OrderBuilder<Limit, K> {
         tracing::instrument(skip(self), err(level = "warn"))
     )]
     pub async fn build(self) -> Result<SignableOrder> {
-        let Some(token_id) = self.token_id else {
-            return Err(Error::validation(
-                "Unable to build Order due to missing token ID",
-            ));
-        };
+        let asset = self.order_asset()?;
+        let asset_id = asset.id();
 
         let Some(side) = self.side else {
             return Err(Error::validation(
@@ -274,7 +318,7 @@ impl<K: AuthKind> OrderBuilder<Limit, K> {
 
         let minimum_tick_size = self
             .client
-            .tick_size(token_id)
+            .tick_size(asset_id)
             .await?
             .minimum_tick_size
             .as_decimal();
@@ -358,7 +402,7 @@ impl<K: AuthKind> OrderBuilder<Limit, K> {
 
         let payload = self
             .build_payload(
-                token_id,
+                asset,
                 side,
                 to_fixed_u128(maker_amount),
                 to_fixed_u128(taker_amount),
@@ -368,7 +412,7 @@ impl<K: AuthKind> OrderBuilder<Limit, K> {
             .await?;
 
         #[cfg(feature = "tracing")]
-        tracing::debug!(token_id = %token_id, side = ?side, price = %price, size = %size, "limit order built");
+        tracing::debug!(asset_id = %asset_id, side = ?side, price = %price, size = %size, "limit order built");
 
         Ok(SignableOrder {
             payload,
@@ -388,12 +432,16 @@ impl<K: AuthKind> OrderBuilder<Limit, K> {
     /// Returns an error if any of the build, sign, or post steps fails.
     pub async fn build_sign_and_post<S: Signer>(self, signer: &S) -> Result<PostOrderResponse> {
         let client = self.client.clone();
-        let before_version = client.resolve_version(false).await.unwrap_or(0);
+        let before_version = match self.order_asset()? {
+            OrderAsset::Token(_) => Some(client.resolve_version(false).await.unwrap_or(0)),
+            OrderAsset::Position(_) => None,
+        };
         let retry = self.clone();
         let order = self.build().await?;
         let signed = client.sign(signer, order).await?;
         let result = client.post_order(signed).await;
         if let Err(err) = &result
+            && let Some(before_version) = before_version
             && let Some(status) = err.downcast_ref::<crate::error::Status>()
             && status
                 .message
@@ -439,10 +487,7 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
     //   - BUY + USDC: walk asks until notional >= USDC
     //   - BUY + Shares: walk asks until shares >= N
     //   - SELL + Shares: walk bids until shares >= N
-    async fn calculate_price(&self, order_type: OrderType) -> Result<Decimal> {
-        let token_id = self
-            .token_id
-            .expect("Token ID was already validated in `build`");
+    async fn calculate_price(&self, asset_id: U256, order_type: OrderType) -> Result<Decimal> {
         let side = self.side.expect("Side was already validated in `build`");
         let amount = self
             .amount
@@ -452,7 +497,7 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
         let book = self
             .client
             .order_book(&OrderBookSummaryRequest {
-                token_id,
+                token_id: asset_id,
                 side: None,
             })
             .await?;
@@ -479,7 +524,7 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
 
         if levels.is_empty() {
             return Err(Error::validation(format!(
-                "No opposing orders for {token_id} which means there is no market price"
+                "No opposing orders for {asset_id} which means there is no market price"
             )));
         }
 
@@ -495,7 +540,7 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
 
         cutoff_price.ok_or_else(|| {
             Error::validation(format!(
-                "Insufficient liquidity to fill order for {token_id} at {target}"
+                "Insufficient liquidity to fill order for {asset_id} at {target}"
             ))
         })
     }
@@ -510,11 +555,8 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
         tracing::instrument(skip(self), err(level = "warn"))
     )]
     pub async fn build(self) -> Result<SignableOrder> {
-        let Some(token_id) = self.token_id else {
-            return Err(Error::validation(
-                "Unable to build Order due to missing token ID",
-            ));
-        };
+        let asset = self.order_asset()?;
+        let asset_id = asset.id();
 
         let Some(side) = self.side else {
             return Err(Error::validation(
@@ -536,12 +578,12 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
 
         let price = match self.price {
             Some(price) => price,
-            None => self.calculate_price(order_type.clone()).await?,
+            None => self.calculate_price(asset_id, order_type.clone()).await?,
         };
 
         let minimum_tick_size = self
             .client
-            .tick_size(token_id)
+            .tick_size(asset_id)
             .await?
             .minimum_tick_size
             .as_decimal();
@@ -564,9 +606,9 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
 
         let amount = match (side, amount.0, self.user_usdc_balance) {
             (Side::Buy, AmountInner::Usdc(raw), Some(balance)) => {
-                // V2 uses `/clob-markets/{id}` `fd` (rate + exponent); `/fee-rate`
-                // only exposes V1 bps and would silently mis-size V2 orders.
-                let fee = self.client.fee_info(token_id).await?;
+                // V2/V3 use `/clob-markets/{id}` `fd` (rate + exponent); `/fee-rate`
+                // only exposes V1 bps and would silently mis-size these orders.
+                let fee = self.client.fee_info(asset_id).await?;
                 let fee_rate = fee.rate;
                 let fee_exponent = Decimal::from(fee.exponent);
                 let builder_taker_fee = match self.builder_code {
@@ -617,7 +659,7 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
 
         let payload = self
             .build_payload(
-                token_id,
+                asset,
                 side,
                 to_fixed_u128(maker_amount),
                 to_fixed_u128(taker_amount),
@@ -627,7 +669,7 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
             .await?;
 
         #[cfg(feature = "tracing")]
-        tracing::debug!(token_id = %token_id, side = ?side, price = %price, amount = %amount.as_inner(), "market order built");
+        tracing::debug!(asset_id = %asset_id, side = ?side, price = %price, amount = %amount.as_inner(), "market order built");
 
         Ok(SignableOrder {
             payload,
@@ -647,12 +689,16 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
     /// Returns an error if any of the build, sign, or post steps fails.
     pub async fn build_sign_and_post<S: Signer>(self, signer: &S) -> Result<PostOrderResponse> {
         let client = self.client.clone();
-        let before_version = client.resolve_version(false).await.unwrap_or(0);
+        let before_version = match self.order_asset()? {
+            OrderAsset::Token(_) => Some(client.resolve_version(false).await.unwrap_or(0)),
+            OrderAsset::Position(_) => None,
+        };
         let retry = self.clone();
         let order = self.build().await?;
         let signed = client.sign(signer, order).await?;
         let result = client.post_order(signed).await;
         if let Err(err) = &result
+            && let Some(before_version) = before_version
             && let Some(status) = err.downcast_ref::<crate::error::Status>()
             && status
                 .message

--- a/src/clob/types/mod.rs
+++ b/src/clob/types/mod.rs
@@ -522,13 +522,16 @@ pub use v2::Order as OrderV2;
 /// Deprecated alias preserved for callers that predate the V1/V2 split. Resolves to [`OrderV2`].
 pub type Order = OrderV2;
 
-/// V2 order payload: the signed struct plus the out-of-struct `expiration`.
+/// V2/V3 order payload: the signed struct plus the out-of-struct `expiration`.
 #[non_exhaustive]
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct OrderPayloadV2 {
     pub order: OrderV2,
     pub expiration: U256,
 }
+
+/// V3 reuses the V2 signed order structure and wire payload shape.
+pub type OrderPayloadV3 = OrderPayloadV2;
 
 /// V1 order payload. `expiration` lives inside the signed struct.
 #[non_exhaustive]
@@ -543,6 +546,7 @@ pub struct OrderPayloadV1 {
 pub enum OrderPayload {
     V1(OrderPayloadV1),
     V2(OrderPayloadV2),
+    V3(OrderPayloadV3),
 }
 
 impl Default for OrderPayload {
@@ -558,88 +562,144 @@ impl OrderPayload {
         OrderPayload::V2(OrderPayloadV2 { order, expiration })
     }
 
+    /// Construct a V3 payload for a Polymarket V2 position order.
+    #[must_use]
+    pub fn new_v3(order: OrderV2, expiration: U256) -> Self {
+        OrderPayload::V3(OrderPayloadV3 { order, expiration })
+    }
+
     /// Construct a V1 payload.
     #[must_use]
     pub fn new_v1(order: OrderV1) -> Self {
         OrderPayload::V1(OrderPayloadV1 { order })
     }
 
-    /// The protocol version this payload targets (1 or 2).
+    /// The protocol version this payload targets (1, 2, or 3).
     #[must_use]
     pub fn version(&self) -> u32 {
         match self {
             OrderPayload::V1(_) => 1,
             OrderPayload::V2(_) => 2,
+            OrderPayload::V3(_) => 3,
         }
     }
 
-    /// Returns the V2 order reference, or `None` for V1 payloads.
+    /// Returns the V2 order reference, or `None` for V1/V3 payloads.
     #[must_use]
     pub fn as_v2(&self) -> Option<&OrderV2> {
         match self {
             OrderPayload::V2(p) => Some(&p.order),
-            OrderPayload::V1(_) => None,
+            OrderPayload::V1(_) | OrderPayload::V3(_) => None,
         }
     }
 
-    /// Returns the V1 order reference, or `None` for V2 payloads.
+    /// Returns the V3 order reference, or `None` for V1/V2 payloads.
+    #[must_use]
+    pub fn as_v3(&self) -> Option<&OrderV2> {
+        match self {
+            OrderPayload::V3(p) => Some(&p.order),
+            OrderPayload::V1(_) | OrderPayload::V2(_) => None,
+        }
+    }
+
+    /// Returns the V1 order reference, or `None` for V2/V3 payloads.
     #[must_use]
     pub fn as_v1(&self) -> Option<&OrderV1> {
         match self {
             OrderPayload::V1(p) => Some(&p.order),
-            OrderPayload::V2(_) => None,
+            OrderPayload::V2(_) | OrderPayload::V3(_) => None,
         }
     }
 }
 
 impl SignableOrder {
-    /// Returns the V2 order struct.
+    /// Returns the V2/V3 order struct.
     ///
     /// # Panics
     ///
-    /// Panics if this is a V1 order. Callers that may encounter either version should
+    /// Panics if this is a V1 order. Callers that may encounter any version should
     /// inspect [`SignableOrder::payload`] directly.
     #[must_use]
     pub fn order(&self) -> &OrderV2 {
-        &self.v2().order
+        match &self.payload {
+            OrderPayload::V2(p) | OrderPayload::V3(p) => &p.order,
+            OrderPayload::V1(_) => panic!("SignableOrder is V1; match on .payload directly"),
+        }
     }
 
     /// Returns the V2 payload.
     ///
     /// # Panics
     ///
-    /// Panics if this is a V1 order.
+    /// Panics if this is not a V2 order.
     #[must_use]
     pub fn v2(&self) -> &OrderPayloadV2 {
         match &self.payload {
             OrderPayload::V2(p) => p,
-            OrderPayload::V1(_) => panic!("SignableOrder is V1; match on .payload directly"),
+            OrderPayload::V1(_) | OrderPayload::V3(_) => {
+                panic!("SignableOrder is not V2; match on .payload directly")
+            }
+        }
+    }
+
+    /// Returns the V3 payload.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this is not a V3 order.
+    #[must_use]
+    pub fn v3(&self) -> &OrderPayloadV3 {
+        match &self.payload {
+            OrderPayload::V3(p) => p,
+            OrderPayload::V1(_) | OrderPayload::V2(_) => {
+                panic!("SignableOrder is not V3; match on .payload directly")
+            }
         }
     }
 }
 
 impl SignedOrder {
-    /// Returns the V2 order struct.
+    /// Returns the V2/V3 order struct.
     ///
     /// # Panics
     ///
-    /// Panics if this is a V1 order. Callers that may encounter either version should
+    /// Panics if this is a V1 order. Callers that may encounter any version should
     /// inspect [`SignedOrder::payload`] directly.
     #[must_use]
     pub fn order(&self) -> &OrderV2 {
-        &self.v2().order
+        match &self.payload {
+            OrderPayload::V2(p) | OrderPayload::V3(p) => &p.order,
+            OrderPayload::V1(_) => panic!("SignedOrder is V1; match on .payload directly"),
+        }
     }
 
     /// Returns the V2 payload.
     ///
     /// # Panics
     ///
-    /// Panics if this is a V1 order.
+    /// Panics if this is not a V2 order.
     #[must_use]
     pub fn v2(&self) -> &OrderPayloadV2 {
         match &self.payload {
             OrderPayload::V2(p) => p,
-            OrderPayload::V1(_) => panic!("SignedOrder is V1; match on .payload directly"),
+            OrderPayload::V1(_) | OrderPayload::V3(_) => {
+                panic!("SignedOrder is not V2; match on .payload directly")
+            }
+        }
+    }
+
+    /// Returns the V3 payload.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this is not a V3 order.
+    #[must_use]
+    pub fn v3(&self) -> &OrderPayloadV3 {
+        match &self.payload {
+            OrderPayload::V3(p) => p,
+            OrderPayload::V1(_) | OrderPayload::V2(_) => {
+                panic!("SignedOrder is not V3; match on .payload directly")
+            }
         }
     }
 }
@@ -820,7 +880,7 @@ impl Serialize for SignedOrder {
         let mut st = serializer.serialize_struct("SignedOrder", field_count)?;
 
         match &self.payload {
-            OrderPayload::V2(payload) => {
+            OrderPayload::V2(payload) | OrderPayload::V3(payload) => {
                 let order = &payload.order;
                 let side = Side::try_from(order.side).map_err(S::Error::custom)?;
                 let body = OrderV2WithSignature {

--- a/src/clob/types/request.rs
+++ b/src/clob/types/request.rs
@@ -24,6 +24,8 @@ use crate::types::{Address, B256};
 #[derive(Debug, Serialize, Builder)]
 #[builder(on(String, into))]
 pub struct MidpointRequest {
+    /// Exchange asset identifier: a CTF token ID or Polymarket V2 position ID.
+    /// The CLOB wire field is named `token_id` for both kinds.
     #[serde_as(as = "DisplayFromStr")]
     pub token_id: U256,
 }
@@ -33,6 +35,8 @@ pub struct MidpointRequest {
 #[derive(Debug, Serialize, Builder)]
 #[builder(on(String, into))]
 pub struct PriceRequest {
+    /// Exchange asset identifier: a CTF token ID or Polymarket V2 position ID.
+    /// The CLOB wire field is named `token_id` for both kinds.
     #[serde_as(as = "DisplayFromStr")]
     pub token_id: U256,
     pub side: Side,
@@ -44,6 +48,8 @@ pub struct PriceRequest {
 #[derive(Debug, Serialize, Builder)]
 #[builder(on(String, into))]
 pub struct SpreadRequest {
+    /// Exchange asset identifier: a CTF token ID or Polymarket V2 position ID.
+    /// The CLOB wire field is named `token_id` for both kinds.
     #[serde_as(as = "DisplayFromStr")]
     pub token_id: U256,
     pub side: Option<Side>,
@@ -55,6 +61,8 @@ pub struct SpreadRequest {
 #[derive(Debug, Serialize, Builder)]
 #[builder(on(String, into))]
 pub struct OrderBookSummaryRequest {
+    /// Exchange asset identifier: a CTF token ID or Polymarket V2 position ID.
+    /// The CLOB wire field is named `token_id` for both kinds.
     #[serde_as(as = "DisplayFromStr")]
     pub token_id: U256,
     pub side: Option<Side>,
@@ -65,6 +73,8 @@ pub struct OrderBookSummaryRequest {
 #[derive(Debug, Serialize, Builder)]
 #[builder(on(String, into))]
 pub struct LastTradePriceRequest {
+    /// Exchange asset identifier: a CTF token ID or Polymarket V2 position ID.
+    /// The CLOB wire field is named `token_id` for both kinds.
     #[serde_as(as = "DisplayFromStr")]
     pub token_id: U256,
 }
@@ -75,7 +85,7 @@ pub struct LastTradePriceRequest {
 #[derive(Debug, Serialize, Builder)]
 #[builder(on(String, into))]
 pub struct PriceHistoryRequest {
-    /// The CLOB token ID to fetch price history for.
+    /// The CLOB asset ID to fetch price history for: a CTF token ID or Polymarket V2 position ID.
     #[serde_as(as = "DisplayFromStr")]
     pub market: U256,
     /// The time range for the price history query.
@@ -489,6 +499,33 @@ mod tests {
         assert_eq!(
             request.query_params(None),
             "?asset_type=COLLATERAL&token_id=1&signature_type=0"
+        );
+    }
+
+    #[test]
+    fn position_ids_use_the_protocol_token_id_field_for_market_data() {
+        let position_id = U256::from(456);
+        let midpoint = MidpointRequest::builder().token_id(position_id).build();
+        let price = PriceRequest::builder()
+            .token_id(position_id)
+            .side(Side::Buy)
+            .build();
+        let spread = SpreadRequest::builder().token_id(position_id).build();
+        let book = OrderBookSummaryRequest::builder()
+            .token_id(position_id)
+            .build();
+        let last_trade = LastTradePriceRequest::builder()
+            .token_id(position_id)
+            .build();
+
+        assert_eq!(midpoint.query_params(None), "?token_id=456");
+        assert_eq!(price.query_params(None), "?token_id=456&side=BUY");
+        assert_eq!(spread.query_params(None), "?token_id=456");
+        assert_eq!(book.query_params(None), "?token_id=456");
+        assert_eq!(last_trade.query_params(None), "?token_id=456");
+        assert_eq!(
+            serde_json::to_value([midpoint]).expect("request should serialize"),
+            serde_json::json!([{ "token_id": "456" }])
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ static CONFIG: phf::Map<ChainId, ContractConfig> = phf_map! {
         conditional_tokens: address!("0x4D97DCd97eC945f40cF65F87097ACe5EA0476045"),
         neg_risk_adapter: None,
         exchange_v2: Some(address!("0xE111180000d2663C0091e4f400237545B87B996B")),
+        exchange_v3: Some(address!("0xe3333700cA9d93003F00f0F71f8515005F6c00Aa")),
     },
     80002_u64 => ContractConfig {
         exchange: address!("0xdFE02Eb6733538f8Ea35D585af8DE5958AD99E40"),
@@ -70,6 +71,7 @@ static CONFIG: phf::Map<ChainId, ContractConfig> = phf_map! {
         conditional_tokens: address!("0x69308FB512518e39F9b16112fA8d994F4e2Bf8bB"),
         neg_risk_adapter: None,
         exchange_v2: Some(address!("0xE111180000d2663C0091e4f400237545B87B996B")),
+        exchange_v3: Some(address!("0x9fE6e61422AdB6F610d8597F9684b16912D50C3D")),
     },
 };
 
@@ -80,6 +82,7 @@ static NEG_RISK_CONFIG: phf::Map<ChainId, ContractConfig> = phf_map! {
         conditional_tokens: address!("0x4D97DCd97eC945f40cF65F87097ACe5EA0476045"),
         neg_risk_adapter: Some(address!("0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296")),
         exchange_v2: Some(address!("0xe2222d279d744050d28e00520010520000310F59")),
+        exchange_v3: Some(address!("0xe3333700cA9d93003F00f0F71f8515005F6c00Aa")),
     },
     80002_u64 => ContractConfig {
         exchange: address!("0xC5d563A36AE78145C45a50134d48A1215220f80a"),
@@ -87,6 +90,7 @@ static NEG_RISK_CONFIG: phf::Map<ChainId, ContractConfig> = phf_map! {
         conditional_tokens: address!("0x69308FB512518e39F9b16112fA8d994F4e2Bf8bB"),
         neg_risk_adapter: Some(address!("0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296")),
         exchange_v2: Some(address!("0xe2222d279d744050d28e00520010520000310F59")),
+        exchange_v3: Some(address!("0x9fE6e61422AdB6F610d8597F9684b16912D50C3D")),
     },
 };
 
@@ -124,6 +128,8 @@ pub struct ContractConfig {
     pub neg_risk_adapter: Option<Address>,
     /// The V2 exchange contract address (CTF Exchange V2).
     pub exchange_v2: Option<Address>,
+    /// The V3 exchange contract address used for Polymarket V2 position orders.
+    pub exchange_v3: Option<Address>,
 }
 
 /// Wallet contract configuration for CREATE2 address derivation
@@ -313,6 +319,15 @@ mod tests {
     use super::*;
 
     #[test]
+    fn config_contains_polygon_exchange_v3() {
+        let cfg = contract_config(POLYGON, false).expect("missing config");
+        assert_eq!(
+            cfg.exchange_v3,
+            Some(address!("0xe3333700cA9d93003F00f0F71f8515005F6c00Aa"))
+        );
+    }
+
+    #[test]
     fn config_contains_80002() {
         let cfg = contract_config(AMOY, false).expect("missing config");
         assert_eq!(
@@ -322,6 +337,10 @@ mod tests {
         assert_eq!(
             cfg.collateral,
             address!("0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB")
+        );
+        assert_eq!(
+            cfg.exchange_v3,
+            Some(address!("0x9fE6e61422AdB6F610d8597F9684b16912D50C3D"))
         );
     }
 
@@ -335,6 +354,10 @@ mod tests {
         assert_eq!(
             cfg.collateral,
             address!("0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB")
+        );
+        assert_eq!(
+            cfg.exchange_v3,
+            Some(address!("0x9fE6e61422AdB6F610d8597F9684b16912D50C3D"))
         );
     }
 

--- a/tests/order.rs
+++ b/tests/order.rs
@@ -5066,3 +5066,176 @@ mod v1 {
         }
     }
 }
+
+mod poly_v2_position_orders {
+    use std::borrow::Cow;
+
+    use alloy::dyn_abi::Eip712Domain;
+    use alloy::signers::Signer as _;
+    use alloy::signers::local::LocalSigner;
+    use alloy::sol_types::SolStruct as _;
+    use polymarket_client_sdk_v2::POLYGON;
+    use polymarket_client_sdk_v2::error::Validation;
+    use serde_json::json;
+
+    use super::*;
+    use crate::common::PRIVATE_KEY;
+
+    const EXCHANGE_V3_POLYGON: Address = address!("0xe3333700cA9d93003F00f0F71f8515005F6c00Aa");
+
+    fn position_id() -> U256 {
+        U256::from_str(
+            "8501497159083948713316135768103773293754490207922884688769443031624417212426",
+        )
+        .expect("valid position ID")
+    }
+
+    fn mock_tick_size(server: &MockServer, position_id: U256) -> httpmock::Mock<'_> {
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/tick-size")
+                .query_param("token_id", position_id.to_string());
+            then.status(StatusCode::OK).json_body(json!({
+                "minimum_tick_size": TickSize::Hundredth.as_decimal(),
+            }));
+        })
+    }
+
+    #[tokio::test]
+    async fn position_limit_order_uses_exchange_v3_without_server_version_or_neg_risk()
+    -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = create_authenticated(&server).await?;
+        let signer = LocalSigner::from_str(PRIVATE_KEY)?.with_chain_id(Some(POLYGON));
+        let position_id = position_id();
+
+        let version = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/version");
+            then.status(StatusCode::OK)
+                .json_body(json!({ "version": 2 }));
+        });
+        let neg_risk = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/neg-risk");
+            then.status(StatusCode::OK)
+                .json_body(json!({ "neg_risk": true }));
+        });
+        let tick_size = mock_tick_size(&server, position_id);
+
+        let signable = client
+            .limit_order()
+            .position_id(position_id)
+            .price(dec!(0.4))
+            .size(dec!(100))
+            .side(Side::Buy)
+            .build()
+            .await?;
+
+        assert_eq!(signable.payload.version(), 3);
+        assert_eq!(signable.v3().order.tokenId, position_id);
+
+        let expected_domain = Eip712Domain {
+            name: Some(Cow::Borrowed("Polymarket CTF Exchange")),
+            version: Some(Cow::Borrowed("3")),
+            chain_id: Some(U256::from(POLYGON)),
+            verifying_contract: Some(EXCHANGE_V3_POLYGON),
+            ..Eip712Domain::default()
+        };
+        let expected_signature = signer
+            .sign_hash(&signable.v3().order.eip712_signing_hash(&expected_domain))
+            .await?;
+        let signed = client.sign(&signer, signable).await?;
+
+        assert_eq!(signed.signature, expected_signature);
+        assert_eq!(signed.v3().order.tokenId, position_id);
+        assert_eq!(
+            serde_json::to_value(&signed)?["order"]["tokenId"],
+            position_id.to_string()
+        );
+        tick_size.assert_calls(1);
+        version.assert_calls(0);
+        neg_risk.assert_calls(0);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn position_market_order_uses_position_id_for_order_book_and_tick_size()
+    -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = create_authenticated(&server).await?;
+        let position_id = position_id();
+        let asks = vec![
+            OrderSummary::builder()
+                .price(dec!(0.5))
+                .size(dec!(100))
+                .build(),
+        ];
+
+        let version = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/version");
+            then.status(StatusCode::OK)
+                .json_body(json!({ "version": 2 }));
+        });
+        let book = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/book")
+                .query_param("token_id", position_id.to_string());
+            then.status(StatusCode::OK).json_body(json!({
+                "market": "0xbd31dc8a20211944f6b70f31557f1001557b59905b7738480ca09bd4532f84af",
+                "asset_id": position_id,
+                "timestamp": "1000",
+                "bids": [],
+                "asks": asks,
+                "min_order_size": "5",
+                "neg_risk": false,
+                "tick_size": TickSize::Hundredth.as_decimal(),
+            }));
+        });
+        let tick_size = mock_tick_size(&server, position_id);
+
+        let signable = client
+            .market_order()
+            .position_id(position_id)
+            .amount(Amount::usdc(dec!(10))?)
+            .side(Side::Buy)
+            .build()
+            .await?;
+
+        assert_eq!(signable.payload.version(), 3);
+        assert_eq!(signable.v3().order.tokenId, position_id);
+        assert_eq!(signable.v3().order.makerAmount, U256::from(10_000_000));
+        assert_eq!(signable.v3().order.takerAmount, U256::from(20_000_000));
+        book.assert_calls(1);
+        tick_size.assert_calls(1);
+        version.assert_calls(0);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn order_rejects_token_and_position_ids_together() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = create_authenticated(&server).await?;
+
+        let err = client
+            .limit_order()
+            .token_id(token_1())
+            .position_id(position_id())
+            .price(dec!(0.4))
+            .size(dec!(100))
+            .side(Side::Buy)
+            .build()
+            .await
+            .expect_err("both identifiers must be rejected");
+        let validation = err
+            .downcast_ref::<Validation>()
+            .expect("expected Validation error");
+
+        assert_eq!(
+            validation.reason,
+            "Unable to build Order: provide exactly one of token ID or position ID"
+        );
+
+        Ok(())
+    }
+}

--- a/tests/order.rs
+++ b/tests/order.rs
@@ -3325,7 +3325,10 @@ mod market {
             .unwrap_err();
         let msg = &err.downcast_ref::<Validation>().unwrap().reason;
 
-        assert_eq!(msg, "Unable to build Order due to missing token ID");
+        assert_eq!(
+            msg,
+            "Unable to build Order: provide one of token ID or position ID"
+        );
 
         let err = client
             .market_order()
@@ -5208,6 +5211,65 @@ mod poly_v2_position_orders {
         book.assert_calls(1);
         tick_size.assert_calls(1);
         version.assert_calls(0);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn position_posts_refresh_version_cache_on_mismatch() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = create_authenticated(&server).await?;
+        let signer = LocalSigner::from_str(PRIVATE_KEY)?.with_chain_id(Some(POLYGON));
+        let position_id = position_id();
+        let tick_size = mock_tick_size(&server, position_id);
+        let version = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/version");
+            then.status(StatusCode::OK)
+                .json_body(json!({ "version": 2 }));
+        });
+        let post_order = server.mock(|when, then| {
+            when.method(httpmock::Method::POST).path("/order");
+            then.status(StatusCode::BAD_REQUEST)
+                .body("order_version_mismatch");
+        });
+        let post_orders = server.mock(|when, then| {
+            when.method(httpmock::Method::POST).path("/orders");
+            then.status(StatusCode::BAD_REQUEST)
+                .body("order_version_mismatch");
+        });
+
+        let first = client
+            .limit_order()
+            .position_id(position_id)
+            .price(dec!(0.4))
+            .size(dec!(100))
+            .side(Side::Buy)
+            .build()
+            .await?;
+        let second = client
+            .limit_order()
+            .position_id(position_id)
+            .price(dec!(0.4))
+            .size(dec!(100))
+            .side(Side::Buy)
+            .build()
+            .await?;
+        let first = client.sign(&signer, first).await?;
+        let second = client.sign(&signer, second).await?;
+
+        client
+            .post_order(first)
+            .await
+            .expect_err("version mismatch should fail the post");
+        client
+            .post_orders(vec![second])
+            .await
+            .expect_err("version mismatch should fail the batch post");
+
+        post_order.assert_calls(1);
+        post_orders.assert_calls(1);
+        version.assert_calls(2);
+        tick_size.assert_calls(1);
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- add explicit position_id support for limit and market orders with exclusive token/position validation
- route position-backed orders through Exchange V3 signing on Polygon and Amoy, bypassing server version and neg-risk lookups
- propagate position IDs through order books, tick sizes, fee metadata, amount calculation, signing, serialization, and submission
- support position IDs in market-data reads while preserving the protocol token_id and tokenId wire fields
- add integration tests, request serialization coverage, API documentation, README guidance, and a changelog entry

## Reference

Rust implementation of the behavior introduced in Polymarket/clob-client-v2#104:
https://github.com/Polymarket/clob-client-v2/pull/104

## Validation

- cargo test --all-features
- cargo test
- cargo build --all-targets --all-features
- cargo +nightly-2025-11-24 fmt --all -- --check
- cargo +1.88.0 clippy --all-targets --all-features -- -D warnings
- cargo +1.88.0 clippy --all-targets -- -D warnings
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches order construction, EIP-712 signing, and contract selection—errors could produce unfillable or wrongly signed orders—but behavior is heavily tested and token-only paths are largely unchanged.
> 
> **Overview**
> Adds **Polymarket V2 position-backed trading** alongside existing CTF token orders. Limit and market builders gain **`position_id()`**; callers must supply **exactly one** of `token_id` or `position_id`.
> 
> **Position orders always use Exchange V3**: EIP-712 domain version `"3"`, `exchange_v3` on Polygon/Amoy, same V2-shaped wire payload (`tokenId` carries the position ID). They **skip** `GET /version` and **neg-risk** during build/sign. Token orders keep V1/V2 auto-detection and version-mismatch retry on post.
> 
> **Signing and types**: `OrderPayload::V3`, `new_v3`, and `v3()` accessors; V3 shares serialization with V2. **Poly1271** is documented for V2/V3 orders.
> 
> **Market data and metadata**: Read paths (`midpoint`, books, tick size, fees, `market_by_token`, etc.) treat position IDs like tokens, still serialized as `token_id` on the wire.
> 
> README, module docs, changelog, request docs, config tests, and integration tests cover position limit/market flows, mutual exclusion of IDs, and serialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d2cc8a03665f0dca72158c98b0b707dd56c5d5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->