### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/Polymarket/rs-clob-client-v2/compare/v0.7.0...v0.8.0) - 2026-09-08
+
 ### Added
 
-- *(clob)* support Polymarket V2 position IDs in Exchange V3 orders and market-data read operations
+- *(clob)* support Polymarket V2 position IDs in Exchange V3 orders and market-data read operations ([#112](https://github.com/Polymarket/rs-clob-client-v2/pull/112))
 
 ## [0.7.0](https://github.com/Polymarket/rs-clob-client-v2/compare/v0.6.0...v0.7.0) - 2026-07-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,9 +1613,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "polymarket_client_sdk_v2"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "polymarket_client_sdk_v2"
 description = "Polymarket CLOB (Central Limit Order Book) API client SDK"
-version = "0.7.0"
+version = "0.8.0"
 authors = [
     "Polymarket Engineering <engineering@polymarket.com>",
     "Chaz Byrnes <chaz@polymarket.com>",


### PR DESCRIPTION
## Summary

- release polymarket_client_sdk_v2 v0.8.0
- document PolyV2 position ID support from #112
- replace yanked chacha20 0.10.0 with compatible 0.10.2 in Cargo.lock

## Validation

- cargo +nightly-2025-11-24 fmt --all -- --check
- cargo +1.88.0 build --all-targets --all-features --locked
- cargo +1.88.0 clippy --all-targets --all-features --locked -- -D warnings
- cargo +1.88.0 clippy --all-targets --locked -- -D warnings
- cargo +1.88.0 test --all-features --locked (613 passed, 21 ignored)
- cargo +1.88.0 test --locked
- cargo +1.88.0 package --locked --all-features
- cargo +1.88.0 publish --dry-run --locked --all-features

## After merge

Publish manually from an up-to-date, clean main checkout:

    cargo +1.88.0 publish --locked --all-features

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata and lockfile refresh only; no SDK source changes in this PR.
> 
> **Overview**
> Cuts **v0.8.0** of `polymarket_client_sdk_v2` by bumping the crate version in `Cargo.toml` / `Cargo.lock` and adding a **0.8.0** changelog section dated 2026-09-08.
> 
> The release notes call out **Polymarket V2 position IDs** for Exchange V3 orders and market-data reads ([#112](https://github.com/Polymarket/rs-clob-client-v2/pull/112)), moved out of `[Unreleased]` with a PR link. `Cargo.lock` also moves **`chacha20`** from yanked **0.10.0** to **0.10.2** (transitive dependency only; no `Cargo.toml` dependency changes in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c213afe49d0b52999a40fb0cc3944c88d06ad939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->